### PR TITLE
Add credential parameters to Invoke-DbaX cmdlets

### DIFF
--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -24,15 +24,21 @@ public class SqlServer : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public virtual object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+    public virtual object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
-        var connectionString = new SqlConnectionStringBuilder
+        var connectionStringBuilder = new SqlConnectionStringBuilder
         {
             DataSource = serverOrInstance,
             InitialCatalog = database,
             IntegratedSecurity = integratedSecurity,
             Pooling = true
-        }.ConnectionString;
+        };
+        if (!integratedSecurity)
+        {
+            connectionStringBuilder.UserID = username;
+            connectionStringBuilder.Password = password;
+        }
+        var connectionString = connectionStringBuilder.ConnectionString;
 
         SqlConnection? connection = null;
         bool dispose = false;
@@ -89,15 +95,21 @@ public class SqlServer : DatabaseClientBase
         return result;
     }
 
-    public virtual int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+    public virtual int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
-        var connectionString = new SqlConnectionStringBuilder
+        var connectionStringBuilder = new SqlConnectionStringBuilder
         {
             DataSource = serverOrInstance,
             InitialCatalog = database,
             IntegratedSecurity = integratedSecurity,
             Pooling = true
-        }.ConnectionString;
+        };
+        if (!integratedSecurity)
+        {
+            connectionStringBuilder.UserID = username;
+            connectionStringBuilder.Password = password;
+        }
+        var connectionString = connectionStringBuilder.ConnectionString;
 
         SqlConnection? connection = null;
         bool dispose = false;
@@ -134,15 +146,21 @@ public class SqlServer : DatabaseClientBase
         }
     }
 
-    public virtual async Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+    public virtual async Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
-        var connectionString = new SqlConnectionStringBuilder
+        var connectionStringBuilder = new SqlConnectionStringBuilder
         {
             DataSource = serverOrInstance,
             InitialCatalog = database,
             IntegratedSecurity = integratedSecurity,
             Pooling = true
-        }.ConnectionString;
+        };
+        if (!integratedSecurity)
+        {
+            connectionStringBuilder.UserID = username;
+            connectionStringBuilder.Password = password;
+        }
+        var connectionString = connectionStringBuilder.ConnectionString;
 
         SqlConnection? connection = null;
         bool dispose = false;
@@ -189,32 +207,38 @@ public class SqlServer : DatabaseClientBase
         return $"EXEC {procedure} {joined}";
     }
 
-    public virtual object? ExecuteStoredProcedure(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+    public virtual object? ExecuteStoredProcedure(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
         var query = BuildStoredProcedureQuery(procedure, parameters);
-        return SqlQuery(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, parameterTypes);
+        return SqlQuery(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, parameterTypes, username, password);
     }
 
-    public virtual Task<object?> ExecuteStoredProcedureAsync(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+    public virtual Task<object?> ExecuteStoredProcedureAsync(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
         var query = BuildStoredProcedureQuery(procedure, parameters);
-        return SqlQueryAsync(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, cancellationToken, parameterTypes);
+        return SqlQueryAsync(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, cancellationToken, parameterTypes, username, password);
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-    public virtual IAsyncEnumerable<DataRow> SqlQueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+    public virtual IAsyncEnumerable<DataRow> SqlQueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
         return Stream();
 
         async IAsyncEnumerable<DataRow> Stream()
         {
-            var connectionString = new SqlConnectionStringBuilder
+            var connectionStringBuilder = new SqlConnectionStringBuilder
             {
                 DataSource = serverOrInstance,
                 InitialCatalog = database,
                 IntegratedSecurity = integratedSecurity,
                 Pooling = true
-            }.ConnectionString;
+            };
+            if (!integratedSecurity)
+            {
+                connectionStringBuilder.UserID = username;
+                connectionStringBuilder.Password = password;
+            }
+            var connectionString = connectionStringBuilder.ConnectionString;
 
             SqlConnection? connection = null;
             bool dispose = false;
@@ -253,40 +277,52 @@ public class SqlServer : DatabaseClientBase
 #endif
 
 
-    public virtual void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity)
+    public virtual void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null)
     {
         if (_transaction != null)
         {
             throw new DbaTransactionException("Transaction already started.");
         }
 
-        var connectionString = new SqlConnectionStringBuilder
+        var connectionStringBuilder = new SqlConnectionStringBuilder
         {
             DataSource = serverOrInstance,
             InitialCatalog = database,
             IntegratedSecurity = integratedSecurity,
             Pooling = true
-        }.ConnectionString;
+        };
+        if (!integratedSecurity)
+        {
+            connectionStringBuilder.UserID = username;
+            connectionStringBuilder.Password = password;
+        }
+        var connectionString = connectionStringBuilder.ConnectionString;
 
         _transactionConnection = new SqlConnection(connectionString);
         _transactionConnection.Open();
         _transaction = _transactionConnection.BeginTransaction();
     }
 
