### PR TITLE
Reuse compiler instance for subqueries

### DIFF
--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -159,7 +159,7 @@ public class QueryCompiler
         return sb.ToString();
     }
 
-    private static void AppendWhereTokens(StringBuilder sb, IReadOnlyList<IWhereToken> tokens)
+    private void AppendWhereTokens(StringBuilder sb, IReadOnlyList<IWhereToken> tokens)
     {
         foreach (var token in tokens)
         {
@@ -188,7 +188,7 @@ public class QueryCompiler
         }
     }
 
-    private static string FormatValue(object value)
+    private string FormatValue(object value)
     {
         return value switch
         {
@@ -200,7 +200,7 @@ public class QueryCompiler
             decimal d => d.ToString(CultureInfo.InvariantCulture),
             double d => d.ToString(CultureInfo.InvariantCulture),
             float f => f.ToString(CultureInfo.InvariantCulture),
-            Query q => "(" + new QueryCompiler().Compile(q) + ")",
+            Query q => "(" + Compile(q) + ")",
             _ => value.ToString()
         };
     }

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -259,6 +259,27 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void NestedSubqueryInWhere()
+    {
+        var inner = new Query()
+            .Select("id")
+            .From("admins");
+
+        var middle = new Query()
+            .Select("id")
+            .From("users")
+            .Where("owner_id", "IN", inner);
+
+        var query = new Query()
+            .Select("*")
+            .From("items")
+            .Where("user_id", "IN", middle);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM items WHERE user_id IN (SELECT id FROM users WHERE owner_id IN (SELECT id FROM admins))", sql);
+    }
+
+    [Fact]
     public void GroupByHaving()
     {
         var query = new Query()


### PR DESCRIPTION
## Summary
- Reuse existing `QueryCompiler` when formatting subqueries
- Add unit test covering nested subquery compilation

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68926a461f38832e8e725f6c8fb1b2f6