### PR TITLE
feat: add ALC support

### DIFF
--- a/DbaClientX.PowerShell/OnImportAndRemove.cs
+++ b/DbaClientX.PowerShell/OnImportAndRemove.cs
@@ -2,18 +2,31 @@ using System;
 using System.IO;
 using System.Management.Automation;
 using System.Reflection;
+#if NET5_0_OR_GREATER
+using System.Runtime.Loader;
+#endif
 
 public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemblyCleanup {
     public void OnImport() {
         if (IsNetFramework()) {
             AppDomain.CurrentDomain.AssemblyResolve += MyResolveEventHandler;
         }
+#if NET5_0_OR_GREATER
+        else {
+            AssemblyLoadContext.Default.Resolving += ResolveAlc;
+        }
+#endif
     }
 
     public void OnRemove(PSModuleInfo module) {
         if (IsNetFramework()) {
             AppDomain.CurrentDomain.AssemblyResolve -= MyResolveEventHandler;
         }
+#if NET5_0_OR_GREATER
+        else {
+            AssemblyLoadContext.Default.Resolving -= ResolveAlc;
+        }
+#endif
     }
 
     private static Assembly MyResolveEventHandler(object sender, ResolveEventArgs args) {
@@ -33,6 +46,53 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         }
         return null!;
     }
+
+#if NET5_0_OR_GREATER
+    private static readonly string _assemblyDir = Path.GetDirectoryName(
+        typeof(OnModuleImportAndRemove).Assembly.Location)!;
+
+    private static readonly ModuleLoadContext _alc = new ModuleLoadContext(_assemblyDir);
+
+    public static AssemblyLoadContext LoadContext => _alc;
+
+    private static Assembly? ResolveAlc(AssemblyLoadContext defaultAlc, AssemblyName assemblyToResolve) {
+        string asmPath = Path.Join(_assemblyDir, $"{assemblyToResolve.Name}.dll");
+        if (IsSatisfyingAssembly(assemblyToResolve, asmPath)) {
+            return _alc.LoadFromAssemblyName(assemblyToResolve);
+        }
+
+        return null;
+    }
+
+    private static bool IsSatisfyingAssembly(AssemblyName requiredAssemblyName, string assemblyPath) {
+        if (requiredAssemblyName.Name == "DBAClientX.PowerShell" || !File.Exists(assemblyPath)) {
+            return false;
+        }
+
+        AssemblyName asmToLoadName = AssemblyName.GetAssemblyName(assemblyPath);
+
+        return string.Equals(asmToLoadName.Name, requiredAssemblyName.Name, StringComparison.OrdinalIgnoreCase)
+            && asmToLoadName.Version >= requiredAssemblyName.Version;
+    }
+
+    private class ModuleLoadContext : AssemblyLoadContext {
+        private readonly string _assemblyDir;
+
+        public ModuleLoadContext(string assemblyDir)
+            : base("DbaClientX.PowerShell", isCollectible: false) {
+            _assemblyDir = assemblyDir;
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName) {
+            string asmPath = Path.Join(_assemblyDir, $"{assemblyName.Name}.dll");
+            if (File.Exists(asmPath)) {
+                return LoadFromAssemblyPath(asmPath);
+            }
+
+            return null;
+        }
+    }
+#endif
 
     private bool IsNetFramework() {
         // Get the version of the CLR

--- a/DbaClientX.Tests/OnImportAndRemoveTests.cs
+++ b/DbaClientX.Tests/OnImportAndRemoveTests.cs
@@ -15,4 +15,12 @@ public class OnImportAndRemoveTests
         var result = (Assembly?)method!.Invoke(null, new object?[] { null, resolveArgs });
         Assert.Null(result);
     }
+
+#if NET5_0_OR_GREATER
+    [Fact]
+    public void LoadContext_IsAvailable()
+    {
+        Assert.NotNull(OnModuleImportAndRemove.LoadContext);
+    }
+#endif
 }

--- a/Module/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Module/Tests/AssemblyLoadContext.Tests.ps1
@@ -1,0 +1,11 @@
+Describe 'Assembly Load Context' {
+    BeforeAll {
+        Import-Module (Join-Path $PSScriptRoot '..' 'DbaClientX.psd1') -Force
+    }
+
+    It 'creates custom ALC on CoreCLR' -Skip:(-not $IsCoreCLR) {
+        $alc = [OnModuleImportAndRemove]::LoadContext
+        $alc | Should -Not -BeNull
+        $alc.Name | Should -Be 'DbaClientX.PowerShell'
+    }
+}


### PR DESCRIPTION
## Summary
- hook up custom AssemblyLoadContext on PowerShell to isolate module dependencies
- expose load context for tests and diagnostics
- add unit and Pester tests verifying ALC initialization

## Testing
- `pwsh Module/DbaClientX.Tests.ps1`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689388f094b0832e9c968ed909931bc2