### PR TITLE
Add mock transaction tests

### DIFF
--- a/DbaClientX.Tests/SqlServerTransactionTests.cs
+++ b/DbaClientX.Tests/SqlServerTransactionTests.cs
@@ -1,0 +1,105 @@
+using System.Data;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class SqlServerTransactionTests
+{
+    private class FakeSqlConnection
+    {
+        public bool BeginCalled { get; private set; }
+        public FakeSqlTransaction BeginTransaction()
+        {
+            BeginCalled = true;
+            return new FakeSqlTransaction(this);
+        }
+    }
+
+    private class FakeSqlTransaction
+    {
+        private readonly FakeSqlConnection _connection;
+        public bool CommitCalled { get; private set; }
+        public bool RollbackCalled { get; private set; }
+
+        public FakeSqlTransaction(FakeSqlConnection connection)
+        {
+            _connection = connection;
+        }
+
+        public void Commit() => CommitCalled = true;
+        public void Rollback() => RollbackCalled = true;
+    }
+
+    private class TestSqlServer : DBAClientX.SqlServer
+    {
+        public FakeSqlConnection? Connection { get; private set; }
+        public FakeSqlTransaction? Transaction { get; private set; }
+
+        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity)
+        {
+            Connection = new FakeSqlConnection();
+            Transaction = Connection.BeginTransaction();
+        }
+
+        public override void Commit()
+        {
+            if (Transaction == null)
+            {
+                throw new DBAClientX.DbaTransactionException("No active transaction.");
+            }
+            Transaction.Commit();
+            Transaction = null;
+        }
+
+        public override void Rollback()
+        {
+            if (Transaction == null)
+            {
+                throw new DBAClientX.DbaTransactionException("No active transaction.");
+            }
+            Transaction.Rollback();
+            Transaction = null;
+        }
+
+        public override object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+        {
+            if (useTransaction && Transaction == null)
+            {
+                throw new DBAClientX.DbaTransactionException("Transaction has not been started.");
+            }
+            return null;
+        }
+    }
+
+    [Fact]
+    public void BeginTransaction_UsesConnection()
+    {
+        var server = new TestSqlServer();
+        server.BeginTransaction("s", "db", true);
+        Assert.NotNull(server.Connection);
+        Assert.True(server.Connection!.BeginCalled);
+        Assert.NotNull(server.Transaction);
+    }
+
+    [Fact]
+    public void Commit_CallsCommitOnTransaction()
+    {
+        var server = new TestSqlServer();
+        server.BeginTransaction("s", "db", true);
+        var txn = server.Transaction!;
+        server.Commit();
+        Assert.True(txn.CommitCalled);
+        Assert.Null(server.Transaction);
+    }
+
+    [Fact]
+    public void Rollback_CallsRollbackOnTransaction()
+    {
+        var server = new TestSqlServer();
+        server.BeginTransaction("s", "db", true);
+        var txn = server.Transaction!;
+        server.Rollback();
+        Assert.True(txn.RollbackCalled);
+        Assert.Null(server.Transaction);
+    }
+}


### PR DESCRIPTION
## Summary
- add SqlServerTransactionTests for transaction handling
- ensure tests target net8.0

## Testing
- `dotnet test DbaClientX.Tests/DbaClientX.Tests.csproj -c Release --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_687fd5931318832e9256178ff7784fa3