### PR TITLE
Add descending and raw order options

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -170,6 +170,21 @@ public class Query
         return this;
     }
 
+    public Query OrderByDescending(params string[] columns)
+    {
+        foreach (var column in columns)
+        {
+            _orderBy.Add($"{column} DESC");
+        }
+        return this;
+    }
+
+    public Query OrderByRaw(params string[] expressions)
+    {
+        _orderBy.AddRange(expressions);
+        return this;
+    }
+
     public Query GroupBy(params string[] columns)
     {
         _groupBy.AddRange(columns);
@@ -228,6 +243,7 @@ public class Query
     public string UpdateTable => _updateTable;
     public IReadOnlyList<(string Column, object Value)> SetValues => _set;
     public string DeleteTable => _deleteTable;
+    public IReadOnlyList<string> OrderByExpressions => _orderBy;
     public IReadOnlyList<string> OrderByColumns => _orderBy;
     public IReadOnlyList<string> GroupByColumns => _groupBy;
     public IReadOnlyList<(string Column, string Operator, object Value)> HavingClauses => _having;

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -137,9 +137,9 @@ public class QueryCompiler
             }
         }
 
-        if (query.OrderByColumns.Count > 0)
+        if (query.OrderByExpressions.Count > 0)
         {
-            sb.Append(" ORDER BY ").Append(string.Join(", ", query.OrderByColumns));
+            sb.Append(" ORDER BY ").Append(string.Join(", ", query.OrderByExpressions));
         }
 
         if (query.LimitValue.HasValue && !query.UseTop)

--- a/DbaClientX.Examples/OrderByExample.cs
+++ b/DbaClientX.Examples/OrderByExample.cs
@@ -1,0 +1,15 @@
+using DBAClientX.QueryBuilder;
+
+public static class OrderByExample
+{
+    public static void Run()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .OrderByDescending("age")
+            .OrderByRaw("RAND()");
+
+        Console.WriteLine(QueryBuilder.Compile(query));
+    }
+}

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -25,8 +25,11 @@ public class Program
             case "streamquery":
                 await StreamQueryExample.RunAsync();
                 break;
+            case "orderby":
+                OrderByExample.Run();
+                break;
             default:
-                Console.WriteLine("Available examples: asyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery");
+                Console.WriteLine("Available examples: asyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, orderby");
                 break;
         }
     }

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -106,6 +106,30 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void SelectOrderByDescending()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .OrderByDescending("age");
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users ORDER BY age DESC", sql);
+    }
+
+    [Fact]
+    public void SelectOrderByRaw()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .OrderByRaw("RAND()");
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users ORDER BY RAND()", sql);
+    }
+
+    [Fact]
     public void LimitThenTop_UsesTop()
     {
         var query = new Query()


### PR DESCRIPTION
## Summary
- add `OrderByDescending` and `OrderByRaw` to query builder
- expose order expressions to compiler
- demonstrate and test ordering options

## Testing
- `dotnet build --no-restore`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68910cae3e80832e9be20db31dda2547