### PR TITLE
Implement transaction support

### DIFF
--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -13,8 +13,11 @@ public class Program
             case "parallelqueries":
                 await ParallelQueriesExample.RunAsync();
                 break;
+            case "transaction":
+                await TransactionExample.RunAsync();
+                break;
             default:
-                Console.WriteLine("Available examples: asyncquery, parallelqueries");
+                Console.WriteLine("Available examples: asyncquery, parallelqueries, transaction");
                 break;
         }
     }

--- a/DbaClientX.Examples/TransactionExample.cs
+++ b/DbaClientX.Examples/TransactionExample.cs
@@ -1,0 +1,24 @@
+using DBAClientX;
+using System;
+using System.Threading.Tasks;
+
+public static class TransactionExample
+{
+    public static Task RunAsync()
+    {
+        var sql = new SqlServer();
+        sql.BeginTransaction("SQL1", "master", true);
+        try
+        {
+            sql.SqlQuery("SQL1", "master", true, "CREATE TABLE #temp(id int)", null, true);
+            sql.Commit();
+            Console.WriteLine("Committed");
+        }
+        catch
+        {
+            sql.Rollback();
+            Console.WriteLine("Rolled back");
+        }
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- extend `SqlServer` with transaction management
- allow running queries inside a transaction
- add tests for transactional behaviour
- include new example demonstrating commit and rollback

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687f5b0e28e0832e8b1ea5c3f398258d