### PR TITLE
Add IN and BETWEEN query support to QueryBuilder

### DIFF
--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -196,6 +196,42 @@ public class QueryCompiler
                 case NotNullToken nn:
                     sb.Append(nn.Column).Append(" IS NOT NULL");
                     break;
+                case InToken it:
+                    sb.Append(it.Column).Append(" IN (");
+                    for (int i = 0; i < it.Values.Count; i++)
+                    {
+                        if (i > 0)
+                        {
+                            sb.Append(", ");
+                        }
+                        AppendValue(sb, it.Values[i], parameters);
+                    }
+                    sb.Append(')');
+                    break;
+                case NotInToken nit:
+                    sb.Append(nit.Column).Append(" NOT IN (");
+                    for (int i = 0; i < nit.Values.Count; i++)
+                    {
+                        if (i > 0)
+                        {
+                            sb.Append(", ");
+                        }
+                        AppendValue(sb, nit.Values[i], parameters);
+                    }
+                    sb.Append(')');
+                    break;
+                case BetweenToken bt:
+                    sb.Append(bt.Column).Append(" BETWEEN ");
+                    AppendValue(sb, bt.Start, parameters);
+                    sb.Append(" AND ");
+                    AppendValue(sb, bt.End, parameters);
+                    break;
+                case NotBetweenToken nbt:
+                    sb.Append(nbt.Column).Append(" NOT BETWEEN ");
+                    AppendValue(sb, nbt.Start, parameters);
+                    sb.Append(" AND ");
+                    AppendValue(sb, nbt.End, parameters);
+                    break;
             }
         }
     }

--- a/DbaClientX.Examples/InAndBetweenExample.cs
+++ b/DbaClientX.Examples/InAndBetweenExample.cs
@@ -1,0 +1,15 @@
+using DBAClientX.QueryBuilder;
+
+public static class InAndBetweenExample
+{
+    public static void Run()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .WhereIn("id", 1, 2, 3)
+            .OrWhereBetween("age", 18, 30);
+
+        Console.WriteLine(QueryBuilder.Compile(query));
+    }
+}

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -218,6 +218,80 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void WhereInCondition()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .WhereIn("id", 1, 2, 3);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users WHERE id IN (1, 2, 3)", sql);
+    }
+
+    [Fact]
+    public void OrWhereInCondition()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .Where("age", ">", 18)
+            .OrWhereIn("id", 1, 2);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users WHERE age > 18 OR id IN (1, 2)", sql);
+    }
+
+    [Fact]
+    public void WhereNotInCondition()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .WhereNotIn("id", 1, 2);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users WHERE id NOT IN (1, 2)", sql);
+    }
+
+    [Fact]
+    public void WhereBetweenCondition()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .WhereBetween("age", 18, 30);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users WHERE age BETWEEN 18 AND 30", sql);
+    }
+
+    [Fact]
+    public void OrWhereBetweenCondition()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .Where("status", "=", "active")
+            .OrWhereBetween("age", 18, 30);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users WHERE status = 'active' OR age BETWEEN 18 AND 30", sql);
+    }
+
+    [Fact]
+    public void WhereNotBetweenCondition()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .WhereNotBetween("age", 18, 30);
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users WHERE age NOT BETWEEN 18 AND 30", sql);
+    }
+
+    [Fact]
     public void SelectWithoutFrom()
     {
         var query = new Query()


### PR DESCRIPTION
## Summary
- implement `WhereIn`/`WhereBetween` with NOT and OR variants
- extend query compiler for IN and BETWEEN token types
- add unit tests and examples for new clause support

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68933e8faf7c832e9b333f84ac8f364b