### PR TITLE
Add non-query support and PowerShell cmdlet

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -98,6 +98,21 @@ public abstract class DatabaseClientBase
         return BuildResult(dataSet);
     }
 
+    protected virtual int ExecuteNonQuery(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, IDictionary<string, DbType>? parameterTypes = null)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = query;
+        command.Transaction = transaction;
+        AddParameters(command, parameters, parameterTypes);
+        var commandTimeout = CommandTimeout;
+        if (commandTimeout > 0)
+        {
+            command.CommandTimeout = commandTimeout;
+        }
+
+        return command.ExecuteNonQuery();
+    }
+
     protected virtual async Task<object?> ExecuteQueryAsync(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, CancellationToken cancellationToken = default, IDictionary<string, DbType>? parameterTypes = null)
     {
         using var command = connection.CreateCommand();

--- a/DbaClientX.Examples/NonQueryExample.cs
+++ b/DbaClientX.Examples/NonQueryExample.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+
+public static class NonQueryExample
+{
+    public static void Run()
+    {
+        var sqlServer = new DBAClientX.SqlServer();
+        var affected = sqlServer.SqlQueryNonQuery("SQL1", "master", true, "CREATE TABLE #Example (Id INT)");
+        Console.WriteLine($"Rows affected: {affected}");
+    }
+}

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -25,8 +25,11 @@ public class Program
             case "streamquery":
                 await StreamQueryExample.RunAsync();
                 break;
+            case "nonquery":
+                NonQueryExample.Run();
+                break;
             default:
-                Console.WriteLine("Available examples: asyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery");
+                Console.WriteLine("Available examples: asyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery");
                 break;
         }
     }

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
@@ -1,0 +1,55 @@
+namespace DBAClientX.PowerShell;
+
+[Cmdlet(VerbsLifecycle.Invoke, "DbaXNonQuery", DefaultParameterSetName = "DefaultCredentials", SupportsShouldProcess = true)]
+[CmdletBinding()]
+public sealed class CmdletIInvokeDbaXNonQuery : PSCmdlet {
+    [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
+    [Alias("DBServer", "SqlInstance", "Instance")]
+    public string Server { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
+    public string Database { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
+    public string Query { get; set; }
+
+    [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
+    public int QueryTimeout { get; set; }
+
+    [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
+    public Hashtable Parameters { get; set; }
+
+    private ActionPreference ErrorAction;
+
+    protected override void BeginProcessing() {
+        ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
+        if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
+            string errorActionString = this.MyInvocation.BoundParameters["ErrorAction"].ToString();
+            if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
+                ErrorAction = actionPreference;
+            }
+        }
+    }
+
+    protected override void ProcessRecord() {
+        var sqlServer = new DBAClientX.SqlServer {
+            CommandTimeout = QueryTimeout
+        };
+        try {
+            IDictionary<string, object?>? parameters = null;
+            if (Parameters != null) {
+                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
+                    de => de.Key.ToString(),
+                    de => de.Value);
+            }
+
+            var affected = sqlServer.SqlQueryNonQuery(Server, Database, true, Query, parameters);
+            WriteObject(affected);
+        } catch (Exception ex) {
+            WriteWarning($"Invoke-DbaXNonQuery - Error querying SqlServer: {ex.Message}");
+            if (ErrorAction == ActionPreference.Stop) {
+                throw;
+            }
+        }
+    }
+}

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -84,6 +84,51 @@ public class SqlServer : DatabaseClientBase
         return result;
     }
 
+    public virtual int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+    {
+        var connectionString = new SqlConnectionStringBuilder
+        {
+            DataSource = serverOrInstance,
+            InitialCatalog = database,
+            IntegratedSecurity = integratedSecurity,
+            Pooling = true
+        }.ConnectionString;
+
+        SqlConnection? connection = null;
+        bool dispose = false;
+        try
+        {
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new SqlConnection(connectionString);
+                connection.Open();
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
     public virtual async Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
     {
         var connectionString = new SqlConnectionStringBuilder

--- a/DbaClientX.Tests/SqlServerNonQueryTests.cs
+++ b/DbaClientX.Tests/SqlServerNonQueryTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+
+namespace DbaClientX.Tests;
+
+public class SqlServerNonQueryTests
+{
+    private class CaptureParametersSqlServer : DBAClientX.SqlServer
+    {
+        public List<(string Name, object? Value, DbType Type)> Captured { get; } = new();
+
+        protected override int ExecuteNonQuery(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, IDictionary<string, DbType>? parameterTypes = null)
+        {
+            var command = new SqlCommand(query);
+            AddParameters(command, parameters, parameterTypes);
+            foreach (DbParameter p in command.Parameters)
+            {
+                Captured.Add((p.ParameterName, p.Value, p.DbType));
+            }
+            return 1;
+        }
+
+        public override int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+        {
+            IDictionary<string, DbType>? dbTypes = null;
+            if (parameterTypes != null)
+            {
+                dbTypes = new Dictionary<string, DbType>(parameterTypes.Count);
+                foreach (var kv in parameterTypes)
+                {
+                    var p = new SqlParameter { SqlDbType = kv.Value };
+                    dbTypes[kv.Key] = p.DbType;
+                }
+            }
+            return ExecuteNonQuery(null!, null, query, parameters, dbTypes);
+        }
+    }
+
+    [Fact]
+    public void SqlQueryNonQuery_BindsParameters()
+    {
+        var sqlServer = new CaptureParametersSqlServer();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 5,
+            ["@name"] = "test"
+        };
+
+        sqlServer.SqlQueryNonQuery("s", "db", true, "UPDATE t SET c=1 WHERE id=@id", parameters);
+
+        Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && (int)p.Value == 5);
+        Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && (string)p.Value == "test");
+    }
+
+    [Fact]
+    public void SqlQueryNonQuery_PreservesParameterTypes()
+    {
+        var sqlServer = new CaptureParametersSqlServer();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 5,
+            ["@name"] = "test"
+        };
+        var types = new Dictionary<string, SqlDbType>
+        {
+            ["@id"] = SqlDbType.Int,
+            ["@name"] = SqlDbType.NVarChar
+        };
+
+        sqlServer.SqlQueryNonQuery("s", "db", true, "UPDATE t SET name=@name WHERE id=@id", parameters, parameterTypes: types);
+
+        Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && p.Type == DbType.Int32);
+        Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && p.Type == DbType.String);
+    }
+
+    private class FakeTransactionSqlServer : DBAClientX.SqlServer
+    {
+        public bool TransactionStarted { get; private set; }
+
+        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity)
+        {
+            TransactionStarted = true;
+        }
+
+        public override void Commit()
+        {
+            if (!TransactionStarted) throw new DBAClientX.DbaTransactionException("No active transaction.");
+            TransactionStarted = false;
+        }
+
+        public override void Rollback()
+        {
+            if (!TransactionStarted) throw new DBAClientX.DbaTransactionException("No active transaction.");
+            TransactionStarted = false;
+        }
+
+        public override int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+        {
+            if (useTransaction && !TransactionStarted) throw new DBAClientX.DbaTransactionException("Transaction has not been started.");
+            return 0;
+        }
+    }
+
+    [Fact]
+    public void SqlQueryNonQuery_WithTransactionNotStarted_Throws()
+    {
+        var sqlServer = new FakeTransactionSqlServer();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlServer.SqlQueryNonQuery("s", "db", true, "q", useTransaction: true));
+    }
+
+    [Fact]
+    public void SqlQueryNonQuery_UsesTransaction_WhenStarted()
+    {
+        var sqlServer = new FakeTransactionSqlServer();
+        sqlServer.BeginTransaction("s", "db", true);
+        var ex = Record.Exception(() => sqlServer.SqlQueryNonQuery("s", "db", true, "q", useTransaction: true));
+        Assert.Null(ex);
+    }
+}
+

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -12,7 +12,7 @@
         Tags                 = @('Windows', 'MacOS', 'Linux')
         ProjectUri           = 'https://github.com/EvotecIT/DbaClientX'
         #AliasesToExport      = @('')
