### PR TITLE
Add SQLite provider with examples and tests

### DIFF
--- a/DbaClientX.Examples/DbaClientX.Examples.csproj
+++ b/DbaClientX.Examples/DbaClientX.Examples.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\DbaClientX.SqlServer\DbaClientX.SqlServer.csproj" />
     <ProjectReference Include="..\DbaClientX.PostgreSql\DbaClientX.PostgreSql.csproj" />
     <ProjectReference Include="..\DbaClientX.MySql\DbaClientX.MySql.csproj" />
+    <ProjectReference Include="..\DbaClientX.SQLite\DbaClientX.SQLite.csproj" />
   </ItemGroup>
 
 </Project>

--- a/DbaClientX.Examples/QuerySqliteExample.cs
+++ b/DbaClientX.Examples/QuerySqliteExample.cs
@@ -1,0 +1,27 @@
+using DBAClientX;
+using System.Data;
+
+public static class QuerySqliteExample
+{
+    public static void Run()
+    {
+        var sqlite = new SQLite
+        {
+            ReturnType = ReturnType.DataTable,
+        };
+
+        var result = sqlite.SqliteQuery("example.db", "SELECT 1");
+
+        if (result is DataTable table)
+        {
+            foreach (DataRow row in table.Rows)
+            {
+                foreach (DataColumn col in table.Columns)
+                {
+                    Console.Write($"{row[col]}\t");
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
+++ b/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
@@ -21,6 +21,7 @@
         <ItemGroup>
                 <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
                 <ProjectReference Include="..\DbaClientX.SqlServer\DbaClientX.SqlServer.csproj" />
+                <ProjectReference Include="..\DbaClientX.SQLite\DbaClientX.SQLite.csproj" />
         </ItemGroup>
 
 	<ItemGroup>

--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>DbaClientX SQLite provider</Description>
+    <AssemblyName>DbaClientX.SQLite</AssemblyName>
+    <AssemblyTitle>DbaClientX.SQLite</AssemblyTitle>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">netstandard2.0;net472;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">netstandard2.0;net8.0</TargetFrameworks>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <Company>Evotec</Company>
+    <Authors>Przemyslaw Klys</Authors>
+    <LangVersion>Latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PackageId>DBAClientX.SQLite</PackageId>
+    <PackageProjectUrl>https://github.com/EvotecIT/DbaClientX</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RequireLicenseAcceptance>false</RequireLicenseAcceptance>
+    <DelaySign>False</DelaySign>
+    <IsPublishable>True</IsPublishable>
+    <RepositoryUrl>https://github.com/EvotecIT/DbaClientX</RepositoryUrl>
+    <DebugType>portable</DebugType>
+    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryType>git</RepositoryType>
+    <SignAssembly>False</SignAssembly>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <NeutralLanguage>en</NeutralLanguage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="System.Collections" />
+    <Using Include="System.Threading.Tasks" />
+    <Using Include="System.Collections.Concurrent" />
+    <Using Include="System.Threading" />
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Text" />
+    <Using Include="System.IO" />
+    <Using Include="System.Net" />
+  </ItemGroup>
+</Project>

--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Concurrent;
+using Microsoft.Data.Sqlite;
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+using System.Runtime.CompilerServices;
+#endif
+
+namespace DBAClientX;
+
+/// <summary>
+/// This class is used to connect to SQLite
+/// </summary>
+public class SQLite : DatabaseClientBase
+{
+    private readonly object _syncRoot = new();
+    private SqliteConnection? _transactionConnection;
+    private SqliteTransaction? _transaction;
+    private static readonly ConcurrentDictionary<SqliteType, DbType> TypeCache = new();
+
+    public bool IsInTransaction => _transaction != null;
+
+    public virtual object? SqliteQuery(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null)
+    {
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = database,
+            Pooling = true
+        }.ConnectionString;
+
+        SqliteConnection? connection = null;
+        bool dispose = false;
+        try
+        {
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new SqliteConnection(connectionString);
+                connection.Open();
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return ExecuteQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    private static IDictionary<string, DbType>? ConvertParameterTypes(IDictionary<string, SqliteType>? types)
+    {
+        if (types == null)
+        {
+            return null;
+        }
+
+        var result = new Dictionary<string, DbType>(types.Count);
+        foreach (var pair in types)
+        {
+            var dbType = TypeCache.GetOrAdd(pair.Value, static s =>
+            {
+                var parameter = new SqliteParameter { SqliteType = s };
+                return parameter.DbType;
+            });
+            result[pair.Key] = dbType;
+        }
+        return result;
+    }
+
+    public virtual int SqliteQueryNonQuery(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null)
+    {
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = database,
+            Pooling = true
+        }.ConnectionString;
+
+        SqliteConnection? connection = null;
+        bool dispose = false;
+        try
+        {
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new SqliteConnection(connectionString);
+                connection.Open();
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    public virtual async Task<object?> SqliteQueryAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null)
+    {
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = database,
+            Pooling = true
+        }.ConnectionString;
+
+        SqliteConnection? connection = null;
+        bool dispose = false;
+        try
+        {
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new SqliteConnection(connectionString);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return await ExecuteQueryAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    public virtual async IAsyncEnumerable<DataRow> SqliteQueryStreamAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null)
+    {
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = database,
+            Pooling = true
+        }.ConnectionString;
+
+        SqliteConnection? connection = null;
+        bool dispose = false;
+
+        if (useTransaction)
+        {
+            if (_transaction == null || _transactionConnection == null)
+            {
+                throw new DbaTransactionException("Transaction has not been started.");
+            }
+            connection = _transactionConnection;
+        }
+        else
+        {
+            connection = new SqliteConnection(connectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            dispose = true;
+        }
+
+        var dbTypes = ConvertParameterTypes(parameterTypes);
+        try
+        {
+            await foreach (var row in ExecuteQueryStreamAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes).ConfigureAwait(false))
+            {
+                yield return row;
+            }
+        }
+        finally
+        {
+            if (dispose)
+            {
+                await connection.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+    }
+#endif
+
+    public virtual void BeginTransaction(string database)
+    {
+        if (_transaction != null)
+        {
+            throw new DbaTransactionException("Transaction already started.");
+        }
+
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = database,
+            Pooling = true
+        }.ConnectionString;
+
+        _transactionConnection = new SqliteConnection(connectionString);
+        _transactionConnection.Open();
+        _transaction = _transactionConnection.BeginTransaction();
+    }
+
+    public virtual void Commit()
+    {
+        if (_transaction == null)
+        {
+            throw new DbaTransactionException("No active transaction.");
+        }
+        _transaction.Commit();
+        DisposeTransaction();
+    }
+
+    public virtual void Rollback()
+    {
+        if (_transaction == null)
+        {
+            throw new DbaTransactionException("No active transaction.");
+        }
+        _transaction.Rollback();
+        DisposeTransaction();
+    }
+
+    private void DisposeTransaction()
+    {
+        _transaction?.Dispose();
+        _transaction = null;
+        _transactionConnection?.Dispose();
+        _transactionConnection = null;
+    }
+
+    public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string database, CancellationToken cancellationToken = default)
+    {
+        if (queries == null)
+        {
+            throw new ArgumentNullException(nameof(queries));
+        }
+
+        var tasks = queries.Select(q => SqliteQueryAsync(database, q, null, false, cancellationToken));
+        var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+        return results;
+    }
+}

--- a/DbaClientX.Tests/DbaClientX.Tests.csproj
+++ b/DbaClientX.Tests/DbaClientX.Tests.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\DbaClientX.PowerShell\DbaClientX.PowerShell.csproj" />
     <ProjectReference Include="..\DbaClientX.PostgreSql\DbaClientX.PostgreSql.csproj" />
     <ProjectReference Include="..\DbaClientX.MySql\DbaClientX.MySql.csproj" />
+    <ProjectReference Include="..\DbaClientX.SQLite\DbaClientX.SQLite.csproj" />
   </ItemGroup>
 
 </Project>

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -1,0 +1,88 @@
+using System.Data;
+using System.IO;
+using Xunit;
+using DBAClientX;
+
+namespace DbaClientX.Tests;
+
+public class SqliteTests
+{
+    [Fact]
+    public void SqliteQueryNonQuery_CreatesAndReadsData()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
+            sqlite.SqliteQueryNonQuery(path, "CREATE TABLE t(id INTEGER);");
+            sqlite.SqliteQueryNonQuery(path, "INSERT INTO t(id) VALUES (1);");
+            var result = sqlite.SqliteQuery(path, "SELECT id FROM t;");
+            var table = Assert.IsType<DataTable>(result);
+            Assert.Single(table.Rows);
+            Assert.Equal(1L, table.Rows[0]["id"]);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SqliteQuery_WithTransactionNotStarted_Throws()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var sqlite = new DBAClientX.SQLite();
+            var ex = Assert.Throws<DBAClientX.DbaQueryExecutionException>(() => sqlite.SqliteQuery(path, "SELECT 1", useTransaction: true));
+            Assert.IsType<DBAClientX.DbaTransactionException>(ex.InnerException);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Commit_PersistsChanges()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
+            sqlite.SqliteQueryNonQuery(path, "CREATE TABLE t(id INTEGER);");
+            sqlite.BeginTransaction(path);
+            sqlite.SqliteQueryNonQuery(path, "INSERT INTO t(id) VALUES (1);", useTransaction: true);
+            sqlite.Commit();
+            var result = sqlite.SqliteQuery(path, "SELECT id FROM t;");
+            var table = Assert.IsType<DataTable>(result);
+            Assert.Single(table.Rows);
+            Assert.Equal(1L, table.Rows[0]["id"]);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Rollback_DiscardsChanges()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
+            sqlite.SqliteQueryNonQuery(path, "CREATE TABLE t(id INTEGER);");
+            sqlite.BeginTransaction(path);
+            sqlite.SqliteQueryNonQuery(path, "INSERT INTO t(id) VALUES (1);", useTransaction: true);
+            sqlite.Rollback();
+            var result = sqlite.SqliteQuery(path, "SELECT id FROM t;");
+            var table = Assert.IsType<DataTable>(result);
+            Assert.Equal(0, table.Rows.Count);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -1,7 +1,8 @@
 using System.Data;
 using System.IO;
-using Xunit;
 using DBAClientX;
+using Microsoft.Data.Sqlite;
+using Xunit;
 
 namespace DbaClientX.Tests;
 
@@ -23,7 +24,7 @@ public class SqliteTests
         }
         finally
         {
-            File.Delete(path);
+            Cleanup(path);
         }
     }
 
@@ -39,7 +40,7 @@ public class SqliteTests
         }
         finally
         {
-            File.Delete(path);
+            Cleanup(path);
         }
     }
 
@@ -61,7 +62,7 @@ public class SqliteTests
         }
         finally
         {
-            File.Delete(path);
+            Cleanup(path);
         }
     }
 
