### PR TITLE
Add streaming option to Invoke-DbaXQuery

### DIFF
--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -3,6 +3,7 @@
 [Cmdlet(VerbsLifecycle.Invoke, "DbaXQuery", DefaultParameterSetName = "Query", SupportsShouldProcess = true)]
 [CmdletBinding()]
 public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
+    internal static Func<DBAClientX.SqlServer> SqlServerFactory { get; set; } = () => new DBAClientX.SqlServer();
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [Alias("DBServer", "SqlInstance", "Instance")]
@@ -21,6 +22,9 @@ public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public int QueryTimeout { get; set; }
+
+    [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    public SwitchParameter Stream { get; set; }
 
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
@@ -53,10 +57,9 @@ public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
     /// Process method for PowerShell cmdlet
     /// </summary>
     protected override void ProcessRecord() {
-        var sqlServer = new DBAClientX.SqlServer {
-            ReturnType = ReturnType,
-            CommandTimeout = QueryTimeout
-        };
+        var sqlServer = SqlServerFactory();
+        sqlServer.ReturnType = ReturnType;
+        sqlServer.CommandTimeout = QueryTimeout;
         try {
             IDictionary<string, object?>? parameters = null;
             if (Parameters != null)
@@ -65,6 +68,31 @@ public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
                     de => de.Key.ToString(),
                     de => de.Value);
             }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            if (Stream.IsPresent)
+            {
+                var enumerable = sqlServer.SqlQueryStreamAsync(Server, Database, true, Query, parameters, cancellationToken: CancellationToken.None);
+                var enumerator = enumerable.GetAsyncEnumerator();
+                try
+                {
+                    while (enumerator.MoveNextAsync().AsTask().GetAwaiter().GetResult())
+                    {
+                        WriteObject(DataRowToPSObject(enumerator.Current));
+                    }
+                }
+                finally
+                {
+                    enumerator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                }
+                return;
+            }
+#else
+            if (Stream.IsPresent)
+            {
+                throw new NotSupportedException("Streaming is not supported on this platform.");
+            }
+#endif
 
             object? result;
             if (!string.IsNullOrEmpty(StoredProcedure)) {

--- a/Module/Examples/Example.QuerySqlServerStream.ps1
+++ b/Module/Examples/Example.QuerySqlServerStream.ps1
@@ -1,0 +1,5 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+
+Invoke-DbaXQuery -Query "SELECT * FROM sys.databases" -Server "SQL1" -Database "master" -Stream |
+    Format-Table

--- a/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
@@ -8,4 +8,8 @@ describe 'Invoke-DbaXQuery cmdlet' {
     it 'supports StoredProcedure parameter' {
         (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'StoredProcedure'
     }
+
+    it 'supports Stream parameter' {
+        (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'Stream'
+    }
 }


### PR DESCRIPTION
## Summary
- support streaming rows via new `-Stream` switch in `Invoke-DbaXQuery`
- add example script showing streaming usage
- ensure cmdlet exposes `-Stream` parameter in tests

## Testing
- `dotnet test`
- `pwsh -NoLogo -NoProfile -File Module/DbaClientX.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68911c27f3b4832ea99ba2ef3716a3e6