### PR TITLE
Wrap PostgreSQL stored procedure parameters in parentheses

### DIFF
--- a/DbaClientX.Examples/StoredProcedurePostgreSqlExample.cs
+++ b/DbaClientX.Examples/StoredProcedurePostgreSqlExample.cs
@@ -1,0 +1,33 @@
+using DBAClientX;
+using System.Collections.Generic;
+using System.Data;
+
+public static class StoredProcedurePostgreSqlExample
+{
+    public static void Run()
+    {
+        var pg = new PostgreSql
+        {
+            ReturnType = ReturnType.DataTable,
+        };
+
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 1
+        };
+
+        var result = pg.ExecuteStoredProcedure("localhost", "postgres", "user", "password", "sp_test", parameters);
+
+        if (result is DataTable table)
+        {
+            foreach (DataRow row in table.Rows)
+            {
+                foreach (DataColumn col in table.Columns)
+                {
+                    Console.Write($"{row[col]}\t");
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -188,10 +188,10 @@ public class PostgreSql : DatabaseClientBase
     {
         if (parameters == null || parameters.Count == 0)
         {
-            return $"CALL {procedure}";
+            return $"CALL {procedure}()";
         }
         var joined = string.Join(", ", parameters.Keys);
-        return $"CALL {procedure} {joined}";
+        return $"CALL {procedure}({joined})";
     }
 
     public virtual object? ExecuteStoredProcedure(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)

--- a/DbaClientX.Tests/PostgreSqlTests.cs
+++ b/DbaClientX.Tests/PostgreSqlTests.cs
@@ -185,7 +185,7 @@ public class PostgreSqlTests
             ["@name"] = "n"
         };
         pg.ExecuteStoredProcedure("h", "d", "u", "p", "sp_test", parameters);
-        Assert.Equal("CALL sp_test @id, @name", pg.CapturedQuery);
+        Assert.Equal("CALL sp_test(@id, @name)", pg.CapturedQuery);
     }
 
     [Fact]
@@ -197,6 +197,14 @@ public class PostgreSqlTests
             ["@id"] = 1
         };
         await pg.ExecuteStoredProcedureAsync("h", "d", "u", "p", "sp_test", parameters);
-        Assert.Equal("CALL sp_test @id", pg.CapturedQuery);
+        Assert.Equal("CALL sp_test(@id)", pg.CapturedQuery);
+    }
+
+    [Fact]
+    public void ExecuteStoredProcedure_NoParameters_AddsEmptyParentheses()
+    {
+        var pg = new CaptureStoredProcPostgreSql();
+        pg.ExecuteStoredProcedure("h", "d", "u", "p", "sp_test", null);
+        Assert.Equal("CALL sp_test()", pg.CapturedQuery);
     }
 }


### PR DESCRIPTION
## Summary
- ensure stored procedure calls use parentheses around parameter list
- document PostgreSQL stored procedure usage with a new example
- verify generated CALL statements in tests, including no-parameter case

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689330e31d20832eacedf2a69ae4b8c2