-        CmdletsToExport      = @('Invoke-DbaXQuery', 'New-DbaXQuery')
+        CmdletsToExport      = @('Invoke-DbaXQuery', 'Invoke-DbaXNonQuery', 'New-DbaXQuery')
     }
     New-ConfigurationManifest @Manifest
 
@@ -89,7 +89,7 @@
         NETBinaryModule                   = 'DbaClientX.PowerShell.dll'
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net472', 'net8.0'
-        NETSearchClass                    = "DbaClientX.PowerShell.CmdletIInvokeDbaXQuery"
+        NETSearchClass                    = "DbaClientX.PowerShell.CmdletIInvokeDbaXQuery", "DbaClientX.PowerShell.CmdletIInvokeDbaXNonQuery"
         DotSourceLibraries                = $true
         RefreshPSD1Only                   = $true
     }

--- a/Module/DbaClientX.psd1
+++ b/Module/DbaClientX.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Invoke-DbaXQuery', 'New-DbaXQuery')
+    CmdletsToExport      = @('Invoke-DbaXQuery', 'Invoke-DbaXNonQuery', 'New-DbaXQuery')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/Examples/Example.InvokeNonQuery.ps1
+++ b/Module/Examples/Example.InvokeNonQuery.ps1
@@ -1,0 +1,1 @@
+Invoke-DbaXNonQuery -Query "CREATE TABLE #Test (Id INT)" -Server "SQL1" -Database "master"

--- a/Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1
@@ -1,0 +1,7 @@
+Import-Module "$PSScriptRoot/../DbaClientX.psd1" -Force
+
+Describe 'Invoke-DbaXNonQuery cmdlet' {
+    It 'is exported' {
+        Get-Command Invoke-DbaXNonQuery | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- add `SqlQueryNonQuery` to run non-query statements and return affected rows
- expose new `Invoke-DbaXNonQuery` PowerShell cmdlet
- include non-query examples and corresponding unit tests

## Testing
- `dotnet build`
- `dotnet test`
- `pwsh Module/DbaClientX.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6891097a85f8832eabc3c4d413ef0908