### PR TITLE
Implement parallel SQL query execution

### DIFF
--- a/DbaClientX.Examples/ParallelQueriesExample.cs
+++ b/DbaClientX.Examples/ParallelQueriesExample.cs
@@ -1,0 +1,30 @@
+using DBAClientX;
+using System;
+using System.Data;
+using System.Threading.Tasks;
+
+public static class ParallelQueriesExample
+{
+    public static async Task RunAsync()
+    {
+        var queries = new[]
+        {
+            "SELECT TOP 1 * FROM sys.databases",
+            "SELECT TOP 1 * FROM sys.objects",
+            "SELECT TOP 1 * FROM sys.schemas"
+        };
+
+        var sqlServer = new SqlServer
+        {
+            ReturnType = ReturnType.DataTable,
+        };
+
+        var results = await sqlServer.RunQueriesInParallel(queries, "SQL1", "master", true);
+
+        var index = 0;
+        foreach (var result in results)
+        {
+            Console.WriteLine($"Result {index++} contains {((DataTable?)result)?.Rows.Count ?? 0} rows");
+        }
+    }
+}

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -10,8 +10,11 @@ public class Program
             case "asyncquery":
                 await QuerySqlServerAsyncExample.RunAsync();
                 break;
+            case "parallelqueries":
+                await ParallelQueriesExample.RunAsync();
+                break;
             default:
-                Console.WriteLine("Available examples: asyncquery");
+                Console.WriteLine("Available examples: asyncquery, parallelqueries");
                 break;
         }
     }

--- a/DbaClientX.Tests/SqlServerTests.cs
+++ b/DbaClientX.Tests/SqlServerTests.cs
@@ -1,4 +1,6 @@
 using System.Data.SqlClient;
+using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -14,5 +16,34 @@ public class SqlServerTests
         {
             await sqlServer.SqlQueryAsync("invalid", "master", true, "SELECT 1");
         });
+    }
+
+    [Fact]
+    public async Task RunQueriesInParallel_InvalidServer_ExecutesConcurrently()
+    {
+        var queries = Enumerable.Repeat("SELECT 1", 3).ToArray();
+        var sqlServer = new DBAClientX.SqlServer();
+
+        var sequential = Stopwatch.StartNew();
+        foreach (var query in queries)
+        {
+            try
+            {
+                await sqlServer.SqlQueryAsync("invalid", "master", true, query);
+            }
+            catch (SqlException)
+            {
+            }
+        }
+        sequential.Stop();
+
+        var parallel = Stopwatch.StartNew();
+        await Assert.ThrowsAsync<SqlException>(async () =>
+        {
+            await sqlServer.RunQueriesInParallel(queries, "invalid", "master", true);
+        });
+        parallel.Stop();
+
+        Assert.True(parallel.Elapsed < sequential.Elapsed);
     }
 }

--- a/DbaClientX.Tests/SqlServerTests.cs
+++ b/DbaClientX.Tests/SqlServerTests.cs
@@ -18,30 +18,37 @@ public class SqlServerTests
         });
     }
 
+    private class DelaySqlServer : DBAClientX.SqlServer
+    {
+        private readonly TimeSpan _delay;
+
+        public DelaySqlServer(TimeSpan delay)
+        {
+            _delay = delay;
+        }
+
+        public override async Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query)
+        {
+            await Task.Delay(_delay);
+            return null;
+        }
+    }
+
     [Fact]
