### PR TITLE
Add extended query builder operations

### DIFF
--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -26,5 +26,54 @@ public class QueryBuilderTests
         var sql = QueryBuilder.Compile(query);
         Assert.Equal("INSERT INTO users (name, age) VALUES ('Bob', 42)", sql);
     }
+
+    [Fact]
+    public void UpdateWithWhere()
+    {
+        var query = new Query()
+            .Update("users")
+            .Set("name", "Alice")
+            .Where("id", 1);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("UPDATE users SET name = 'Alice' WHERE id = 1", sql);
+    }
+
+    [Fact]
+    public void DeleteWithWhere()
+    {
+        var query = new Query()
+            .DeleteFrom("users")
+            .Where("id", 1);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("DELETE FROM users WHERE id = 1", sql);
+    }
+
+    [Fact]
+    public void SelectOrderByLimit()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .OrderBy("name")
+            .Limit(10);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users ORDER BY name LIMIT 10", sql);
+    }
+
+    [Fact]
+    public void SelectOrderByTop()
+    {
+        var query = new Query()
+            .Top(5)
+            .Select("*")
+            .From("users")
+            .OrderBy("age");
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT TOP 5 * FROM users ORDER BY age", sql);
+    }
 }
 

--- a/DbaClientX/QueryBuilder/Query.cs
+++ b/DbaClientX/QueryBuilder/Query.cs
@@ -10,6 +10,12 @@ public class Query
     private string _insertTable;
     private readonly List<string> _insertColumns = new();
     private readonly List<object> _values = new();
+    private string _updateTable;
+    private readonly List<(string Column, object Value)> _set = new();
+    private string _deleteTable;
+    private readonly List<string> _orderBy = new();
+    private int? _limit;
+    private bool _useTop;
 
     public Query Select(params string[] columns)
     {
@@ -41,6 +47,44 @@ public class Query
         return this;
     }
 
+    public Query Update(string table)
+    {
+        _updateTable = table;
+        return this;
+    }
+
+    public Query Set(string column, object value)
+    {
+        _set.Add((column, value));
+        return this;
+    }
+
+    public Query DeleteFrom(string table)
+    {
+        _deleteTable = table;
+        return this;
+    }
+
+    public Query OrderBy(params string[] columns)
+    {
+        _orderBy.AddRange(columns);
+        return this;
+    }
+
+    public Query Limit(int limit)
+    {
+        _limit = limit;
+        _useTop = false;
+        return this;
+    }
+
+    public Query Top(int top)
+    {
+        _limit = top;
+        _useTop = true;
+        return this;
+    }
+
     public Query Values(params object[] values)
     {
         _values.AddRange(values);
@@ -53,5 +97,11 @@ public class Query
     public string InsertTable => _insertTable;
     public IReadOnlyList<string> InsertColumns => _insertColumns;
     public IReadOnlyList<object> InsertValues => _values;
+    public string UpdateTable => _updateTable;
+    public IReadOnlyList<(string Column, object Value)> SetValues => _set;
+    public string DeleteTable => _deleteTable;
+    public IReadOnlyList<string> OrderByColumns => _orderBy;
+    public int? LimitValue => _limit;
+    public bool UseTop => _useTop;
 }
 

--- a/DbaClientX/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX/QueryBuilder/QueryCompiler.cs
@@ -36,7 +36,72 @@ public class QueryCompiler
             return sb.ToString();
         }
 
+        if (!string.IsNullOrWhiteSpace(query.UpdateTable))
+        {
+            sb.Append("UPDATE ").Append(query.UpdateTable);
+            if (query.SetValues.Count > 0)
+            {
+                sb.Append(" SET ");
+                bool firstSet = true;
+                foreach (var set in query.SetValues)
+                {
+                    if (!firstSet)
+                    {
+                        sb.Append(", ");
+                    }
+                    sb.Append(set.Column).Append(" = ").Append(FormatValue(set.Value));
+                    firstSet = false;
+                }
+            }
+
+            if (query.WhereClauses.Count > 0)
+            {
+                sb.Append(" WHERE ");
+                bool first = true;
+                foreach (var clause in query.WhereClauses)
+                {
+                    if (!first)
+                    {
+                        sb.Append(" AND ");
+                    }
+                    sb.Append(clause.Column).Append(' ').Append(clause.Operator).Append(' ');
+                    sb.Append(FormatValue(clause.Value));
+                    first = false;
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.DeleteTable))
+        {
+            sb.Append("DELETE FROM ").Append(query.DeleteTable);
+
+            if (query.WhereClauses.Count > 0)
+            {
+                sb.Append(" WHERE ");
+                bool first = true;
+                foreach (var clause in query.WhereClauses)
+                {
+                    if (!first)
+                    {
+                        sb.Append(" AND ");
+                    }
+                    sb.Append(clause.Column).Append(' ').Append(clause.Operator).Append(' ');
+                    sb.Append(FormatValue(clause.Value));
+                    first = false;
+                }
+            }
+
+            return sb.ToString();
+        }
+
         sb.Append("SELECT ");
+        if (query.LimitValue.HasValue && query.UseTop)
+        {
+            sb.Append("TOP ").Append(query.LimitValue.Value).Append(' ');
+        }
+
         if (query.SelectColumns.Count > 0)
         {
             sb.Append(string.Join(", ", query.SelectColumns));
@@ -66,6 +131,17 @@ public class QueryCompiler
                 first = false;
             }
         }
+
+        if (query.OrderByColumns.Count > 0)
+        {
+            sb.Append(" ORDER BY ").Append(string.Join(", ", query.OrderByColumns));
+        }
+
+        if (query.LimitValue.HasValue && !query.UseTop)
+        {
+            sb.Append(" LIMIT ").Append(query.LimitValue.Value);
+        }
+
         return sb.ToString();
     }
 

--- a/Module/Examples/Example.NewQueryBuilder.ps1
+++ b/Module/Examples/Example.NewQueryBuilder.ps1
@@ -1,8 +1,26 @@
 Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force
 
 $query = [DBAClientX.QueryBuilder.QueryBuilder]::Query()
-$query = $query.Select('*').From('users').Where('id', 1)
+$query = $query.Select('*').From('users').Where('id', 1).OrderBy('name').Limit(5)
 
 $sql = [DBAClientX.QueryBuilder.QueryBuilder]::Compile($query)
 $sql
+
+$queryUpdate = [DBAClientX.QueryBuilder.QueryBuilder]::Query()
+$queryUpdate = $queryUpdate.Update('users').Set('name', 'Alice').Where('id', 1)
+
+$sqlUpdate = [DBAClientX.QueryBuilder.QueryBuilder]::Compile($queryUpdate)
+$sqlUpdate
+
+$queryDelete = [DBAClientX.QueryBuilder.QueryBuilder]::Query()
+$queryDelete = $queryDelete.DeleteFrom('users').Where('id', 1)
+
+$sqlDelete = [DBAClientX.QueryBuilder.QueryBuilder]::Compile($queryDelete)
+$sqlDelete
+
+$queryTop = [DBAClientX.QueryBuilder.QueryBuilder]::Query()
+$queryTop = $queryTop.Top(3).Select('*').From('users').OrderBy('age')
+
+$sqlTop = [DBAClientX.QueryBuilder.QueryBuilder]::Compile($queryTop)
+$sqlTop
 


### PR DESCRIPTION
## Summary
- add new Query methods for Update/Delete and compile them
- support OrderBy with optional LIMIT or TOP
- expand examples for new Query builder API
- test various query scenarios

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_687f73d46b60832e9fa87d1aea78349e