### PR TITLE
Add parameterized query compilation support

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -329,6 +329,18 @@ public class Query
         }
     }
 
+    public string Compile()
+    {
+        var compiler = new QueryCompiler();
+        return compiler.Compile(this);
+    }
+
+    public (string Sql, IReadOnlyList<object> Parameters) CompileWithParameters()
+    {
+        var compiler = new QueryCompiler();
+        return compiler.CompileWithParameters(this);
+    }
+
     public IReadOnlyList<string> SelectColumns => _select;
     public string Table => _from;
     public (Query Query, string Alias)? FromSubquery => _fromSubquery;

--- a/DbaClientX.Core/QueryBuilder/QueryBuilder.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryBuilder.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace DBAClientX.QueryBuilder;
 
 public static class QueryBuilder
@@ -8,6 +10,12 @@ public static class QueryBuilder
     {
         var compiler = new QueryCompiler();
         return compiler.Compile(query);
+    }
+
+    public static (string Sql, IReadOnlyList<object> Parameters) CompileWithParameters(Query query)
+    {
+        var compiler = new QueryCompiler();
+        return compiler.CompileWithParameters(query);
     }
 }
 

--- a/DbaClientX.Examples/ParameterizedQueryExample.cs
+++ b/DbaClientX.Examples/ParameterizedQueryExample.cs
@@ -1,0 +1,22 @@
+using DBAClientX.QueryBuilder;
+
+public static class ParameterizedQueryExample
+{
+    public static void Run()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .Where("name", "Alice")
+            .Where("age", ">", 30);
+
+        var (sql, parameters) = QueryBuilder.CompileWithParameters(query);
+
+        Console.WriteLine(sql);
+        for (int i = 0; i < parameters.Count; i++)
+        {
+            Console.WriteLine($"@p{i} = {parameters[i]}");
+        }
+    }
+}
+

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -37,8 +37,11 @@ public class Program
             case "nullconditions":
                 NullConditionsExample.Run();
                 break;
+            case "parameterized":
+                ParameterizedQueryExample.Run();
+                break;
             default:
-                Console.WriteLine("Available examples: asyncquery, pgasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions");
+                Console.WriteLine("Available examples: asyncquery, pgasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized");
                 break;
         }
     }

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -399,6 +399,20 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void CompileWithParameters_ReturnsSqlAndParameters()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .Where("id", 1)
+            .Where("name", "Bob");
+
+        var (sql, parameters) = QueryBuilder.CompileWithParameters(query);
+        Assert.Equal("SELECT * FROM users WHERE id = @p0 AND name = @p1", sql);
+        Assert.Equal(new object[] { 1, "Bob" }, parameters);
+    }
+
+    [Fact]
     public void Select_WithNoColumns_Throws()
     {
         var query = new Query();


### PR DESCRIPTION
## Summary
- support compiling queries into SQL with parameter placeholders and return parameter list
- expose helper methods on `Query` and `QueryBuilder` for parameterized compilation
- add example and unit test demonstrating secure parameter usage

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test DbaClientX.sln`


------
https://chatgpt.com/codex/tasks/task_e_68926dff1ac4832eb788ab9aa709b0db