### PR TITLE
Handle limit/top exclusivity

### DIFF
--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -106,6 +106,33 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void LimitThenTop_UsesTop()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .Limit(5)
+            .Offset(2)
+            .Top(3);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT TOP 3 * FROM users", sql);
+    }
+
+    [Fact]
+    public void TopThenLimit_UsesLimit()
+    {
+        var query = new Query()
+            .Top(5)
+            .Limit(2)
+            .Select("*")
+            .From("users");
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users LIMIT 2", sql);
+    }
+
+    [Fact]
     public void SelectMultipleColumns()
     {
         var query = new Query()

--- a/DbaClientX/QueryBuilder/Query.cs
+++ b/DbaClientX/QueryBuilder/Query.cs
@@ -110,6 +110,8 @@ public class Query
     {
         _limit = limit;
         _useTop = false;
+        // Ensure pagination mode is exclusive
+        // Limit/Offset mode should not use TOP
         return this;
     }
 
@@ -124,6 +126,8 @@ public class Query
     {
         _limit = top;
         _useTop = true;
+        // Reset offset when switching to TOP to avoid mixed pagination modes
+        _offset = null;
         return this;
     }
 


### PR DESCRIPTION
## Summary
- fix pagination mode by resetting offset when switching to `Top`
- test sequential usage of `Limit` and `Top`

## Testing
- `dotnet test`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_688a39d16f00832e8de927636f1bc1eb