-    public virtual async Task BeginTransactionAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default)
+    public virtual async Task BeginTransactionAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null)
     {
         if (_transaction != null)
         {
             throw new DbaTransactionException("Transaction already started.");
         }
 
-        var connectionString = new SqlConnectionStringBuilder
+        var connectionStringBuilder = new SqlConnectionStringBuilder
         {
             DataSource = serverOrInstance,
             InitialCatalog = database,
             IntegratedSecurity = integratedSecurity,
             Pooling = true
-        }.ConnectionString;
+        };
+        if (!integratedSecurity)
+        {
+            connectionStringBuilder.UserID = username;
+            connectionStringBuilder.Password = password;
+        }
+        var connectionString = connectionStringBuilder.ConnectionString;
 
         _transactionConnection = new SqlConnection(connectionString);
         await _transactionConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
@@ -353,14 +389,14 @@ public class SqlServer : DatabaseClientBase
         _transactionConnection = null;
     }
 
-    public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null)
     {
         if (queries == null)
         {
             throw new ArgumentNullException(nameof(queries));
         }
 
-        var tasks = queries.Select(q => SqlQueryAsync(serverOrInstance, database, integratedSecurity, q, null, false, cancellationToken));
+        var tasks = queries.Select(q => SqlQueryAsync(serverOrInstance, database, integratedSecurity, q, null, false, cancellationToken, username: username, password: password));
         var results = await Task.WhenAll(tasks).ConfigureAwait(false);
         return results;
     }

--- a/DbaClientX.Tests/ParallelQueriesTests.cs
+++ b/DbaClientX.Tests/ParallelQueriesTests.cs
@@ -17,7 +17,7 @@ public class ParallelQueriesTests
             _responses = responses;
         }
 
-        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             _responses.TryGetValue(query, out var result);
             return Task.FromResult(result);

--- a/DbaClientX.Tests/SqlQueryStreamTests.cs
+++ b/DbaClientX.Tests/SqlQueryStreamTests.cs
@@ -30,7 +30,7 @@ public class SqlQueryStreamTests
             _rows = table.Rows.Cast<DataRow>().ToList();
         }
 
-        public override async IAsyncEnumerable<DataRow> SqlQueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override async IAsyncEnumerable<DataRow> SqlQueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             foreach (var row in _rows)
             {

--- a/DbaClientX.Tests/SqlServerNonQueryTests.cs
+++ b/DbaClientX.Tests/SqlServerNonQueryTests.cs
@@ -22,7 +22,7 @@ public class SqlServerNonQueryTests
             return 1;
         }
 
-        public override int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             IDictionary<string, DbType>? dbTypes = null;
             if (parameterTypes != null)
@@ -79,7 +79,7 @@ public class SqlServerNonQueryTests
     {
         public bool TransactionStarted { get; private set; }
 
-        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity)
+        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null)
         {
             TransactionStarted = true;
         }
@@ -96,7 +96,7 @@ public class SqlServerNonQueryTests
             TransactionStarted = false;
         }
 
-        public override int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             if (useTransaction && !TransactionStarted) throw new DBAClientX.DbaTransactionException("Transaction has not been started.");
             return 0;

--- a/DbaClientX.Tests/SqlServerTests.cs
+++ b/DbaClientX.Tests/SqlServerTests.cs
@@ -33,7 +33,7 @@ public class SqlServerTests
             _delay = delay;
         }
 
-        public override async Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override async Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             await Task.Delay(_delay, cancellationToken);
             return null;
@@ -99,7 +99,7 @@ public class SqlServerTests
             }
         }
 
-        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             var command = new SqlCommand(query);
             IDictionary<string, DbType>? dbTypes = null;
@@ -159,14 +159,14 @@ public class SqlServerTests
         public string? CapturedQuery;
         public IDictionary<string, object?>? CapturedParameters;
 
-        public override object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             CapturedQuery = query;
             CapturedParameters = parameters;
             return null;
         }
 
-        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             CapturedQuery = query;
             CapturedParameters = parameters;
@@ -203,7 +203,7 @@ public class SqlServerTests
     {
         public bool TransactionStarted { get; private set; }
 
-        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity)
+        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null)
         {
             TransactionStarted = true;
         }
@@ -220,15 +220,15 @@ public class SqlServerTests
             TransactionStarted = false;
         }
 
-        public override object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             if (useTransaction && !TransactionStarted) throw new DBAClientX.DbaTransactionException("Transaction has not been started.");
             return null;
         }
 
-        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
-            return Task.FromResult<object?>(SqlQuery(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction));
+            return Task.FromResult<object?>(SqlQuery(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, parameterTypes, username, password));
         }
     }
 

--- a/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
@@ -46,7 +46,7 @@ public class SqlServerTransactionAsyncTests
         public FakeSqlConnection? Connection { get; private set; }
         public FakeSqlTransaction? Transaction { get; private set; }
 
-        public override async Task BeginTransactionAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default)
+        public override async Task BeginTransactionAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null)
         {
             Connection = new FakeSqlConnection();
             Transaction = await Connection.BeginTransactionAsync(cancellationToken);
@@ -72,7 +72,7 @@ public class SqlServerTransactionAsyncTests
             Transaction = null;
         }
 
