### PR TITLE
Add INSERT query builder support

### DIFF
--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -15,5 +15,16 @@ public class QueryBuilderTests
         var sql = QueryBuilder.Compile(query);
         Assert.Equal("SELECT * FROM users WHERE id = 1", sql);
     }
+
+    [Fact]
+    public void SimpleInsertIntoValues()
+    {
+        var query = new Query()
+            .InsertInto("users", "name", "age")
+            .Values("Bob", 42);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("INSERT INTO users (name, age) VALUES ('Bob', 42)", sql);
+    }
 }
 

--- a/DbaClientX/QueryBuilder/Query.cs
+++ b/DbaClientX/QueryBuilder/Query.cs
@@ -7,6 +7,9 @@ public class Query
     private readonly List<string> _select = new();
     private string _from;
     private readonly List<(string Column, string Operator, object Value)> _where = new();
+    private string _insertTable;
+    private readonly List<string> _insertColumns = new();
+    private readonly List<object> _values = new();
 
     public Query Select(params string[] columns)
     {
@@ -31,8 +34,24 @@ public class Query
         return this;
     }
 
+    public Query InsertInto(string table, params string[] columns)
+    {
+        _insertTable = table;
+        _insertColumns.AddRange(columns);
+        return this;
+    }
+
+    public Query Values(params object[] values)
+    {
+        _values.AddRange(values);
+        return this;
+    }
+
     public IReadOnlyList<string> SelectColumns => _select;
     public string Table => _from;
     public IReadOnlyList<(string Column, string Operator, object Value)> WhereClauses => _where;
+    public string InsertTable => _insertTable;
+    public IReadOnlyList<string> InsertColumns => _insertColumns;
+    public IReadOnlyList<object> InsertValues => _values;
 }
 

--- a/DbaClientX/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX/QueryBuilder/QueryCompiler.cs
@@ -7,6 +7,35 @@ public class QueryCompiler
     public string Compile(Query query)
     {
         var sb = new StringBuilder();
+
+        if (!string.IsNullOrWhiteSpace(query.InsertTable))
+        {
+            sb.Append("INSERT INTO ").Append(query.InsertTable);
+
+            if (query.InsertColumns.Count > 0)
+            {
+                sb.Append(" (").Append(string.Join(", ", query.InsertColumns)).Append(')');
+            }
+
+            if (query.InsertValues.Count > 0)
+            {
+                sb.Append(" VALUES (");
+                bool firstValue = true;
+                foreach (var value in query.InsertValues)
+                {
+                    if (!firstValue)
+                    {
+                        sb.Append(", ");
+                    }
+                    sb.Append(FormatValue(value));
+                    firstValue = false;
+                }
+                sb.Append(')');
+            }
+
+            return sb.ToString();
+        }
+
         sb.Append("SELECT ");
         if (query.SelectColumns.Count > 0)
         {


### PR DESCRIPTION
## Summary
- extend `Query` with `InsertInto` and `Values` methods
- enable `QueryCompiler` to compile INSERT statements
- add unit test for building a simple INSERT query

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687f6edceacc832e92a856b28f8c5d4d