### PR TITLE
Restrict frameworks to net472, netstandard2.0 and net8

### DIFF
--- a/DbaClientX.Core/DbaClientX.Core.csproj
+++ b/DbaClientX.Core/DbaClientX.Core.csproj
@@ -4,8 +4,8 @@
     <AssemblyName>DbaClientX.Core</AssemblyName>
     <AssemblyTitle>DbaClientX.Core</AssemblyTitle>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;netstandard2.1;net472;net48;net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;net472;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">netstandard2.0;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
+++ b/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-			netstandard2.0;net472;net6.0;net7.0;net8.0
-		</TargetFrameworks>
-		<TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-			net6.0;net7.0;net8.0
-		</TargetFrameworks>
+                <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
+                        netstandard2.0;net472;net8.0
+                </TargetFrameworks>
+                <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
+                        netstandard2.0;net8.0
+                </TargetFrameworks>
 		<Description>PowerShell Module for working with databases</Description>
 		<AssemblyName>DBAClientX.PowerShell</AssemblyName>
 		<AssemblyTitle>DBAClientX.PowerShell</AssemblyTitle>

--- a/DbaClientX.SqlServer/DbaClientX.SqlServer.csproj
+++ b/DbaClientX.SqlServer/DbaClientX.SqlServer.csproj
@@ -4,8 +4,8 @@
     <AssemblyName>DbaClientX.SqlServer</AssemblyName>
     <AssemblyTitle>DbaClientX.SqlServer</AssemblyTitle>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;netstandard2.1;net472;net48;net6.0;net7.0;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;net472;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">netstandard2.0;net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>


### PR DESCRIPTION
## Summary
- trim supported frameworks to only `net472`, `netstandard2.0` and `net8.0`
- update Core, SqlServer and PowerShell projects

## Testing
- `dotnet build DbaClientX.sln -c Release`
- `dotnet test DbaClientX.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_688b9ffeb9f8832eb9cc4312a23bf4e0