### PR TITLE
Add async SQL query examples

### DIFF
--- a/DbaClientX.Examples/DbaClientX.Examples.csproj
+++ b/DbaClientX.Examples/DbaClientX.Examples.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DbaClientX\DbaClientX.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        var example = args.Length > 0 ? args[0].ToLowerInvariant() : string.Empty;
+        switch (example)
+        {
+            case "asyncquery":
+                await QuerySqlServerAsyncExample.RunAsync();
+                break;
+            default:
+                Console.WriteLine("Available examples: asyncquery");
+                break;
+        }
+    }
+}

--- a/DbaClientX.Examples/QuerySqlServerAsyncExample.cs
+++ b/DbaClientX.Examples/QuerySqlServerAsyncExample.cs
@@ -1,0 +1,27 @@
+using DBAClientX;
+using System.Data;
+
+public static class QuerySqlServerAsyncExample
+{
+    public static async Task RunAsync()
+    {
+        var sqlServer = new SqlServer
+        {
+            ReturnType = ReturnType.DataTable,
+        };
+
+        var result = await sqlServer.SqlQueryAsync("SQL1", "master", true, "SELECT TOP 1 * FROM sys.databases");
+
+        if (result is DataTable table)
+        {
+            foreach (DataRow row in table.Rows)
+            {
+                foreach (DataColumn col in table.Columns)
+                {
+                    Console.Write($"{row[col]}\t");
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/DbaClientX.Tests/SqlServerTests.cs
+++ b/DbaClientX.Tests/SqlServerTests.cs
@@ -1,0 +1,18 @@
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class SqlServerTests
+{
+    [Fact]
+    public async Task SqlQueryAsync_InvalidServer_ThrowsSqlException()
+    {
+        var sqlServer = new DBAClientX.SqlServer();
+        await Assert.ThrowsAsync<SqlException>(async () =>
+        {
+            await sqlServer.SqlQueryAsync("invalid", "master", true, "SELECT 1");
+        });
+    }
+}

--- a/DbaClientX.sln
+++ b/DbaClientX.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DbaClientX.PowerShell", "Db
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.Tests", "DbaClientX.Tests\DbaClientX.Tests.csproj", "{63014CD7-C727-4D52-AFE7-45082627CE04}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.Examples", "DbaClientX.Examples\DbaClientX.Examples.csproj", "{F5D7FDFE-8954-4C13-869F-3DDE4D4FDA07}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{63014CD7-C727-4D52-AFE7-45082627CE04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63014CD7-C727-4D52-AFE7-45082627CE04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63014CD7-C727-4D52-AFE7-45082627CE04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F5D7FDFE-8954-4C13-869F-3DDE4D4FDA07}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F5D7FDFE-8954-4C13-869F-3DDE4D4FDA07}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F5D7FDFE-8954-4C13-869F-3DDE4D4FDA07}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F5D7FDFE-8954-4C13-869F-3DDE4D4FDA07}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DbaClientX/SqlServer.cs
+++ b/DbaClientX/SqlServer.cs
@@ -45,4 +45,46 @@ public class SqlServer {
 
         return null;
     }
+
+    public async Task<object> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query) {
+        var connectionString = new SqlConnectionStringBuilder {
+            DataSource = serverOrInstance,
+            InitialCatalog = database,
+            IntegratedSecurity = integratedSecurity,
+        }.ConnectionString;
+
+        using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync().ConfigureAwait(false);
+
+        var command = new SqlCommand(query, connection);
+        if (command.CommandTimeout > 0) {
+            command.CommandTimeout = CommandTimeout;
+        }
+
+        var dataSet = new DataSet();
+        using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+        var tableIndex = 0;
+        do {
+            var dataTable = new DataTable($"Table{tableIndex}");
+            dataTable.Load(reader);
+            dataSet.Tables.Add(dataTable);
+            tableIndex++;
+        } while (!reader.IsClosed && await reader.NextResultAsync().ConfigureAwait(false));
+
+        if (ReturnType == ReturnType.DataRow || ReturnType == ReturnType.PSObject) {
+            if (dataSet.Tables.Count > 0) {
+                return dataSet.Tables[0];
+            }
+        }
+
+        if (ReturnType == ReturnType.DataSet) {
+            return dataSet;
+        }
+
+        if (ReturnType == ReturnType.DataTable) {
+            return dataSet.Tables;
+        }
+
+        return null;
+    }
 }

--- a/Module/Examples/Example.QuerySqlServerAsync.ps1
+++ b/Module/Examples/Example.QuerySqlServerAsync.ps1
@@ -1,0 +1,5 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+
+Invoke-DbaXQuery -Server "SQL1" -Database "master" -Query "SELECT * FROM sys.databases" -ReturnType DataRow |
+    Format-Table


### PR DESCRIPTION
## Summary
- create `DbaClientX.Examples` console project for code samples
- run async SQL query example from Program.cs on demand
- showcase Invoke-DbaXQuery usage in PowerShell async example script

## Testing
- `dotnet test --logger "trx;LogFileName=test_results.trx"`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_687f39feb130832e83ca2d859607367f