### PR TITLE
Add query set operations

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -22,6 +22,7 @@ public class Query
     private int? _limit;
     private int? _offset;
     private bool _useTop;
+    private readonly List<(string Type, Query Query)> _compoundQueries = new();
 
     public Query Select(params string[] columns)
     {
@@ -408,6 +409,36 @@ public class Query
         return this;
     }
 
+    public Query Union(Query query)
+    {
+        if (query == null)
+        {
+            throw new ArgumentException("Query cannot be null.", nameof(query));
+        }
+        _compoundQueries.Add(("UNION", query));
+        return this;
+    }
+
+    public Query UnionAll(Query query)
+    {
+        if (query == null)
+        {
+            throw new ArgumentException("Query cannot be null.", nameof(query));
+        }
+        _compoundQueries.Add(("UNION ALL", query));
+        return this;
+    }
+
+    public Query Intersect(Query query)
+    {
+        if (query == null)
+        {
+            throw new ArgumentException("Query cannot be null.", nameof(query));
+        }
+        _compoundQueries.Add(("INTERSECT", query));
+        return this;
+    }
+
     public Query Values(params object[] values)
     {
         _values.AddRange(values);
@@ -462,6 +493,7 @@ public class Query
     public IReadOnlyList<string> GroupByColumns => _groupBy;
     public IReadOnlyList<(string Column, string Operator, object Value)> HavingClauses => _having;
     public IReadOnlyList<(string Type, string Table, string Condition)> Joins => _joins;
+    public IReadOnlyList<(string Type, Query Query)> CompoundQueries => _compoundQueries;
     public int? LimitValue => _limit;
     public int? OffsetValue => _offset;
     public bool UseTop => _useTop;

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -167,6 +167,13 @@ public class QueryCompiler
         {
             sb.Append(" OFFSET ").Append(query.OffsetValue.Value);
         }
+        if (query.CompoundQueries.Count > 0)
+        {
+            foreach (var (type, q) in query.CompoundQueries)
+            {
+                sb.Append(' ').Append(type).Append(' ').Append(CompileInternal(q, parameters));
+            }
+        }
 
         return sb.ToString();
     }

--- a/DbaClientX.Examples/UnionExample.cs
+++ b/DbaClientX.Examples/UnionExample.cs
@@ -1,0 +1,14 @@
+using DBAClientX.QueryBuilder;
+
+public static class UnionExample
+{
+    public static void Run()
+    {
+        var query = new Query()
+            .Select("id")
+            .From("users1")
+            .UnionAll(new Query().Select("id").From("users2"));
+
+        Console.WriteLine(QueryBuilder.Compile(query));
+    }
+}

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -487,6 +487,42 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void UnionQueries()
+    {
+        var query = new Query()
+            .Select("id")
+            .From("users1")
+            .Union(new Query().Select("id").From("users2"));
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT id FROM users1 UNION SELECT id FROM users2", sql);
+    }
+
+    [Fact]
+    public void UnionAllQueries()
+    {
+        var query = new Query()
+            .Select("id")
+            .From("users1")
+            .UnionAll(new Query().Select("id").From("users2"));
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT id FROM users1 UNION ALL SELECT id FROM users2", sql);
+    }
+
+    [Fact]
+    public void IntersectQueries()
+    {
+        var query = new Query()
+            .Select("id")
+            .From("users1")
+            .Intersect(new Query().Select("id").From("users2"));
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT id FROM users1 INTERSECT SELECT id FROM users2", sql);
+    }
+
+    [Fact]
     public void Select_WithNoColumns_Throws()
     {
         var query = new Query();


### PR DESCRIPTION
## Summary
- allow combining queries with UNION, UNION ALL, and INTERSECT
- compile compound queries correctly
- cover set operations with unit tests and example

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68935b2f42d8832e9092e33f058b31c7