### PR TITLE
Add PostgreSQL client and tests

### DIFF
--- a/DbaClientX.Examples/DbaClientX.Examples.csproj
+++ b/DbaClientX.Examples/DbaClientX.Examples.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,6 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
     <ProjectReference Include="..\DbaClientX.SqlServer\DbaClientX.SqlServer.csproj" />
+    <ProjectReference Include="..\DbaClientX.PostgreSql\DbaClientX.PostgreSql.csproj" />
   </ItemGroup>
 
 </Project>

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -10,6 +10,9 @@ public class Program
             case "asyncquery":
                 await QuerySqlServerAsyncExample.RunAsync();
                 break;
+            case "pgasyncquery":
+                await QueryPostgreSqlAsyncExample.RunAsync();
+                break;
             case "nestedquery":
                 NestedQueryExample.Run();
                 break;
@@ -35,7 +38,7 @@ public class Program
                 NullConditionsExample.Run();
                 break;
             default:
-                Console.WriteLine("Available examples: asyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions");
+                Console.WriteLine("Available examples: asyncquery, pgasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions");
                 break;
         }
     }

--- a/DbaClientX.Examples/QueryPostgreSqlAsyncExample.cs
+++ b/DbaClientX.Examples/QueryPostgreSqlAsyncExample.cs
@@ -1,0 +1,29 @@
+using System;
+using DBAClientX;
+using System.Data;
+using System.Threading;
+
+public static class QueryPostgreSqlAsyncExample
+{
+    public static async Task RunAsync()
+    {
+        var pg = new PostgreSql
+        {
+            ReturnType = ReturnType.DataTable,
+        };
+
+        var result = await pg.PgQueryAsync("localhost", "postgres", "user", "password", "SELECT 1", cancellationToken: CancellationToken.None);
+
+        if (result is DataTable table)
+        {
+            foreach (DataRow row in table.Rows)
+            {
+                foreach (DataColumn col in table.Columns)
+                {
+                    Console.Write($"{row[col]}\t");
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
+++ b/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>DbaClientX PostgreSql provider</Description>
+    <AssemblyName>DbaClientX.PostgreSql</AssemblyName>
+    <AssemblyTitle>DbaClientX.PostgreSql</AssemblyTitle>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;net472;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">netstandard2.0;net8.0</TargetFrameworks>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <LangVersion>Latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PackageId>DBAClientX.PostgreSql</PackageId>
+    <PackageProjectUrl>https://github.com/EvotecIT/DBAClientX</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
+    <DelaySign>False</DelaySign>
+    <IsPublishable>True</IsPublishable>
+    <RepositoryUrl>https://github.com/EvotecIT/DBAClientX</RepositoryUrl>
+    <DebugType>portable</DebugType>
+    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryType>git</RepositoryType>
+    <SignAssembly>False</SignAssembly>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NeutralLanguage>en</NeutralLanguage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
+    <PackageReference Include="Npgsql" Version="8.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Collections" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="System.Collections.Concurrent" />
+    <Using Include="System.Threading" />
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Text" />
+    <Using Include="System.IO" />
+    <Using Include="System.Net" />
+  </ItemGroup>
+</Project>

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using Npgsql;
+using NpgsqlTypes;
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+using System.Runtime.CompilerServices;
+#endif
+
+namespace DBAClientX;
+
+/// <summary>
+/// This class is used to connect to PostgreSQL
+/// </summary>
+public class PostgreSql : DatabaseClientBase
+{
+    private readonly object _syncRoot = new();
+    private NpgsqlConnection? _transactionConnection;
+    private NpgsqlTransaction? _transaction;
+    private static readonly ConcurrentDictionary<NpgsqlDbType, DbType> TypeCache = new();
+
+    public bool IsInTransaction => _transaction != null;
+
+    public virtual object? PgQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    {
+        var connectionString = new NpgsqlConnectionStringBuilder
+        {
+            Host = host,
+            Database = database,
+            Username = username,
+            Password = password,
+            Pooling = true
+        }.ConnectionString;
+
+        NpgsqlConnection? connection = null;
+        bool dispose = false;
+        try
+        {
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new NpgsqlConnection(connectionString);
+                connection.Open();
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return ExecuteQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    private static IDictionary<string, DbType>? ConvertParameterTypes(IDictionary<string, NpgsqlDbType>? types)
+    {
+        if (types == null)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, DbType>(types.Count);
+        foreach (var pair in types)
+        {
+            var dbType = TypeCache.GetOrAdd(pair.Value, static s =>
+            {
+                var parameter = new NpgsqlParameter { NpgsqlDbType = s };
+                return parameter.DbType;
+            });
+            result[pair.Key] = dbType;
+        }
+        return result;
+    }
+
+    public virtual int PgQueryNonQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    {
+        var connectionString = new NpgsqlConnectionStringBuilder
+        {
+            Host = host,
+            Database = database,
+            Username = username,
+            Password = password,
+            Pooling = true
+        }.ConnectionString;
+
+        NpgsqlConnection? connection = null;
+        bool dispose = false;
+        try
+        {
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new NpgsqlConnection(connectionString);
+                connection.Open();
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    public virtual async Task<object?> PgQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    {
+        var connectionString = new NpgsqlConnectionStringBuilder
+        {
+            Host = host,
+            Database = database,
+            Username = username,
+            Password = password,
+            Pooling = true
+        }.ConnectionString;
+
+        NpgsqlConnection? connection = null;
+        bool dispose = false;
+        try
+        {
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new NpgsqlConnection(connectionString);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return await ExecuteQueryAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    private static string BuildStoredProcedureQuery(string procedure, IDictionary<string, object?>? parameters)
+    {
+        if (parameters == null || parameters.Count == 0)
+        {
+            return $"CALL {procedure}";
+        }
+        var joined = string.Join(", ", parameters.Keys);
+        return $"CALL {procedure} {joined}";
+    }
+
+    public virtual object? ExecuteStoredProcedure(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    {
+        var query = BuildStoredProcedureQuery(procedure, parameters);
+        return PgQuery(host, database, username, password, query, parameters, useTransaction, parameterTypes);
+    }
+
+    public virtual Task<object?> ExecuteStoredProcedureAsync(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    {
+        var query = BuildStoredProcedureQuery(procedure, parameters);
+        return PgQueryAsync(host, database, username, password, query, parameters, useTransaction, cancellationToken, parameterTypes);
+    }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    public virtual IAsyncEnumerable<DataRow> PgQueryStreamAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    {
+        return Stream();
+
+        async IAsyncEnumerable<DataRow> Stream()
+        {
+            var connectionString = new NpgsqlConnectionStringBuilder
+            {
+                Host = host,
+                Database = database,
+                Username = username,
+                Password = password,
+                Pooling = true
+            }.ConnectionString;
+
+            NpgsqlConnection? connection = null;
+            bool dispose = false;
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new NpgsqlConnection(connectionString);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            try
+            {
+                await foreach (var row in ExecuteQueryStreamAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes).ConfigureAwait(false))
+                {
+                    yield return row;
+                }
+            }
+            finally
+            {
+                if (dispose)
+                {
+                    connection?.Dispose();
+                }
+            }
+        }
+    }
+#endif
+
+    public virtual void BeginTransaction(string host, string database, string username, string password)
+    {
+        if (_transaction != null)
+        {
+            throw new DbaTransactionException("Transaction already started.");
+        }
+
+        var connectionString = new NpgsqlConnectionStringBuilder
+        {
+            Host = host,
+            Database = database,
+            Username = username,
+            Password = password,
+            Pooling = true
+        }.ConnectionString;
+
+        _transactionConnection = new NpgsqlConnection(connectionString);
+        _transactionConnection.Open();
+        _transaction = _transactionConnection.BeginTransaction();
+    }
+
+    public virtual void Commit()
+    {
+        if (_transaction == null)
+        {
+            throw new DbaTransactionException("No active transaction.");
+        }
+        _transaction.Commit();
+        DisposeTransaction();
+    }
+
+    public virtual void Rollback()
+    {
+        if (_transaction == null)
+        {
+            throw new DbaTransactionException("No active transaction.");
+        }
+        _transaction.Rollback();
+        DisposeTransaction();
+    }
+
+    private void DisposeTransaction()
+    {
+        _transaction?.Dispose();
+        _transaction = null;
+        _transactionConnection?.Dispose();
+        _transactionConnection = null;
+    }
+
+    public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string host, string database, string username, string password, CancellationToken cancellationToken = default)
+    {
+        if (queries == null)
+        {
+            throw new ArgumentNullException(nameof(queries));
+        }
+
+        var tasks = queries.Select(q => PgQueryAsync(host, database, username, password, q, null, false, cancellationToken));
+        var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+        return results;
+    }
+}

--- a/DbaClientX.Tests/DbaClientX.Tests.csproj
+++ b/DbaClientX.Tests/DbaClientX.Tests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
     <ProjectReference Include="..\DbaClientX.SqlServer\DbaClientX.SqlServer.csproj" />
     <ProjectReference Include="..\DbaClientX.PowerShell\DbaClientX.PowerShell.csproj" />
+    <ProjectReference Include="..\DbaClientX.PostgreSql\DbaClientX.PostgreSql.csproj" />
   </ItemGroup>
 
 </Project>

--- a/DbaClientX.Tests/PostgreSqlTests.cs
+++ b/DbaClientX.Tests/PostgreSqlTests.cs
@@ -1,0 +1,202 @@
+using System;
+using Npgsql;
+using NpgsqlTypes;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Data;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class PostgreSqlTests
+{
+    [Fact]
+    public async Task PgQueryAsync_InvalidServer_ThrowsDbaQueryExecutionException()
+    {
+        var pg = new DBAClientX.PostgreSql();
+        var ex = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(async () =>
+        {
+            await pg.PgQueryAsync("invalid", "postgres", "user", "pass", "SELECT 1");
+        });
+        Assert.Contains("SELECT 1", ex.Message);
+    }
+
+    private class DelayPostgreSql : DBAClientX.PostgreSql
+    {
+        private readonly TimeSpan _delay;
+
+        public DelayPostgreSql(TimeSpan delay)
+        {
+            _delay = delay;
+        }
+
+        public override async Task<object?> PgQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+        {
+            await Task.Delay(_delay, cancellationToken);
+            return null;
+        }
+    }
+
+    [Fact]
+    public async Task RunQueriesInParallel_ExecutesConcurrently()
+    {
+        var queries = Enumerable.Repeat("SELECT 1", 3).ToArray();
+        var pg = new DelayPostgreSql(TimeSpan.FromMilliseconds(200));
+
+        var sequential = Stopwatch.StartNew();
+        foreach (var query in queries)
+        {
+            await pg.PgQueryAsync("h", "d", "u", "p", query);
+        }
+        sequential.Stop();
+
+        var parallel = Stopwatch.StartNew();
+        await pg.RunQueriesInParallel(queries, "h", "d", "u", "p");
+        parallel.Stop();
+
+        Assert.True(parallel.Elapsed < sequential.Elapsed);
+    }
+
+    [Fact]
+    public async Task PgQueryAsync_CanBeCancelled()
+    {
+        var pg = new DelayPostgreSql(TimeSpan.FromSeconds(5));
+        using var cts = new CancellationTokenSource(100);
+        await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+        {
+            await pg.PgQueryAsync("h", "d", "u", "p", "q", cancellationToken: cts.Token);
+        });
+    }
+
+    [Fact]
+    public async Task RunQueriesInParallel_ForwardsCancellation()
+    {
+        var pg = new DelayPostgreSql(TimeSpan.FromSeconds(5));
+        var queries = new[] { "q1", "q2" };
+        using var cts = new CancellationTokenSource(100);
+        await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+        {
+            await pg.RunQueriesInParallel(queries, "h", "d", "u", "p", cts.Token);
+        });
+    }
+
+    private class CaptureParametersPostgreSql : DBAClientX.PostgreSql
+    {
+        public List<(string Name, object? Value, NpgsqlDbType Type)> Captured { get; } = new();
+
+        protected override void AddParameters(DbCommand command, IDictionary<string, object?>? parameters, IDictionary<string, DbType>? parameterTypes = null)
+        {
+            base.AddParameters(command, parameters, parameterTypes);
+            foreach (DbParameter p in command.Parameters)
+            {
+                if (p is NpgsqlParameter np)
+                {
+                    Captured.Add((np.ParameterName, np.Value, np.NpgsqlDbType));
+                }
+            }
+        }
+
+        public override Task<object?> PgQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+        {
+            var command = new NpgsqlCommand(query);
+            IDictionary<string, DbType>? dbTypes = null;
+            if (parameterTypes != null)
+            {
+                dbTypes = new Dictionary<string, DbType>(parameterTypes.Count);
+                foreach (var kv in parameterTypes)
+                {
+                    var p = new NpgsqlParameter { NpgsqlDbType = kv.Value };
+                    dbTypes[kv.Key] = p.DbType;
+                }
+            }
+            AddParameters(command, parameters, dbTypes);
+            return Task.FromResult<object?>(null);
+        }
+    }
+
+    [Fact]
+    public async Task PgQueryAsync_BindsParameters()
+    {
+        var pg = new CaptureParametersPostgreSql();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 5,
+            ["@name"] = "test"
+        };
+
+        await pg.PgQueryAsync("h", "d", "u", "p", "SELECT 1", parameters);
+
+        Assert.Contains(pg.Captured, p => p.Name == "@id" && (int)p.Value == 5);
+        Assert.Contains(pg.Captured, p => p.Name == "@name" && (string)p.Value == "test");
+    }
+
+    [Fact]
+    public async Task PgQueryAsync_PreservesParameterTypes()
+    {
+        var pg = new CaptureParametersPostgreSql();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 5,
+            ["@name"] = "test"
+        };
+        var types = new Dictionary<string, NpgsqlDbType>
+        {
+            ["@id"] = NpgsqlDbType.Integer,
+            ["@name"] = NpgsqlDbType.Text
+        };
+
+        await pg.PgQueryAsync("h", "d", "u", "p", "SELECT 1", parameters, cancellationToken: CancellationToken.None, parameterTypes: types);
+
+        Assert.Contains(pg.Captured, p => p.Name == "@id" && p.Type == NpgsqlDbType.Integer);
+        Assert.Contains(pg.Captured, p => p.Name == "@name" && p.Type == NpgsqlDbType.Text);
+    }
+
+    private class CaptureStoredProcPostgreSql : DBAClientX.PostgreSql
+    {
+        public string? CapturedQuery;
+        public IDictionary<string, object?>? CapturedParameters;
+
+        public override object? PgQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+        {
+            CapturedQuery = query;
+            CapturedParameters = parameters;
+            return null;
+        }
+
+        public override Task<object?> PgQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+        {
+            CapturedQuery = query;
+            CapturedParameters = parameters;
+            return Task.FromResult<object?>(null);
+        }
+    }
+
+    [Fact]
+    public void ExecuteStoredProcedure_BuildsCallStatement()
+    {
+        var pg = new CaptureStoredProcPostgreSql();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 1,
+            ["@name"] = "n"
+        };
+        pg.ExecuteStoredProcedure("h", "d", "u", "p", "sp_test", parameters);
+        Assert.Equal("CALL sp_test @id, @name", pg.CapturedQuery);
+    }
+
+    [Fact]
+    public async Task ExecuteStoredProcedureAsync_BuildsCallStatement()
+    {
+        var pg = new CaptureStoredProcPostgreSql();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 1
+        };
+        await pg.ExecuteStoredProcedureAsync("h", "d", "u", "p", "sp_test", parameters);
+        Assert.Equal("CALL sp_test @id", pg.CapturedQuery);
+    }
+}

--- a/DbaClientX.sln
+++ b/DbaClientX.sln
@@ -13,20 +13,22 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.Tests", "DbaClie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.Examples", "DbaClientX.Examples\DbaClientX.Examples.csproj", "{F5D7FDFE-8954-4C13-869F-3DDE4D4FDA07}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.PostgreSql", "DbaClientX.PostgreSql\DbaClientX.PostgreSql.csproj", "{541C4466-43B7-4668-A131-397D39613BFC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-                {29FBC065-3146-47BD-8471-194AA95BC2B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {29FBC065-3146-47BD-8471-194AA95BC2B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {29FBC065-3146-47BD-8471-194AA95BC2B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {29FBC065-3146-47BD-8471-194AA95BC2B8}.Release|Any CPU.Build.0 = Release|Any CPU
-                {A0FD77C3-777C-4474-9D56-DACF1B64A7C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-                {A0FD77C3-777C-4474-9D56-DACF1B64A7C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-                {A0FD77C3-777C-4474-9D56-DACF1B64A7C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-                {A0FD77C3-777C-4474-9D56-DACF1B64A7C0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{29FBC065-3146-47BD-8471-194AA95BC2B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{29FBC065-3146-47BD-8471-194AA95BC2B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{29FBC065-3146-47BD-8471-194AA95BC2B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{29FBC065-3146-47BD-8471-194AA95BC2B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0FD77C3-777C-4474-9D56-DACF1B64A7C0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0FD77C3-777C-4474-9D56-DACF1B64A7C0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0FD77C3-777C-4474-9D56-DACF1B64A7C0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0FD77C3-777C-4474-9D56-DACF1B64A7C0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C4CF8029-093D-4F65-B37E-BA85AB4DBF0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C4CF8029-093D-4F65-B37E-BA85AB4DBF0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4CF8029-093D-4F65-B37E-BA85AB4DBF0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -39,6 +41,10 @@ Global
 		{F5D7FDFE-8954-4C13-869F-3DDE4D4FDA07}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F5D7FDFE-8954-4C13-869F-3DDE4D4FDA07}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F5D7FDFE-8954-4C13-869F-3DDE4D4FDA07}.Release|Any CPU.Build.0 = Release|Any CPU
+		{541C4466-43B7-4668-A131-397D39613BFC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{541C4466-43B7-4668-A131-397D39613BFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{541C4466-43B7-4668-A131-397D39613BFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{541C4466-43B7-4668-A131-397D39613BFC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add DbaClientX.PostgreSql project using Npgsql
- expose PostgreSql client with query, stored procedure, transaction and parallel query support
- include PostgreSQL example and unit tests

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test DbaClientX.sln`


------
https://chatgpt.com/codex/tasks/task_e_68926a681fc8832e9790e33490b4f1f4