### PR TITLE
Add null condition support to query builder

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -90,6 +90,26 @@ public class Query
         return AddCondition(column, op, subQuery, "OR");
     }
 
+    public Query WhereNull(string column)
+    {
+        return AddNullCondition(column);
+    }
+
+    public Query OrWhereNull(string column)
+    {
+        return AddNullCondition(column, "OR");
+    }
+
+    public Query WhereNotNull(string column)
+    {
+        return AddNotNullCondition(column);
+    }
+
+    public Query OrWhereNotNull(string column)
+    {
+        return AddNotNullCondition(column, "OR");
+    }
+
     public Query BeginGroup()
     {
         AddDefaultAndIfRequired();
@@ -113,6 +133,20 @@ public class Query
     {
         AddLogicalOperator(logical);
         _where.Add(new ConditionToken(column, op, value));
+        return this;
+    }
+
+    private Query AddNullCondition(string column, string? logical = null)
+    {
+        AddLogicalOperator(logical);
+        _where.Add(new NullToken(column));
+        return this;
+    }
+
+    private Query AddNotNullCondition(string column, string? logical = null)
+    {
+        AddLogicalOperator(logical);
+        _where.Add(new NotNullToken(column));
         return this;
     }
 
@@ -262,4 +296,8 @@ public sealed record OperatorToken(string Operator) : IWhereToken;
 public sealed record GroupStartToken() : IWhereToken;
 
 public sealed record GroupEndToken() : IWhereToken;
+
+public sealed record NullToken(string Column) : IWhereToken;
+
+public sealed record NotNullToken(string Column) : IWhereToken;
 

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -178,6 +178,12 @@ public class QueryCompiler
                 case GroupEndToken:
                     sb.Append(')');
                     break;
+                case NullToken n:
+                    sb.Append(n.Column).Append(" IS NULL");
+                    break;
+                case NotNullToken nn:
+                    sb.Append(nn.Column).Append(" IS NOT NULL");
+                    break;
             }
         }
     }

--- a/DbaClientX.Examples/NullConditionsExample.cs
+++ b/DbaClientX.Examples/NullConditionsExample.cs
@@ -1,0 +1,15 @@
+using DBAClientX.QueryBuilder;
+
+public static class NullConditionsExample
+{
+    public static void Run()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .WhereNull("deleted_at")
+            .OrWhereNotNull("verified_at");
+
+        Console.WriteLine(QueryBuilder.Compile(query));
+    }
+}

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -31,8 +31,11 @@ public class Program
             case "nonquery":
                 NonQueryExample.Run();
                 break;
+            case "nullconditions":
+                NullConditionsExample.Run();
+                break;
             default:
-                Console.WriteLine("Available examples: asyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery");
+                Console.WriteLine("Available examples: asyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions");
                 break;
         }
     }

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -181,6 +181,43 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void WhereNullCondition()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .WhereNull("deleted_at");
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users WHERE deleted_at IS NULL", sql);
+    }
+
+    [Fact]
+    public void WhereNotNullCondition()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .WhereNotNull("email");
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users WHERE email IS NOT NULL", sql);
+    }
+
+    [Fact]
+    public void OrWhereNullCondition()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .Where("age", ">", 18)
+            .OrWhereNull("deleted_at");
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users WHERE age > 18 OR deleted_at IS NULL", sql);
+    }
+
+    [Fact]
     public void SelectWithoutFrom()
     {
         var query = new Query()


### PR DESCRIPTION
## Summary
- support building `IS NULL` and `IS NOT NULL` predicates with `WhereNull`/`WhereNotNull` and their OR variants
- extend query compiler to handle new null tokens
- cover null-condition helpers with unit tests and example

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689117a1a1fc832e81a81d5fa0e567dc