### PR TITLE
Ensure invariant numeric formatting

### DIFF
--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -1,4 +1,5 @@
 using DBAClientX.QueryBuilder;
+using System.Globalization;
 
 namespace DbaClientX.Tests;
 
@@ -180,6 +181,27 @@ public class QueryBuilderTests
 
         var sql = QueryBuilder.Compile(query);
         Assert.Equal("SELECT age, COUNT(*) FROM users GROUP BY age HAVING COUNT(*) > 1", sql);
+    }
+
+    [Fact]
+    public void DecimalFormatting_UsesInvariantCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("pl-PL");
+            var query = new Query()
+                .Select("*")
+                .From("prices")
+                .Where("amount", 10.5m);
+
+            var sql = QueryBuilder.Compile(query);
+            Assert.Equal("SELECT * FROM prices WHERE amount = 10.5", sql);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
     }
 }
 

--- a/DbaClientX/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX/QueryBuilder/QueryCompiler.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Globalization;
 
 namespace DBAClientX.QueryBuilder;
 
@@ -187,6 +188,9 @@ public class QueryCompiler
             string s => $"'{s.Replace("'", "''")}'",
             null => "NULL",
             bool b => b ? "1" : "0",
+            decimal d => d.ToString(CultureInfo.InvariantCulture),
+            double d => d.ToString(CultureInfo.InvariantCulture),
+            float f => f.ToString(CultureInfo.InvariantCulture),
             Query q => "(" + new QueryCompiler().Compile(q) + ")",
             _ => value.ToString()
         };


### PR DESCRIPTION
## Summary
- fix numeric formatting by switching to invariant culture
- verify decimal formatting with a new unit test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688a16688a44832e936018c48f9a2f24