### PR TITLE
Fix resolve handler nullability

### DIFF
--- a/DbaClientX.PowerShell/OnImportAndRemove.cs
+++ b/DbaClientX.PowerShell/OnImportAndRemove.cs
@@ -31,7 +31,7 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
                 return Assembly.LoadFile(file);
             }
         }
-        return null;
+        return null!;
     }
 
     private bool IsNetFramework() {

--- a/DbaClientX.Tests/OnImportAndRemoveTests.cs
+++ b/DbaClientX.Tests/OnImportAndRemoveTests.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Reflection;
+using DBAClientX.PowerShell;
+using Xunit;
+
+public class OnImportAndRemoveTests
+{
+    [Fact]
+    public void MyResolveEventHandler_ReturnsNullWhenNoMatch()
+    {
+        var resolveArgs = new ResolveEventArgs("NonExistingAssembly");
+        var method = typeof(OnModuleImportAndRemove).GetMethod(
+            "MyResolveEventHandler",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        var result = (Assembly?)method!.Invoke(null, new object?[] { null, resolveArgs });
+        Assert.Null(result);
+    }
+}


### PR DESCRIPTION
## Summary
- update `OnModuleImportAndRemove.MyResolveEventHandler` to return `null!`
- add unit test validating null return when assembly isn't found

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688a39c9776c832eaf50c6c1e8b15524