### PR TITLE
Add stored procedure execution support

### DIFF
--- a/DbaClientX.Examples/StoredProcedureExample.cs
+++ b/DbaClientX.Examples/StoredProcedureExample.cs
@@ -1,0 +1,33 @@
+using DBAClientX;
+using System.Data;
+using System.Collections.Generic;
+
+public static class StoredProcedureExample
+{
+    public static void Run()
+    {
+        var sqlServer = new SqlServer
+        {
+            ReturnType = ReturnType.DataTable,
+        };
+
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@dbname"] = "master"
+        };
+
+        var result = sqlServer.ExecuteStoredProcedure("SQL1", "master", true, "sp_helpdb", parameters);
+
+        if (result is DataTable table)
+        {
+            foreach (DataRow row in table.Rows)
+            {
+                foreach (DataColumn col in table.Columns)
+                {
+                    Console.Write($"{row[col]}\t");
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -1,26 +1,34 @@
 ﻿namespace DBAClientX.PowerShell;
 
-[Cmdlet(VerbsLifecycle.Invoke, "DbaXQuery", DefaultParameterSetName = "Compatibility", SupportsShouldProcess = true)]
+[Cmdlet(VerbsLifecycle.Invoke, "DbaXQuery", DefaultParameterSetName = "Query", SupportsShouldProcess = true)]
 [CmdletBinding()]
 public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
-    [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
+    [Parameter(Mandatory = true, ParameterSetName = "Query")]
+    [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [Alias("DBServer", "SqlInstance", "Instance")]
     public string Server { get; set; }
 
-    [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
+    [Parameter(Mandatory = true, ParameterSetName = "Query")]
+    [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     public string Database { get; set; }
 
-    [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
+    [Parameter(Mandatory = true, ParameterSetName = "Query")]
     public string Query { get; set; }
 
-    [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
+    [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
+    public string StoredProcedure { get; set; }
+
+    [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public int QueryTimeout { get; set; }
 
-    [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
+    [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     [Alias("As")]
     public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
 
-    [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
+    [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public Hashtable Parameters { get; set; }
 
     private ActionPreference ErrorAction;
@@ -58,7 +66,12 @@ public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
                     de => de.Value);
             }
 
-            var result = sqlServer.SqlQuery(Server, Database, true, Query, parameters);
+            object? result;
+            if (!string.IsNullOrEmpty(StoredProcedure)) {
+                result = sqlServer.ExecuteStoredProcedure(Server, Database, true, StoredProcedure, parameters);
+            } else {
+                result = sqlServer.SqlQuery(Server, Database, true, Query, parameters);
+            }
             if (result != null) {
                 if (ReturnType == ReturnType.PSObject) {
                     //var resultConverted = result as DataTable;

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -174,6 +174,28 @@ public class SqlServer : DatabaseClientBase
         }
     }
 
+    private static string BuildStoredProcedureQuery(string procedure, IDictionary<string, object?>? parameters)
+    {
+        if (parameters == null || parameters.Count == 0)
+        {
+            return $"EXEC {procedure}";
+        }
+        var joined = string.Join(", ", parameters.Keys);
+        return $"EXEC {procedure} {joined}";
+    }
+
+    public virtual object? ExecuteStoredProcedure(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+    {
+        var query = BuildStoredProcedureQuery(procedure, parameters);
+        return SqlQuery(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, parameterTypes);
+    }
+
+    public virtual Task<object?> ExecuteStoredProcedureAsync(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+    {
+        var query = BuildStoredProcedureQuery(procedure, parameters);
+        return SqlQueryAsync(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, cancellationToken, parameterTypes);
+    }
+
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
     public virtual IAsyncEnumerable<DataRow> SqlQueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
     {

--- a/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
@@ -1,0 +1,11 @@
+Import-Module "$PSScriptRoot/../DbaClientX.psd1" -Force
+
+describe 'Invoke-DbaXQuery cmdlet' {
+    it 'is exported' {
+        Get-Command Invoke-DbaXQuery | Should -Not -BeNullOrEmpty
+    }
+
+    it 'supports StoredProcedure parameter' {
+        (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'StoredProcedure'
+    }
+}


### PR DESCRIPTION
## Summary
- allow executing stored procedures via `SqlServer` with sync and async APIs
- expose stored procedure execution through `Invoke-DbaXQuery`
- add sample usage and tests

## Testing
- `dotnet test`
- `pwsh Module/DbaClientX.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6891179cdd5c832e921401ca23c2638e