-    public async Task RunQueriesInParallel_InvalidServer_ExecutesConcurrently()
+    public async Task RunQueriesInParallel_ExecutesConcurrently()
     {
         var queries = Enumerable.Repeat("SELECT 1", 3).ToArray();
-        var sqlServer = new DBAClientX.SqlServer();
+        var sqlServer = new DelaySqlServer(TimeSpan.FromMilliseconds(200));
 
         var sequential = Stopwatch.StartNew();
         foreach (var query in queries)
         {
-            try
-            {
-                await sqlServer.SqlQueryAsync("invalid", "master", true, query);
-            }
-            catch (SqlException)
-            {
-            }
+            await sqlServer.SqlQueryAsync("ignored", "ignored", true, query);
         }
         sequential.Stop();
 
         var parallel = Stopwatch.StartNew();
-        await Assert.ThrowsAsync<SqlException>(async () =>
-        {
-            await sqlServer.RunQueriesInParallel(queries, "invalid", "master", true);
-        });
+        await sqlServer.RunQueriesInParallel(queries, "ignored", "ignored", true);
         parallel.Stop();
 
         Assert.True(parallel.Elapsed < sequential.Elapsed);

--- a/DbaClientX/SqlServer.cs
+++ b/DbaClientX/SqlServer.cs
@@ -1,64 +1,94 @@
-﻿using System.Data;
+using System;
+using System.Data;
 using System.Data.SqlClient;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace DBAClientX;
 
 /// <summary>
 /// This class is used to connect to SQL Server
 /// </summary>
-public class SqlServer {
-    public ReturnType ReturnType;
-    public int CommandTimeout { get; set; }
+public class SqlServer
+{
+    private readonly object _syncRoot = new();
+    private ReturnType _returnType;
+    private int _commandTimeout;
 
-    public object SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query) {
-        var connectionString = new SqlConnectionStringBuilder {
+    public ReturnType ReturnType
+    {
+        get { lock (_syncRoot) { return _returnType; } }
+        set { lock (_syncRoot) { _returnType = value; } }
+    }
+
+    public int CommandTimeout
+    {
+        get { lock (_syncRoot) { return _commandTimeout; } }
+        set { lock (_syncRoot) { _commandTimeout = value; } }
+    }
+
+    public object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query)
+    {
+        var connectionString = new SqlConnectionStringBuilder
+        {
             DataSource = serverOrInstance,
             InitialCatalog = database,
             IntegratedSecurity = integratedSecurity,
+            Pooling = true
         }.ConnectionString;
 
         using var connection = new SqlConnection(connectionString);
         connection.Open();
 
         var command = new SqlCommand(query, connection);
-        if (command.CommandTimeout > 0) {
-            command.CommandTimeout = CommandTimeout;
+        var commandTimeout = CommandTimeout;
+        if (commandTimeout > 0)
+        {
+            command.CommandTimeout = commandTimeout;
         }
         var dataAdapter = new SqlDataAdapter(command);
         var dataSet = new System.Data.DataSet();
 
         dataAdapter.Fill(dataSet);
 
-        if (ReturnType == ReturnType.DataRow || ReturnType == ReturnType.PSObject) {
+        var returnType = ReturnType;
+        if (returnType == ReturnType.DataRow || returnType == ReturnType.PSObject)
+        {
             if (dataSet.Tables.Count > 0) {
                 return dataSet.Tables[0];
             }
         }
 
-        if (ReturnType == ReturnType.DataSet) {
+        if (returnType == ReturnType.DataSet) {
             return dataSet;
         }
 
-        if (ReturnType == ReturnType.DataTable) {
+        if (returnType == ReturnType.DataTable) {
             return dataSet.Tables;
         }
 
         return null;
     }
 
-    public async Task<object> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query) {
-        var connectionString = new SqlConnectionStringBuilder {
+    public async Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query)
+    {
+        var connectionString = new SqlConnectionStringBuilder
+        {
             DataSource = serverOrInstance,
             InitialCatalog = database,
             IntegratedSecurity = integratedSecurity,
+            Pooling = true
         }.ConnectionString;
 
         using var connection = new SqlConnection(connectionString);
         await connection.OpenAsync().ConfigureAwait(false);
 
         var command = new SqlCommand(query, connection);
-        if (command.CommandTimeout > 0) {
-            command.CommandTimeout = CommandTimeout;
+        var commandTimeout = CommandTimeout;
+        if (commandTimeout > 0)
+        {
+            command.CommandTimeout = commandTimeout;
         }
 
         var dataSet = new DataSet();
@@ -71,20 +101,37 @@ public class SqlServer {
             tableIndex++;
         } while (!reader.IsClosed && await reader.NextResultAsync().ConfigureAwait(false));
 
-        if (ReturnType == ReturnType.DataRow || ReturnType == ReturnType.PSObject) {
-            if (dataSet.Tables.Count > 0) {
+        var returnType = ReturnType;
+        if (returnType == ReturnType.DataRow || returnType == ReturnType.PSObject)
+        {
+            if (dataSet.Tables.Count > 0)
+            {
                 return dataSet.Tables[0];
             }
         }
 
-        if (ReturnType == ReturnType.DataSet) {
+        if (returnType == ReturnType.DataSet)
+        {
             return dataSet;
         }
 
-        if (ReturnType == ReturnType.DataTable) {
+        if (returnType == ReturnType.DataTable)
+        {
             return dataSet.Tables;
         }
 
         return null;
+    }
+
+    public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string serverOrInstance, string database, bool integratedSecurity)
+    {
+        if (queries == null)
+        {
+            throw new ArgumentNullException(nameof(queries));
+        }
+
+        var tasks = queries.Select(q => SqlQueryAsync(serverOrInstance, database, integratedSecurity, q));
+        var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+        return results;
     }
 }

--- a/DbaClientX/SqlServer.cs
+++ b/DbaClientX/SqlServer.cs
@@ -71,7 +71,7 @@ public class SqlServer
         return null;
     }
 
-    public async Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query)
+    public virtual async Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query)
     {
         var connectionString = new SqlConnectionStringBuilder
         {


### PR DESCRIPTION
## Summary
- enable pooling in `SqlConnectionStringBuilder`
- add thread-safe handling in `SqlServer`
- implement `RunQueriesInParallel` for concurrent query execution
- add example demonstrating running queries in parallel
- add concurrency unit test

## Testing
- `dotnet build DbaClientX.sln -c Release`
- `dotnet test DbaClientX.Tests/DbaClientX.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687f42cebe98832ebdea3909fb439fa7