### PR TITLE
Add MySQL provider and tests

### DIFF
--- a/DbaClientX.Examples/DbaClientX.Examples.csproj
+++ b/DbaClientX.Examples/DbaClientX.Examples.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
     <ProjectReference Include="..\DbaClientX.SqlServer\DbaClientX.SqlServer.csproj" />
     <ProjectReference Include="..\DbaClientX.PostgreSql\DbaClientX.PostgreSql.csproj" />
+    <ProjectReference Include="..\DbaClientX.MySql\DbaClientX.MySql.csproj" />
   </ItemGroup>
 
 </Project>

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -13,6 +13,9 @@ public class Program
             case "pgasyncquery":
                 await QueryPostgreSqlAsyncExample.RunAsync();
                 break;
+            case "mysqlasyncquery":
+                await QueryMySqlAsyncExample.RunAsync();
+                break;
             case "nestedquery":
                 NestedQueryExample.Run();
                 break;
@@ -41,7 +44,7 @@ public class Program
                 ParameterizedQueryExample.Run();
                 break;
             default:
-                Console.WriteLine("Available examples: asyncquery, pgasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized");
+                Console.WriteLine("Available examples: asyncquery, pgasyncquery, mysqlasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized");
                 break;
         }
     }

--- a/DbaClientX.Examples/QueryMySqlAsyncExample.cs
+++ b/DbaClientX.Examples/QueryMySqlAsyncExample.cs
@@ -1,0 +1,28 @@
+using DBAClientX;
+using System.Data;
+using System.Threading;
+
+public static class QueryMySqlAsyncExample
+{
+    public static async Task RunAsync()
+    {
+        var mySql = new MySql
+        {
+            ReturnType = ReturnType.DataTable,
+        };
+
+        var result = await mySql.MySqlQueryAsync("MYSQL1", "mysql", "user", "password", "SELECT 1", cancellationToken: CancellationToken.None);
+
+        if (result is DataTable table)
+        {
+            foreach (DataRow row in table.Rows)
+            {
+                foreach (DataColumn col in table.Columns)
+                {
+                    Console.Write($"{row[col]}\t");
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/DbaClientX.MySql/DbaClientX.MySql.csproj
+++ b/DbaClientX.MySql/DbaClientX.MySql.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>DbaClientX MySql provider</Description>
+    <AssemblyName>DbaClientX.MySql</AssemblyName>
+    <AssemblyTitle>DbaClientX.MySql</AssemblyTitle>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;net472;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">netstandard2.0;net8.0</TargetFrameworks>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <LangVersion>Latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PackageId>DBAClientX.MySql</PackageId>
+    <PackageProjectUrl>https://github.com/EvotecIT/DBAClientX</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
+    <DelaySign>False</DelaySign>
+    <IsPublishable>True</IsPublishable>
+    <RepositoryUrl>https://github.com/EvotecIT/DBAClientX</RepositoryUrl>
+    <DebugType>portable</DebugType>
+    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryType>git</RepositoryType>
+    <SignAssembly>False</SignAssembly>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NeutralLanguage>en</NeutralLanguage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
+    <PackageReference Include="MySqlConnector" Version="2.4.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Collections" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="System.Collections.Concurrent" />
+    <Using Include="System.Threading" />
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Text" />
+    <Using Include="System.IO" />
+    <Using Include="System.Net" />
+  </ItemGroup>
+</Project>

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using MySqlConnector;
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+using System.Runtime.CompilerServices;
+#endif
+
+namespace DBAClientX;
+
+/// <summary>
+/// This class is used to connect to MySQL
+/// </summary>
+public class MySql : DatabaseClientBase
+{
+    private readonly object _syncRoot = new();
+    private MySqlConnection? _transactionConnection;
+    private MySqlTransaction? _transaction;
+    private static readonly ConcurrentDictionary<MySqlDbType, DbType> TypeCache = new();
+
+    public bool IsInTransaction => _transaction != null;
+
+    public virtual object? MySqlQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    {
+        var connectionString = new MySqlConnectionStringBuilder
+        {
+            Server = host,
+            Database = database,
+            UserID = username,
+            Password = password,
+            Pooling = true
+        }.ConnectionString;
+
+        MySqlConnection? connection = null;
+        bool dispose = false;
+        try
+        {
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new MySqlConnection(connectionString);
+                connection.Open();
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return ExecuteQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    private static IDictionary<string, DbType>? ConvertParameterTypes(IDictionary<string, MySqlDbType>? types)
+    {
+        if (types == null)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, DbType>(types.Count);
+        foreach (var pair in types)
+        {
+            var dbType = TypeCache.GetOrAdd(pair.Value, static s =>
+            {
+                var parameter = new MySqlParameter { MySqlDbType = s };
+                return parameter.DbType;
+            });
+            result[pair.Key] = dbType;
+        }
+        return result;
+    }
+
+    public virtual int MySqlQueryNonQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    {
+        var connectionString = new MySqlConnectionStringBuilder
+        {
+            Server = host,
+            Database = database,
+            UserID = username,
+            Password = password,
+            Pooling = true
+        }.ConnectionString;
+
+        MySqlConnection? connection = null;
+        bool dispose = false;
+        try
+        {
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new MySqlConnection(connectionString);
+                connection.Open();
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    public virtual async Task<object?> MySqlQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    {
+        var connectionString = new MySqlConnectionStringBuilder
+        {
+            Server = host,
+            Database = database,
+            UserID = username,
+            Password = password,
+            Pooling = true
+        }.ConnectionString;
+
+        MySqlConnection? connection = null;
+        bool dispose = false;
+        try
+        {
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new MySqlConnection(connectionString);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return await ExecuteQueryAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    public virtual void BeginTransaction(string host, string database, string username, string password)
+    {
+        if (_transaction != null)
+        {
+            throw new DbaTransactionException("Transaction already started.");
+        }
+
+        var connectionString = new MySqlConnectionStringBuilder
+        {
+            Server = host,
+            Database = database,
+            UserID = username,
+            Password = password,
+            Pooling = true
+        }.ConnectionString;
+
+        _transactionConnection = new MySqlConnection(connectionString);
+        _transactionConnection.Open();
+        _transaction = _transactionConnection.BeginTransaction();
+    }
+
+    public virtual void Commit()
+    {
+        if (_transaction == null)
+        {
+            throw new DbaTransactionException("No active transaction.");
+        }
+        _transaction.Commit();
+        DisposeTransaction();
+    }
+
+    public virtual void Rollback()
+    {
+        if (_transaction == null)
+        {
+            throw new DbaTransactionException("No active transaction.");
+        }
+        _transaction.Rollback();
+        DisposeTransaction();
+    }
+
+    private void DisposeTransaction()
+    {
+        _transaction?.Dispose();
+        _transaction = null;
+        _transactionConnection?.Dispose();
+        _transactionConnection = null;
+    }
+
+    public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string host, string database, string username, string password, CancellationToken cancellationToken = default)
+    {
+        if (queries == null)
+        {
+            throw new ArgumentNullException(nameof(queries));
+        }
+
+        var tasks = queries.Select(q => MySqlQueryAsync(host, database, username, password, q, null, false, cancellationToken));
+        var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+        return results;
+    }
+}

--- a/DbaClientX.Tests/DbaClientX.Tests.csproj
+++ b/DbaClientX.Tests/DbaClientX.Tests.csproj
@@ -26,6 +26,7 @@
     <ProjectReference Include="..\DbaClientX.SqlServer\DbaClientX.SqlServer.csproj" />
     <ProjectReference Include="..\DbaClientX.PowerShell\DbaClientX.PowerShell.csproj" />
     <ProjectReference Include="..\DbaClientX.PostgreSql\DbaClientX.PostgreSql.csproj" />
+    <ProjectReference Include="..\DbaClientX.MySql\DbaClientX.MySql.csproj" />
   </ItemGroup>
 
 </Project>

--- a/DbaClientX.Tests/MySqlTests.cs
+++ b/DbaClientX.Tests/MySqlTests.cs
@@ -1,0 +1,222 @@
+using MySqlConnector;
+using System.Data.Common;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Data;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class MySqlTests
+{
+    [Fact]
+    public async Task MySqlQueryAsync_InvalidServer_ThrowsDbaQueryExecutionException()
+    {
+        var mySql = new DBAClientX.MySql();
+        var ex = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(async () =>
+        {
+            await mySql.MySqlQueryAsync("invalid", "mysql", "user", "pass", "SELECT 1");
+        });
+        Assert.Contains("SELECT 1", ex.Message);
+    }
+
+    private class DelayMySql : DBAClientX.MySql
+    {
+        private readonly TimeSpan _delay;
+
+        public DelayMySql(TimeSpan delay)
+        {
+            _delay = delay;
+        }
+
+        public override async Task<object?> MySqlQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
+        {
+            await Task.Delay(_delay, cancellationToken);
+            return null;
+        }
+    }
+
+    [Fact]
+    public async Task RunQueriesInParallel_ExecutesConcurrently()
+    {
+        var queries = Enumerable.Repeat("SELECT 1", 3).ToArray();
+        var mySql = new DelayMySql(TimeSpan.FromMilliseconds(200));
+
+        var sequential = Stopwatch.StartNew();
+        foreach (var query in queries)
+        {
+            await mySql.MySqlQueryAsync("h", "d", "u", "p", query);
+        }
+        sequential.Stop();
+
+        var parallel = Stopwatch.StartNew();
+        await mySql.RunQueriesInParallel(queries, "h", "d", "u", "p");
+        parallel.Stop();
+
+        Assert.True(parallel.Elapsed < sequential.Elapsed);
+    }
+
+    [Fact]
+    public async Task MySqlQueryAsync_CanBeCancelled()
+    {
+        var mySql = new DelayMySql(TimeSpan.FromSeconds(5));
+        using var cts = new CancellationTokenSource(100);
+        await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+        {
+            await mySql.MySqlQueryAsync("h", "d", "u", "p", "q", cancellationToken: cts.Token);
+        });
+    }
+
+    [Fact]
+    public async Task RunQueriesInParallel_ForwardsCancellation()
+    {
+        var mySql = new DelayMySql(TimeSpan.FromSeconds(5));
+        var queries = new[] { "q1", "q2" };
+        using var cts = new CancellationTokenSource(100);
+        await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+        {
+            await mySql.RunQueriesInParallel(queries, "h", "d", "u", "p", cts.Token);
+        });
+    }
+
+    private class CaptureParametersMySql : DBAClientX.MySql
+    {
+        public List<(string Name, object? Value, MySqlDbType Type)> Captured { get; } = new();
+
+        protected override void AddParameters(DbCommand command, IDictionary<string, object?>? parameters, IDictionary<string, DbType>? parameterTypes = null)
+        {
+            base.AddParameters(command, parameters, parameterTypes);
+            foreach (DbParameter p in command.Parameters)
+            {
+                if (p is MySqlParameter mp)
+                {
+                    Captured.Add((mp.ParameterName, mp.Value, mp.MySqlDbType));
+                }
+            }
+        }
+
+        public override Task<object?> MySqlQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
+        {
+            var command = new MySqlCommand(query);
+            IDictionary<string, DbType>? dbTypes = null;
+            if (parameterTypes != null)
+            {
+                dbTypes = new Dictionary<string, DbType>(parameterTypes.Count);
+                foreach (var kv in parameterTypes)
+                {
+                    var p = new MySqlParameter { MySqlDbType = kv.Value };
+                    dbTypes[kv.Key] = p.DbType;
+                }
+            }
+            AddParameters(command, parameters, dbTypes);
+            return Task.FromResult<object?>(null);
+        }
+    }
+
+    [Fact]
+    public async Task MySqlQueryAsync_BindsParameters()
+    {
+        var mySql = new CaptureParametersMySql();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 5,
+            ["@name"] = "test"
+        };
+
+        await mySql.MySqlQueryAsync("h", "d", "u", "p", "SELECT 1", parameters);
+
+        Assert.Contains(mySql.Captured, p => p.Name == "@id" && (int)p.Value == 5);
+        Assert.Contains(mySql.Captured, p => p.Name == "@name" && (string)p.Value == "test");
+    }
+
+    [Fact]
+    public async Task MySqlQueryAsync_PreservesParameterTypes()
+    {
+        var mySql = new CaptureParametersMySql();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 5,
+            ["@name"] = "test"
+        };
+        var types = new Dictionary<string, MySqlDbType>
+        {
+            ["@id"] = MySqlDbType.Int32,
+            ["@name"] = MySqlDbType.VarChar
+        };
+
+        await mySql.MySqlQueryAsync("h", "d", "u", "p", "SELECT 1", parameters, cancellationToken: CancellationToken.None, parameterTypes: types);
+
+        Assert.Contains(mySql.Captured, p => p.Name == "@id" && p.Type == MySqlDbType.Int32);
+        Assert.Contains(mySql.Captured, p => p.Name == "@name" && p.Type == MySqlDbType.VarChar);
+    }
+
+    private class FakeTransactionMySql : DBAClientX.MySql
+    {
+        public bool TransactionStarted { get; private set; }
+
+        public override void BeginTransaction(string host, string database, string username, string password)
+        {
+            TransactionStarted = true;
+        }
+
+        public override void Commit()
+        {
+            if (!TransactionStarted) throw new DBAClientX.DbaTransactionException("No active transaction.");
+            TransactionStarted = false;
+        }
+
+        public override void Rollback()
+        {
+            if (!TransactionStarted) throw new DBAClientX.DbaTransactionException("No active transaction.");
+            TransactionStarted = false;
+        }
+
+        public override object? MySqlQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
+        {
+            if (useTransaction && !TransactionStarted) throw new DBAClientX.DbaTransactionException("Transaction has not been started.");
+            return null;
+        }
+
+        public override Task<object?> MySqlQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
+        {
+            return Task.FromResult<object?>(MySqlQuery(host, database, username, password, query, parameters, useTransaction));
+        }
+    }
+
+    [Fact]
+    public void MySqlQuery_WithTransactionNotStarted_Throws()
+    {
+        var mySql = new FakeTransactionMySql();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => mySql.MySqlQuery("h", "d", "u", "p", "q", null, true));
+    }
+
+    [Fact]
+    public void Commit_EndsTransaction()
+    {
+        var mySql = new FakeTransactionMySql();
+        mySql.BeginTransaction("h", "d", "u", "p");
+        mySql.Commit();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => mySql.MySqlQuery("h", "d", "u", "p", "q", null, true));
+    }
+
+    [Fact]
+    public void Rollback_EndsTransaction()
+    {
+        var mySql = new FakeTransactionMySql();
+        mySql.BeginTransaction("h", "d", "u", "p");
+        mySql.Rollback();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => mySql.MySqlQuery("h", "d", "u", "p", "q", null, true));
+    }
+
+    [Fact]
+    public void MySqlQuery_UsesTransaction_WhenStarted()
+    {
+        var mySql = new FakeTransactionMySql();
+        mySql.BeginTransaction("h", "d", "u", "p");
+        var ex = Record.Exception(() => mySql.MySqlQuery("h", "d", "u", "p", "q", null, true));
+        Assert.Null(ex);
+    }
+}

--- a/DbaClientX.sln
+++ b/DbaClientX.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.Examples", "DbaC
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.PostgreSql", "DbaClientX.PostgreSql\DbaClientX.PostgreSql.csproj", "{541C4466-43B7-4668-A131-397D39613BFC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.MySql", "DbaClientX.MySql\DbaClientX.MySql.csproj", "{A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{541C4466-43B7-4668-A131-397D39613BFC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{541C4466-43B7-4668-A131-397D39613BFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{541C4466-43B7-4668-A131-397D39613BFC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add new MySQL provider project with basic query and transaction support
- include example usage and wire into example runner
- test MySQL provider for queries, parameter binding, and transaction handling

## Testing
- `dotnet build --no-restore`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689330f4a5dc832e8cb429440ab1eb99