### PR TITLE
Add async streaming query API

### DIFF
--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -22,8 +22,11 @@ public class Program
             case "cancellation":
                 await CancellationExample.RunAsync();
                 break;
+            case "streamquery":
+                await StreamQueryExample.RunAsync();
+                break;
             default:
-                Console.WriteLine("Available examples: asyncquery, parallelqueries, transaction, cancellation, nestedquery");
+                Console.WriteLine("Available examples: asyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery");
                 break;
         }
     }

--- a/DbaClientX.Examples/StreamQueryExample.cs
+++ b/DbaClientX.Examples/StreamQueryExample.cs
@@ -1,0 +1,23 @@
+using DBAClientX;
+using System.Data;
+using System.Threading;
+
+public static class StreamQueryExample
+{
+    public static async Task RunAsync()
+    {
+        var sqlServer = new SqlServer
+        {
+            ReturnType = ReturnType.DataRow
+        };
+
+        await foreach (DataRow row in sqlServer.SqlQueryStreamAsync("SQL1", "master", true, "SELECT TOP 5 * FROM sys.databases", cancellationToken: CancellationToken.None))
+        {
+            foreach (DataColumn col in row.Table.Columns)
+            {
+                Console.Write($"{row[col]}\t");
+            }
+            Console.WriteLine();
+        }
+    }
+}

--- a/DbaClientX.Tests/SqlQueryStreamTests.cs
+++ b/DbaClientX.Tests/SqlQueryStreamTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class SqlQueryStreamTests
+{
+    private class DummySqlServer : DBAClientX.SqlServer
+    {
+        private readonly List<DataRow> _rows;
+
+        public DummySqlServer()
+        {
+            var table = new DataTable();
+            table.Columns.Add("id", typeof(int));
+            table.Columns.Add("name", typeof(string));
+            var r1 = table.NewRow();
+            r1["id"] = 1;
+            r1["name"] = "one";
+            table.Rows.Add(r1);
+            var r2 = table.NewRow();
+            r2["id"] = 2;
+            r2["name"] = "two";
+            table.Rows.Add(r2);
+            _rows = table.Rows.Cast<DataRow>().ToList();
+        }
+
+        public override async IAsyncEnumerable<DataRow> SqlQueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+        {
+            foreach (var row in _rows)
+            {
+                await Task.Yield();
+                yield return row;
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SqlQueryStreamAsync_EnumeratesRows()
+    {
+        var server = new DummySqlServer();
+        var list = new List<int>();
+
+        await foreach (DataRow row in server.SqlQueryStreamAsync("s", "d", true, "q"))
+        {
+            list.Add((int)row["id"]);
+        }
+
+        Assert.Equal(new[] { 1, 2 }, list);
+    }
+}

--- a/DbaClientX/DbaClientX.csproj
+++ b/DbaClientX/DbaClientX.csproj
@@ -39,6 +39,7 @@
 	</PropertyGroup>
         <ItemGroup>
                 <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+                <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         </ItemGroup>
 	<ItemGroup>
 		<Using Include="System.Collections" />

--- a/DbaClientX/SqlServer.cs
+++ b/DbaClientX/SqlServer.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+using System.Runtime.CompilerServices;
+#endif
 
 namespace DBAClientX;
 
@@ -125,6 +128,57 @@ public class SqlServer : DatabaseClientBase
             }
         }
     }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    public virtual IAsyncEnumerable<DataRow> SqlQueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+    {
+        return Stream();
+
+        async IAsyncEnumerable<DataRow> Stream()
+        {
+            var connectionString = new SqlConnectionStringBuilder
+            {
+                DataSource = serverOrInstance,
+                InitialCatalog = database,
+                IntegratedSecurity = integratedSecurity,
+                Pooling = true
+            }.ConnectionString;
+
+            SqlConnection? connection = null;
+            bool dispose = false;
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new SqlConnection(connectionString);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            try
+            {
+                await foreach (var row in ExecuteQueryStreamAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes).ConfigureAwait(false))
+                {
+                    yield return row;
+                }
+            }
+            finally
+            {
+                if (dispose)
+                {
+                    connection?.Dispose();
+                }
+            }
+        }
+    }
+#endif
 
 
     public virtual void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity)


### PR DESCRIPTION
## Summary
- support async streaming via `ExecuteQueryStreamAsync` and `SqlQueryStreamAsync`
- expose streaming example and update program options
- add unit test verifying streamed rows
- reference Microsoft.Bcl.AsyncInterfaces for cross-target `IAsyncEnumerable`

## Testing
- `dotnet build DbaClientX.sln -c Release`
- `dotnet test DbaClientX.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688a39b88e30832ea9269518c19f421f