### PR TITLE
Introduce abstract base class for db access

### DIFF
--- a/DbaClientX/DatabaseClientBase.cs
+++ b/DbaClientX/DatabaseClientBase.cs
@@ -97,7 +97,7 @@ public abstract class DatabaseClientBase
 
     protected virtual async Task<object?> ExecuteQueryAsync(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, CancellationToken cancellationToken = default, IDictionary<string, DbType>? parameterTypes = null)
     {
-        await using var command = connection.CreateCommand();
+        using var command = connection.CreateCommand();
         command.CommandText = query;
         command.Transaction = transaction;
         AddParameters(command, parameters, parameterTypes);
@@ -108,7 +108,7 @@ public abstract class DatabaseClientBase
         }
 
         var dataSet = new DataSet();
-        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         var tableIndex = 0;
         do
         {

--- a/DbaClientX/DatabaseClientBase.cs
+++ b/DbaClientX/DatabaseClientBase.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DBAClientX;
+
+public abstract class DatabaseClientBase
+{
+    private readonly object _syncRoot = new();
+    private ReturnType _returnType;
+    private int _commandTimeout;
+
+    public ReturnType ReturnType
+    {
+        get { lock (_syncRoot) { return _returnType; } }
+        set { lock (_syncRoot) { _returnType = value; } }
+    }
+
+    public int CommandTimeout
+    {
+        get { lock (_syncRoot) { return _commandTimeout; } }
+        set { lock (_syncRoot) { _commandTimeout = value; } }
+    }
+
+    protected virtual void AddParameters(DbCommand command, IDictionary<string, object?>? parameters, IDictionary<string, DbType>? parameterTypes = null)
+    {
+        if (parameters == null)
+        {
+            return;
+        }
+
+        foreach (var pair in parameters)
+        {
+            var value = pair.Value ?? DBNull.Value;
+            var parameter = command.CreateParameter();
+            parameter.ParameterName = pair.Key;
+            parameter.Value = value;
+            if (parameterTypes != null && parameterTypes.TryGetValue(pair.Key, out var explicitType))
+            {
+                parameter.DbType = explicitType;
+            }
+            else
+            {
+                parameter.DbType = InferDbType(value);
+            }
+            command.Parameters.Add(parameter);
+        }
+    }
+
+    private static DbType InferDbType(object? value)
+    {
+        if (value == null || value == DBNull.Value) return DbType.Object;
+        return Type.GetTypeCode(value.GetType()) switch
+        {
+            TypeCode.Byte => DbType.Byte,
+            TypeCode.Int16 => DbType.Int16,
+            TypeCode.Int32 => DbType.Int32,
+            TypeCode.Int64 => DbType.Int64,
+            TypeCode.Decimal => DbType.Decimal,
+            TypeCode.Double => DbType.Double,
+            TypeCode.Single => DbType.Single,
+            TypeCode.Boolean => DbType.Boolean,
+            TypeCode.String => DbType.String,
+            TypeCode.DateTime => DbType.DateTime,
+            _ => DbType.Object
+        };
+    }
+
+    protected virtual object? ExecuteQuery(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, IDictionary<string, DbType>? parameterTypes = null)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = query;
+        command.Transaction = transaction;
+        AddParameters(command, parameters, parameterTypes);
+        var commandTimeout = CommandTimeout;
+        if (commandTimeout > 0)
+        {
+            command.CommandTimeout = commandTimeout;
+        }
+
+        var dataSet = new DataSet();
+        using var reader = command.ExecuteReader();
+        var tableIndex = 0;
+        do
+        {
+            var table = new DataTable($"Table{tableIndex}");
+            table.Load(reader);
+            dataSet.Tables.Add(table);
+            tableIndex++;
+        } while (!reader.IsClosed && reader.NextResult());
+
+        return BuildResult(dataSet);
+    }
+
+    protected virtual async Task<object?> ExecuteQueryAsync(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, CancellationToken cancellationToken = default, IDictionary<string, DbType>? parameterTypes = null)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = query;
+        command.Transaction = transaction;
+        AddParameters(command, parameters, parameterTypes);
+        var commandTimeout = CommandTimeout;
+        if (commandTimeout > 0)
+        {
+            command.CommandTimeout = commandTimeout;
+        }
+
+        var dataSet = new DataSet();
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var tableIndex = 0;
+        do
+        {
+            var table = new DataTable($"Table{tableIndex}");
+            table.Load(reader);
+            dataSet.Tables.Add(table);
+            tableIndex++;
+        } while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+
+        return BuildResult(dataSet);
+    }
+
+    private object? BuildResult(DataSet dataSet)
+    {
+        var returnType = ReturnType;
+        if (returnType == ReturnType.DataRow || returnType == ReturnType.PSObject)
+        {
+            if (dataSet.Tables.Count > 0)
+            {
+                return dataSet.Tables[0];
+            }
+        }
+        else if (returnType == ReturnType.DataSet)
+        {
+            return dataSet;
+        }
+        else if (returnType == ReturnType.DataTable)
+        {
+            return dataSet.Tables;
+        }
+        return null;
+    }
+}
+

--- a/DbaClientX/SqlServer.cs
+++ b/DbaClientX/SqlServer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using System.Data.SqlClient;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,27 +12,13 @@ namespace DBAClientX;
 /// <summary>
 /// This class is used to connect to SQL Server
 /// </summary>
