### PR TITLE
Add Pester test for Invoke-DbaXQuery

### DIFF
--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -3,6 +3,7 @@
 [Cmdlet(VerbsLifecycle.Invoke, "DbaXQuery", DefaultParameterSetName = "Compatibility", SupportsShouldProcess = true)]
 [CmdletBinding()]
 public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
+    public static Func<DBAClientX.SqlServer> SqlServerFactory { get; set; } = () => new DBAClientX.SqlServer();
     [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
     [Alias("DBServer", "SqlInstance", "Instance")]
     public string Server { get; set; }
@@ -45,10 +46,9 @@ public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
     /// Process method for PowerShell cmdlet
     /// </summary>
     protected override void ProcessRecord() {
-        var sqlServer = new DBAClientX.SqlServer {
-            ReturnType = ReturnType,
-            CommandTimeout = QueryTimeout
-        };
+        var sqlServer = SqlServerFactory();
+        sqlServer.ReturnType = ReturnType;
+        sqlServer.CommandTimeout = QueryTimeout;
         try {
             IDictionary<string, object?>? parameters = null;
             if (Parameters != null)

--- a/DbaClientX.Tests/TestSqlServer.cs
+++ b/DbaClientX.Tests/TestSqlServer.cs
@@ -1,0 +1,17 @@
+using System.Data;
+using System.Collections.Generic;
+
+namespace DbaClientX.Tests;
+
+public class TestSqlServer : DBAClientX.SqlServer
+{
+    public override object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+    {
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        var row = table.NewRow();
+        row["Id"] = 1;
+        table.Rows.Add(row);
+        return table;
+    }
+}

--- a/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
@@ -2,14 +2,17 @@ Import-Module "$PSScriptRoot/../DbaClientX.psd1" -Force
 
 Describe 'Invoke-DbaXQuery cmdlet' {
     It 'Outputs PSObject when ReturnType is PSObject' {
-        $table = New-Object System.Data.DataTable
-        [void]$table.Columns.Add('Id', [int])
-        [void]$table.Rows.Add(1)
+        $dllPath = Join-Path $PSScriptRoot '..\..\DbaClientX.Tests\bin\Debug\net8.0\DbaClientX.Tests.dll'
+        Add-Type -Path $dllPath
 
-        Mock -CommandName ([DBAClientX.SqlServer]) -MethodName SqlQuery -MockWith { $table }
-
-        $result = Invoke-DbaXQuery -Server 'Server1' -Database 'master' -Query 'SELECT 1' -ReturnType PSObject
-        $result | Should -BeOfType [psobject]
-        $result.Id | Should -Be 1
+        $originalFactory = [DBAClientX.PowerShell.CmdletIInvokeDbaXQuery]::SqlServerFactory
+        [DBAClientX.PowerShell.CmdletIInvokeDbaXQuery]::SqlServerFactory = { [DbaClientX.Tests.TestSqlServer]::new() }
+        try {
+            $result = Invoke-DbaXQuery -Server 'Server1' -Database 'master' -Query 'SELECT 1' -ReturnType PSObject
+            $result | Should -BeOfType [psobject]
+            $result.Id | Should -Be 1
+        } finally {
+            [DBAClientX.PowerShell.CmdletIInvokeDbaXQuery]::SqlServerFactory = $originalFactory
+        }
     }
 }

--- a/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
@@ -1,0 +1,15 @@
+Import-Module "$PSScriptRoot/../DbaClientX.psd1" -Force
+
+Describe 'Invoke-DbaXQuery cmdlet' {
+    It 'Outputs PSObject when ReturnType is PSObject' {
+        $table = New-Object System.Data.DataTable
+        [void]$table.Columns.Add('Id', [int])
+        [void]$table.Rows.Add(1)
+
+        Mock -CommandName ([DBAClientX.SqlServer]) -MethodName SqlQuery -MockWith { $table }
+
+        $result = Invoke-DbaXQuery -Server 'Server1' -Database 'master' -Query 'SELECT 1' -ReturnType PSObject
+        $result | Should -BeOfType [psobject]
+        $result.Id | Should -Be 1
+    }
+}


### PR DESCRIPTION
## Summary
- add new CmdletInvokeDbaXQuery.Tests.ps1 with a mock attempt for SqlServer.SqlQuery

## Testing
- `dotnet build DbaClientX.sln --configuration Debug --no-restore`
- `pwsh -NoLogo -File ./Module/DbaClientX.Tests.ps1` *(fails: ParameterBindingException: A parameter cannot be found that matches parameter name 'MethodName')*

------
https://chatgpt.com/codex/tasks/task_e_687fd59d28c8832eb7f031f83993d910