### PR TITLE
Add streaming support to Invoke-DbaXQuery

### DIFF
--- a/Module/Examples/Example.QuerySqlServer.ps1
+++ b/Module/Examples/Example.QuerySqlServer.ps1
@@ -15,3 +15,6 @@ $T3 | Format-Table
 
 $T4 = Invoke-DbaXQuery -Query "SELECT * FROM MSreplication_options" -Server "SQL1" -Database "master" -ReturnType DataTable
 $T4 | Format-Table
+
+$T5 = Invoke-DbaXQuery -Query "SELECT * FROM MSreplication_options" -Server "SQL1" -Database "master" -Stream
+$T5 | Format-Table

--- a/Module/Examples/Example.QuerySqlServerAsync.ps1
+++ b/Module/Examples/Example.QuerySqlServerAsync.ps1
@@ -1,5 +1,5 @@
 Clear-Host
 Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
 
-Invoke-DbaXQuery -Server "SQL1" -Database "master" -Query "SELECT * FROM sys.databases" -ReturnType DataRow |
+Invoke-DbaXQuery -Server "SQL1" -Database "master" -Query "SELECT * FROM sys.databases" -Stream |
     Format-Table

--- a/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
@@ -1,0 +1,47 @@
+Import-Module "$PSScriptRoot/../DbaClientX.psd1" -Force
+
+Describe 'Invoke-DbaXQuery streaming' {
+    BeforeAll {
+        Add-Type -ReferencedAssemblies @('System.Data', 'System.Data.Common', 'System.ComponentModel.TypeConverter') -TypeDefinition @"
+#nullable enable
+using System.Collections.Generic;
+using System.Data;
+using System.Threading.Tasks;
+
+public static class DummyStream
+{
+    public static async IAsyncEnumerable<DataRow> GetRows()
+    {
+        var table = new DataTable();
+        table.Columns.Add("id", typeof(int));
+        var r1 = table.NewRow();
+        r1["id"] = 1;
+        table.Rows.Add(r1);
+        var r2 = table.NewRow();
+        r2["id"] = 2;
+        table.Rows.Add(r2);
+        foreach (DataRow row in table.Rows)
+        {
+            await Task.Yield();
+            yield return row;
+        }
+    }
+}
+"@
+        $script:oldStream = [DBAClientX.PowerShell.CmdletIInvokeDbaXQuery]::StreamGenerator
+        [DBAClientX.PowerShell.CmdletIInvokeDbaXQuery]::StreamGenerator = { [DummyStream]::GetRows() }
+    }
+
+    AfterAll {
+        [DBAClientX.PowerShell.CmdletIInvokeDbaXQuery]::StreamGenerator = $script:oldStream
+    }
+
+    It 'emits streamed rows as PSObjects' {
+        $rows = Invoke-DbaXQuery -Server 's' -Database 'd' -Query 'q' -Stream
+        $rows.Count | Should -Be 2
+        $rows[0].id | Should -Be 1
+        $rows[0] | Should -BeOfType [pscustomobject]
+    }
+}
+
+


### PR DESCRIPTION
## Summary
- add `-Stream` switch to Invoke-DbaXQuery for immediate row emission
- provide streaming example scripts
- add Pester tests covering streaming output

## Testing
- `~/.dotnet/dotnet build DbaClientX.sln`
- `~/.dotnet/dotnet test DbaClientX.sln`
- `pwsh -NoLogo -NoProfile -File Module/DbaClientX.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_689117b70490832e8514dd4a61f0a301