### PR TITLE
Include query details in query execution exceptions

### DIFF
--- a/DbaClientX.Tests/SqlServerTests.cs
+++ b/DbaClientX.Tests/SqlServerTests.cs
@@ -15,10 +15,11 @@ public class SqlServerTests
     public async Task SqlQueryAsync_InvalidServer_ThrowsDbaQueryExecutionException()
     {
         var sqlServer = new DBAClientX.SqlServer();
-        await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(async () =>
+        var ex = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(async () =>
         {
             await sqlServer.SqlQueryAsync("invalid", "master", true, "SELECT 1");
         });
+        Assert.Contains("SELECT 1", ex.Message);
     }
 
     private class DelaySqlServer : DBAClientX.SqlServer

--- a/DbaClientX/DbaQueryExecutionException.cs
+++ b/DbaClientX/DbaQueryExecutionException.cs
@@ -2,15 +2,28 @@ namespace DBAClientX;
 
 public class DbaQueryExecutionException : DbaClientXException
 {
+    public string? Query { get; }
+
     public DbaQueryExecutionException()
     {
     }
 
-    public DbaQueryExecutionException(string? message) : base(message)
+    public DbaQueryExecutionException(string? message, string? query = null) : base(BuildMessage(message, query))
     {
+        Query = query;
     }
 
-    public DbaQueryExecutionException(string? message, Exception? innerException) : base(message, innerException)
+    public DbaQueryExecutionException(string? message, string? query, Exception? innerException) : base(BuildMessage(message, query), innerException)
     {
+        Query = query;
+    }
+
+    private static string? BuildMessage(string? message, string? query)
+    {
+        if (string.IsNullOrEmpty(query))
+        {
+            return message;
+        }
+        return message + " Query: " + query;
     }
 }

--- a/DbaClientX/SqlServer.cs
+++ b/DbaClientX/SqlServer.cs
@@ -98,7 +98,7 @@ public class SqlServer
         }
         catch (Exception ex)
         {
-            throw new DbaQueryExecutionException("Failed to execute query.", ex);
+            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
         }
         finally
         {
@@ -182,7 +182,7 @@ public class SqlServer
         }
         catch (Exception ex)
         {
-            throw new DbaQueryExecutionException("Failed to execute query.", ex);
+            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- enrich `DbaQueryExecutionException` with a `Query` property
- include query text when throwing the exception in `SqlQuery` and `SqlQueryAsync`
- validate returned exception message in `SqlServerTests`

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_687fd5a942e0832ea154827633f43fdd