### PR TITLE
Make Codecov informational

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        continue-on-error: true
         with:
           files: '**/coverage.cobertura.xml'
           fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary
- disable blocking Codecov status checks
- keep Codecov upload non-fatal

## Testing
- `dotnet test DbaClientX.sln --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_687f4f9a8610832e9a8c70d31bfac47b