-        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             if (useTransaction && Transaction == null)
             {

--- a/DbaClientX.Tests/SqlServerTransactionTests.cs
+++ b/DbaClientX.Tests/SqlServerTransactionTests.cs
@@ -35,7 +35,7 @@ public class SqlServerTransactionTests
         public FakeSqlConnection? Connection { get; private set; }
         public FakeSqlTransaction? Transaction { get; private set; }
 
-        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity)
+        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null)
         {
             Connection = new FakeSqlConnection();
             Transaction = Connection.BeginTransaction();
@@ -61,7 +61,7 @@ public class SqlServerTransactionTests
             Transaction = null;
         }
 
-        public override object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null)
+        public override object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             if (useTransaction && Transaction == null)
             {

--- a/Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1
@@ -4,4 +4,37 @@ Describe 'Invoke-DbaXNonQuery cmdlet' {
     It 'is exported' {
         Get-Command Invoke-DbaXNonQuery | Should -Not -BeNullOrEmpty
     }
+
+    It 'supports Username and Password parameters' {
+        (Get-Command Invoke-DbaXNonQuery).Parameters.Keys | Should -Contain 'Username'
+        (Get-Command Invoke-DbaXNonQuery).Parameters.Keys | Should -Contain 'Password'
+    }
+
+    It 'passes credentials to provider when supplied' {
+        class TestSqlServer : DBAClientX.SqlServer {
+            static [TestSqlServer] $Last
+            [bool] $Integrated
+            [string] $User
+            [string] $Pass
+            TestSqlServer () { [TestSqlServer]::Last = $this }
+            [int] SqlQueryNonQuery([string]$serverOrInstance, [string]$database, [bool]$integratedSecurity, [string]$query, [System.Collections.Generic.IDictionary[[string],[object]]] $parameters = $null, [bool]$useTransaction = $false, [System.Collections.Generic.IDictionary[[string],[System.Data.SqlDbType]]] $parameterTypes = $null, [string]$username = $null, [string]$password = $null) {
+                $this.Integrated = $integratedSecurity
+                $this.User = $username
+                $this.Pass = $password
+                return 0
+            }
+        }
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletIInvokeDbaXNonQuery].GetProperty('SqlServerFactory',$binding)
+        $orig = $prop.GetValue($null)
+        $prop.SetValue($null, [System.Func[DBAClientX.SqlServer]]{ [TestSqlServer]::new() })
+        try {
+            Invoke-DbaXNonQuery -Server s -Database db -Query 'Q' -Username u -Password p | Out-Null
+            [TestSqlServer]::Last.Integrated | Should -BeFalse
+            [TestSqlServer]::Last.User | Should -Be 'u'
+            [TestSqlServer]::Last.Pass | Should -Be 'p'
+        } finally {
+            $prop.SetValue($null, $orig)
+        }
+    }
 }

--- a/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
@@ -12,4 +12,37 @@ describe 'Invoke-DbaXQuery cmdlet' {
     it 'supports Stream parameter' {
         (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'Stream'
     }
+
+    it 'supports Username and Password parameters' {
+        (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'Username'
+        (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'Password'
+    }
+
+    it 'passes credentials to provider when supplied' {
+        class TestSqlServer : DBAClientX.SqlServer {
+            static [TestSqlServer] $Last
+            [bool] $Integrated
+            [string] $User
+            [string] $Pass
+            TestSqlServer () { [TestSqlServer]::Last = $this }
+            [object] SqlQuery([string]$serverOrInstance, [string]$database, [bool]$integratedSecurity, [string]$query, [System.Collections.Generic.IDictionary[[string],[object]]] $parameters = $null, [bool]$useTransaction = $false, [System.Collections.Generic.IDictionary[[string],[System.Data.SqlDbType]]] $parameterTypes = $null, [string]$username = $null, [string]$password = $null) {
+                $this.Integrated = $integratedSecurity
+                $this.User = $username
+                $this.Pass = $password
+                return $null
+            }
+        }
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletIInvokeDbaXQuery].GetProperty('SqlServerFactory',$binding)
+        $orig = $prop.GetValue($null)
+        $prop.SetValue($null, [System.Func[DBAClientX.SqlServer]]{ [TestSqlServer]::new() })
+        try {
+            Invoke-DbaXQuery -Server s -Database db -Query 'SELECT 1' -Username u -Password p | Out-Null
+            [TestSqlServer]::Last.Integrated | Should -BeFalse
+            [TestSqlServer]::Last.User | Should -Be 'u'
+            [TestSqlServer]::Last.Pass | Should -Be 'p'
+        } finally {
+            $prop.SetValue($null, $orig)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- allow Invoke-DbaXQuery/Invoke-DbaXNonQuery to accept SQL authentication credentials
- pass credentials through SqlServer provider with integrated security disabled
- test credential handling in both cmdlets

## Testing
- `dotnet build`
- `pwsh -NoLogo -NoProfile Module/DbaClientX.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68935b36ef20832ead14fc5c1499036b