### PR TITLE
Add DateTime handling in query compiler

### DIFF
--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -203,5 +203,49 @@ public class QueryBuilderTests
             CultureInfo.CurrentCulture = original;
         }
     }
+
+    [Fact]
+    public void DateTimeFormatting_UsesInvariantCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("pl-PL");
+            var date = new DateTime(2024, 1, 2, 3, 4, 5);
+            var query = new Query()
+                .Select("*")
+                .From("events")
+                .Where("created", date);
+
+            var sql = QueryBuilder.Compile(query);
+            Assert.Equal("SELECT * FROM events WHERE created = '2024-01-02 03:04:05'", sql);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
+
+    [Fact]
+    public void DateTimeOffsetFormatting_UsesInvariantCulture()
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("pl-PL");
+            var dateOffset = new DateTimeOffset(2024, 1, 2, 3, 4, 5, TimeSpan.FromHours(2));
+            var query = new Query()
+                .Select("*")
+                .From("events")
+                .Where("created", dateOffset);
+
+            var sql = QueryBuilder.Compile(query);
+            Assert.Equal("SELECT * FROM events WHERE created = '2024-01-02 03:04:05'", sql);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+    }
 }
 

--- a/DbaClientX/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX/QueryBuilder/QueryCompiler.cs
@@ -188,6 +188,8 @@ public class QueryCompiler
             string s => $"'{s.Replace("'", "''")}'",
             null => "NULL",
             bool b => b ? "1" : "0",
+            DateTime dt => $"'{dt.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)}'",
+            DateTimeOffset dto => $"'{dto.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)}'",
             decimal d => d.ToString(CultureInfo.InvariantCulture),
             double d => d.ToString(CultureInfo.InvariantCulture),
             float f => f.ToString(CultureInfo.InvariantCulture),


### PR DESCRIPTION
## Summary
- support DateTime/DateTimeOffset formatting in `QueryCompiler`
- test DateTime and DateTimeOffset formatting in `QueryBuilderTests`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688a39dae570832e8a1d1d806abb6219