### PR TITLE
Add parameter binding support

### DIFF
--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -20,6 +20,9 @@ public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
     [Alias("As")]
     public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
 
+    [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
+    public Hashtable Parameters { get; set; }
+
     private ActionPreference ErrorAction;
 
     /// <summary>
@@ -47,7 +50,15 @@ public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
             CommandTimeout = QueryTimeout
         };
         try {
-            var result = sqlServer.SqlQuery(Server, Database, true, Query);
+            IDictionary<string, object?>? parameters = null;
+            if (Parameters != null)
+            {
+                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
+                    de => de.Key.ToString(),
+                    de => de.Value);
+            }
+
+            var result = sqlServer.SqlQuery(Server, Database, true, Query, parameters);
             if (result != null) {
                 if (ReturnType == ReturnType.PSObject) {
                     //var resultConverted = result as DataTable;

--- a/Module/Examples/Example.QuerySqlServerParameters.ps1
+++ b/Module/Examples/Example.QuerySqlServerParameters.ps1
@@ -1,0 +1,5 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force -Verbose
+
+$parameters = @{ Id = 1 }
+Invoke-DbaXQuery -Query 'SELECT * FROM sys.databases WHERE database_id = @Id' -Server 'SQL1' -Database 'master' -Parameters $parameters | Format-Table


### PR DESCRIPTION
## Summary
- extend `SqlQuery` and `SqlQueryAsync` to accept dictionaries of parameters
- expose `AddParameters` helper in `SqlServer`
- support parameters in `Invoke-DbaXQuery` cmdlet
- document parameters usage in examples
- test that parameters are bound correctly

## Testing
- `dotnet build DbaClientX.sln -c Debug`
- `dotnet test DbaClientX.sln`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester Module/Tests"`

------
https://chatgpt.com/codex/tasks/task_e_687f4fc03464832ea876097725bc7d5f