-public class SqlServer
+public class SqlServer : DatabaseClientBase
 {
     private readonly object _syncRoot = new();
-    private ReturnType _returnType;
-    private int _commandTimeout;
     private SqlConnection? _transactionConnection;
     private SqlTransaction? _transaction;
 
     public bool IsInTransaction => _transaction != null;
-
-    public ReturnType ReturnType
-    {
-        get { lock (_syncRoot) { return _returnType; } }
-        set { lock (_syncRoot) { _returnType = value; } }
-    }
-
-    public int CommandTimeout
-    {
-        get { lock (_syncRoot) { return _commandTimeout; } }
-        set { lock (_syncRoot) { _commandTimeout = value; } }
-    }
 
     public virtual object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
     {
@@ -45,7 +32,6 @@ public class SqlServer
 
         SqlConnection? connection = null;
         bool dispose = false;
-        object? result = null;
         try
         {
             if (useTransaction)
@@ -63,38 +49,8 @@ public class SqlServer
                 dispose = true;
             }
 
-            var command = new SqlCommand(query, connection);
-            if (useTransaction)
-            {
-                command.Transaction = _transaction;
-            }
-            AddParameters(command, parameters, parameterTypes);
-            var commandTimeout = CommandTimeout;
-            if (commandTimeout > 0)
-            {
-                command.CommandTimeout = commandTimeout;
-            }
-            var dataAdapter = new SqlDataAdapter(command);
-            var dataSet = new System.Data.DataSet();
-
-            dataAdapter.Fill(dataSet);
-
-            var returnType = ReturnType;
-            if (returnType == ReturnType.DataRow || returnType == ReturnType.PSObject)
-            {
-                if (dataSet.Tables.Count > 0)
-                {
-                    result = dataSet.Tables[0];
-                }
-            }
-            else if (returnType == ReturnType.DataSet)
-            {
-                result = dataSet;
-            }
-            else if (returnType == ReturnType.DataTable)
-            {
-                result = dataSet.Tables;
-            }
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return ExecuteQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
         }
         catch (Exception ex)
         {
@@ -107,7 +63,21 @@ public class SqlServer
                 connection?.Dispose();
             }
         }
+    }
 
+    private static IDictionary<string, DbType>? ConvertParameterTypes(IDictionary<string, SqlDbType>? types)
+    {
+        if (types == null)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, DbType>(types.Count);
+        foreach (var pair in types)
+        {
+            var parameter = new SqlParameter { SqlDbType = pair.Value };
+            result[pair.Key] = parameter.DbType;
+        }
         return result;
     }
 
@@ -123,7 +93,6 @@ public class SqlServer
 
         SqlConnection? connection = null;
         bool dispose = false;
-        object? result = null;
         try
         {
             if (useTransaction)
@@ -141,44 +110,8 @@ public class SqlServer
                 dispose = true;
             }
 
-            var command = new SqlCommand(query, connection);
-            if (useTransaction)
-            {
-                command.Transaction = _transaction;
-            }
-            AddParameters(command, parameters, parameterTypes);
-            var commandTimeout = CommandTimeout;
-            if (commandTimeout > 0)
-            {
-                command.CommandTimeout = commandTimeout;
-            }
-
-            var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-            var tableIndex = 0;
-            do {
-                var dataTable = new DataTable($"Table{tableIndex}");
-                dataTable.Load(reader);
-                dataSet.Tables.Add(dataTable);
-                tableIndex++;
-            } while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
-
-            var returnType = ReturnType;
-            if (returnType == ReturnType.DataRow || returnType == ReturnType.PSObject)
-            {
-                if (dataSet.Tables.Count > 0)
-                {
-                    result = dataSet.Tables[0];
-                }
-            }
-            else if (returnType == ReturnType.DataSet)
-            {
-                result = dataSet;
-            }
-            else if (returnType == ReturnType.DataTable)
-            {
-                result = dataSet.Tables;
-            }
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return await ExecuteQueryAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -191,52 +124,8 @@ public class SqlServer
                 connection?.Dispose();
             }
         }
-
-        return result;
     }
 
-    protected virtual void AddParameters(SqlCommand command, IDictionary<string, object?>? parameters, IDictionary<string, SqlDbType>? parameterTypes = null)
-    {
-        if (parameters == null)
-        {
-            return;
-        }
-
-        foreach (var pair in parameters)
-        {
-            var value = pair.Value ?? DBNull.Value;
-            var parameter = command.CreateParameter();
-            parameter.ParameterName = pair.Key;
-            parameter.Value = value;
-            if (parameterTypes != null && parameterTypes.TryGetValue(pair.Key, out var explicitType))
-            {
-                parameter.SqlDbType = explicitType;
-            }
-            else
-            {
-                parameter.SqlDbType = InferSqlDbType(value);
-            }
-            command.Parameters.Add(parameter);
-        }
-    }
-
-    private static SqlDbType InferSqlDbType(object? value)
-    {
-        if (value == null || value == DBNull.Value) return SqlDbType.Variant;
-        return Type.GetTypeCode(value.GetType()) switch
-        {
-            TypeCode.Byte => SqlDbType.TinyInt,
-            TypeCode.Int16 => SqlDbType.SmallInt,
-            TypeCode.Int32 => SqlDbType.Int,
-            TypeCode.Int64 => SqlDbType.BigInt,
-            TypeCode.Decimal => SqlDbType.Decimal,
-            TypeCode.Double => SqlDbType.Float,
-            TypeCode.Single => SqlDbType.Real,
-            TypeCode.Boolean => SqlDbType.Bit,
-            TypeCode.String => SqlDbType.NVarChar,
-            _ => SqlDbType.Variant
-        };
-    }
 
     public virtual void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity)
     {


### PR DESCRIPTION
## Summary
- add `DatabaseClientBase` using `DbConnection` and `DbCommand`
- refactor `SqlServer` to inherit from the base class
- adjust parameter type conversion
- update unit tests

## Testing
- `dotnet build DbaClientX.sln -c Release`
- `dotnet test DbaClientX.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6889cad91454832ea2f165e99c849503