@@ -81,6 +82,15 @@ public class SqliteTests
             Assert.Equal(0, table.Rows.Count);
         }
         finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    private static void Cleanup(string path)
+    {
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(path))
         {
             File.Delete(path);
         }

--- a/DbaClientX.sln
+++ b/DbaClientX.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.PostgreSql", "Db
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.MySql", "DbaClientX.MySql\DbaClientX.MySql.csproj", "{A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.SQLite", "DbaClientX.SQLite\DbaClientX.SQLite.csproj", "{F9215ADC-A725-481D-B297-CB229B42CCFA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,10 +50,14 @@ Global
 		{541C4466-43B7-4668-A131-397D39613BFC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{541C4466-43B7-4668-A131-397D39613BFC}.Release|Any CPU.Build.0 = Release|Any CPU
 		{A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A1BE9FEE-17D6-4BF6-8F92-AA82BA267946}.Release|Any CPU.Build.0 = Release|Any CPU
+                {F9215ADC-A725-481D-B297-CB229B42CCFA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F9215ADC-A725-481D-B297-CB229B42CCFA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F9215ADC-A725-481D-B297-CB229B42CCFA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F9215ADC-A725-481D-B297-CB229B42CCFA}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add SQLite provider with query, non-query, async, and transaction support
- wire SQLite provider into examples, PowerShell module, and tests
- include sample usage and unit tests for SQLite operations

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test DbaClientX.sln`


------
https://chatgpt.com/codex/tasks/task_e_6893c16c3348832e995c873b885cb170