### PR TITLE
Remove redundant order by property

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -488,7 +488,6 @@ public class Query
     public string UpdateTable => _updateTable;
     public IReadOnlyList<(string Column, object Value)> SetValues => _set;
     public string DeleteTable => _deleteTable;
-    public IReadOnlyList<string> OrderByExpressions => _orderBy;
     public IReadOnlyList<string> OrderByColumns => _orderBy;
     public IReadOnlyList<string> GroupByColumns => _groupBy;
     public IReadOnlyList<(string Column, string Operator, object Value)> HavingClauses => _having;

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -149,9 +149,9 @@ public class QueryCompiler
             }
         }
 
-        if (query.OrderByExpressions.Count > 0)
+        if (query.OrderByColumns.Count > 0)
         {
-            sb.Append(" ORDER BY ").Append(string.Join(", ", query.OrderByExpressions));
+            sb.Append(" ORDER BY ").Append(string.Join(", ", query.OrderByColumns));
         }
 
         if (query.LimitValue.HasValue && !query.UseTop)


### PR DESCRIPTION
## Summary
- simplify query builder API by keeping a single order-by collection

## Testing
- `dotnet build DbaClientX.sln -c Release`
- `dotnet build DbaClientX.Core/DbaClientX.Core.csproj -c Release -f netstandard2.0`
- `dotnet build DbaClientX.Core/DbaClientX.Core.csproj -c Release -f net8.0`
- `dotnet build DbaClientX.Core/DbaClientX.Core.csproj -c Release -f net472` *(fails: The reference assemblies for .NETFramework,Version=v4.7.2 were not found)*
- `dotnet test DbaClientX.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6893c1458cbc832eb49237d448a47e6a