### PR TITLE
refactor: unify provider query method names

### DIFF
--- a/DbaClientX.Examples/CancellationExample.cs
+++ b/DbaClientX.Examples/CancellationExample.cs
@@ -11,7 +11,7 @@ public static class CancellationExample
         var sqlServer = new SqlServer();
         try
         {
-            await sqlServer.SqlQueryAsync("SQL1", "master", true, "WAITFOR DELAY '00:00:05'", cancellationToken: cts.Token);
+            await sqlServer.QueryAsync("SQL1", "master", true, "WAITFOR DELAY '00:00:05'", cancellationToken: cts.Token);
         }
         catch (OperationCanceledException)
         {

--- a/DbaClientX.Examples/NonQueryExample.cs
+++ b/DbaClientX.Examples/NonQueryExample.cs
@@ -6,7 +6,7 @@ public static class NonQueryExample
     public static void Run()
     {
         var sqlServer = new DBAClientX.SqlServer();
-        var affected = sqlServer.SqlQueryNonQuery("SQL1", "master", true, "CREATE TABLE #Example (Id INT)");
+        var affected = sqlServer.ExecuteNonQuery("SQL1", "master", true, "CREATE TABLE #Example (Id INT)");
         Console.WriteLine($"Rows affected: {affected}");
     }
 }

--- a/DbaClientX.Examples/QueryMySqlAsyncExample.cs
+++ b/DbaClientX.Examples/QueryMySqlAsyncExample.cs
@@ -11,7 +11,7 @@ public static class QueryMySqlAsyncExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var result = await mySql.MySqlQueryAsync("MYSQL1", "mysql", "user", "password", "SELECT 1", cancellationToken: CancellationToken.None);
+        var result = await mySql.QueryAsync("MYSQL1", "mysql", "user", "password", "SELECT 1", cancellationToken: CancellationToken.None);
 
         if (result is DataTable table)
         {

--- a/DbaClientX.Examples/QueryPostgreSqlAsyncExample.cs
+++ b/DbaClientX.Examples/QueryPostgreSqlAsyncExample.cs
@@ -12,7 +12,7 @@ public static class QueryPostgreSqlAsyncExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var result = await pg.PgQueryAsync("localhost", "postgres", "user", "password", "SELECT 1", cancellationToken: CancellationToken.None);
+        var result = await pg.QueryAsync("localhost", "postgres", "user", "password", "SELECT 1", cancellationToken: CancellationToken.None);
 
         if (result is DataTable table)
         {

--- a/DbaClientX.Examples/QuerySqlServerAsyncExample.cs
+++ b/DbaClientX.Examples/QuerySqlServerAsyncExample.cs
@@ -11,7 +11,7 @@ public static class QuerySqlServerAsyncExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var result = await sqlServer.SqlQueryAsync("SQL1", "master", true, "SELECT TOP 1 * FROM sys.databases", cancellationToken: CancellationToken.None);
+        var result = await sqlServer.QueryAsync("SQL1", "master", true, "SELECT TOP 1 * FROM sys.databases", cancellationToken: CancellationToken.None);
 
         if (result is DataTable table)
         {

--- a/DbaClientX.Examples/QuerySqliteExample.cs
+++ b/DbaClientX.Examples/QuerySqliteExample.cs
@@ -10,7 +10,7 @@ public static class QuerySqliteExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var result = sqlite.SqliteQuery("example.db", "SELECT 1");
+        var result = sqlite.Query("example.db", "SELECT 1");
 
         if (result is DataTable table)
         {

--- a/DbaClientX.Examples/StreamQueryExample.cs
+++ b/DbaClientX.Examples/StreamQueryExample.cs
@@ -11,7 +11,7 @@ public static class StreamQueryExample
             ReturnType = ReturnType.DataRow
         };
 
-        await foreach (DataRow row in sqlServer.SqlQueryStreamAsync("SQL1", "master", true, "SELECT TOP 5 * FROM sys.databases", cancellationToken: CancellationToken.None))
+        await foreach (DataRow row in sqlServer.QueryStreamAsync("SQL1", "master", true, "SELECT TOP 5 * FROM sys.databases", cancellationToken: CancellationToken.None))
         {
             foreach (DataColumn col in row.Table.Columns)
             {

--- a/DbaClientX.Examples/TransactionAsyncExample.cs
+++ b/DbaClientX.Examples/TransactionAsyncExample.cs
@@ -11,7 +11,7 @@ public static class TransactionAsyncExample
         await sql.BeginTransactionAsync("SQL1", "master", true, cancellationToken);
         try
         {
-            await sql.SqlQueryAsync("SQL1", "master", true, "CREATE TABLE #temp(id int)", null, true, cancellationToken);
+            await sql.QueryAsync("SQL1", "master", true, "CREATE TABLE #temp(id int)", null, true, cancellationToken);
             await sql.CommitAsync(cancellationToken);
             Console.WriteLine("Committed");
         }

--- a/DbaClientX.Examples/TransactionExample.cs
+++ b/DbaClientX.Examples/TransactionExample.cs
@@ -10,7 +10,7 @@ public static class TransactionExample
         sql.BeginTransaction("SQL1", "master", true);
         try
         {
-            sql.SqlQuery("SQL1", "master", true, "CREATE TABLE #temp(id int)", null, true);
+            sql.Query("SQL1", "master", true, "CREATE TABLE #temp(id int)", null, true);
             sql.Commit();
             Console.WriteLine("Committed");
         }

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -25,7 +25,7 @@ public class MySql : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public virtual object? MySqlQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    public virtual object? Query(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
     {
         var connectionString = new MySqlConnectionStringBuilder
         {
@@ -91,7 +91,7 @@ public class MySql : DatabaseClientBase
         return result;
     }
 
-    public virtual int MySqlQueryNonQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    public virtual int ExecuteNonQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
     {
         var connectionString = new MySqlConnectionStringBuilder
         {
@@ -137,7 +137,7 @@ public class MySql : DatabaseClientBase
         }
     }
 
-    public virtual async Task<object?> MySqlQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    public virtual async Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
     {
         var connectionString = new MySqlConnectionStringBuilder
         {
@@ -239,7 +239,7 @@ public class MySql : DatabaseClientBase
             throw new ArgumentNullException(nameof(queries));
         }
 
-        var tasks = queries.Select(q => MySqlQueryAsync(host, database, username, password, q, null, false, cancellationToken));
+        var tasks = queries.Select(q => QueryAsync(host, database, username, password, q, null, false, cancellationToken));
         var results = await Task.WhenAll(tasks).ConfigureAwait(false);
         return results;
     }

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -26,7 +26,7 @@ public class PostgreSql : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public virtual object? PgQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    public virtual object? Query(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
     {
         var connectionString = new NpgsqlConnectionStringBuilder
         {
@@ -92,7 +92,7 @@ public class PostgreSql : DatabaseClientBase
         return result;
     }
 
-    public virtual int PgQueryNonQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    public virtual int ExecuteNonQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
     {
         var connectionString = new NpgsqlConnectionStringBuilder
         {
@@ -138,7 +138,7 @@ public class PostgreSql : DatabaseClientBase
         }
     }
 
-    public virtual async Task<object?> PgQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    public virtual async Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
     {
         var connectionString = new NpgsqlConnectionStringBuilder
         {
@@ -197,17 +197,17 @@ public class PostgreSql : DatabaseClientBase
     public virtual object? ExecuteStoredProcedure(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
     {
         var query = BuildStoredProcedureQuery(procedure, parameters);
-        return PgQuery(host, database, username, password, query, parameters, useTransaction, parameterTypes);
+        return Query(host, database, username, password, query, parameters, useTransaction, parameterTypes);
     }
 
     public virtual Task<object?> ExecuteStoredProcedureAsync(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
     {
         var query = BuildStoredProcedureQuery(procedure, parameters);
-        return PgQueryAsync(host, database, username, password, query, parameters, useTransaction, cancellationToken, parameterTypes);
+        return QueryAsync(host, database, username, password, query, parameters, useTransaction, cancellationToken, parameterTypes);
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-    public virtual IAsyncEnumerable<DataRow> PgQueryStreamAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    public virtual IAsyncEnumerable<DataRow> QueryStreamAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
     {
         return Stream();
 
@@ -314,7 +314,7 @@ public class PostgreSql : DatabaseClientBase
             throw new ArgumentNullException(nameof(queries));
         }
 
-        var tasks = queries.Select(q => PgQueryAsync(host, database, username, password, q, null, false, cancellationToken));
+        var tasks = queries.Select(q => QueryAsync(host, database, username, password, q, null, false, cancellationToken));
         var results = await Task.WhenAll(tasks).ConfigureAwait(false);
         return results;
     }

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
@@ -50,7 +50,7 @@ public sealed class CmdletIInvokeDbaXNonQuery : PSCmdlet {
                     de => de.Value);
             }
 
-            var affected = sqlServer.SqlQueryNonQuery(Server, Database, integratedSecurity, Query, parameters, username: Username, password: Password);
+            var affected = sqlServer.ExecuteNonQuery(Server, Database, integratedSecurity, Query, parameters, username: Username, password: Password);
             WriteObject(affected);
         } catch (Exception ex) {
             WriteWarning($"Invoke-DbaXNonQuery - Error querying SqlServer: {ex.Message}");

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -81,7 +81,7 @@ public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
             if (Stream.IsPresent)
             {
-                var enumerable = sqlServer.SqlQueryStreamAsync(Server, Database, integratedSecurity, Query, parameters, cancellationToken: CancellationToken.None, username: Username, password: Password);
+                var enumerable = sqlServer.QueryStreamAsync(Server, Database, integratedSecurity, Query, parameters, cancellationToken: CancellationToken.None, username: Username, password: Password);
                 var enumerator = enumerable.GetAsyncEnumerator();
                 try
                 {
@@ -144,7 +144,7 @@ public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
             if (!string.IsNullOrEmpty(StoredProcedure)) {
                 result = sqlServer.ExecuteStoredProcedure(Server, Database, integratedSecurity, StoredProcedure, parameters, username: Username, password: Password);
             } else {
-                result = sqlServer.SqlQuery(Server, Database, integratedSecurity, Query, parameters, username: Username, password: Password);
+                result = sqlServer.Query(Server, Database, integratedSecurity, Query, parameters, username: Username, password: Password);
             }
             if (result != null) {
                 if (ReturnType == ReturnType.PSObject) {

--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -25,7 +25,7 @@ public class SQLite : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public virtual object? SqliteQuery(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null)
+    public virtual object? Query(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null)
     {
         var connectionString = new SqliteConnectionStringBuilder
         {
@@ -88,7 +88,7 @@ public class SQLite : DatabaseClientBase
         return result;
     }
 
-    public virtual int SqliteQueryNonQuery(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null)
+    public virtual int ExecuteNonQuery(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null)
     {
         var connectionString = new SqliteConnectionStringBuilder
         {
@@ -131,7 +131,7 @@ public class SQLite : DatabaseClientBase
         }
     }
 
-    public virtual async Task<object?> SqliteQueryAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null)
+    public virtual async Task<object?> QueryAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null)
     {
         var connectionString = new SqliteConnectionStringBuilder
         {
@@ -175,7 +175,7 @@ public class SQLite : DatabaseClientBase
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-    public virtual async IAsyncEnumerable<DataRow> SqliteQueryStreamAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null)
+    public virtual async IAsyncEnumerable<DataRow> QueryStreamAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null)
     {
         var connectionString = new SqliteConnectionStringBuilder
         {
@@ -272,7 +272,7 @@ public class SQLite : DatabaseClientBase
             throw new ArgumentNullException(nameof(queries));
         }
 
-        var tasks = queries.Select(q => SqliteQueryAsync(database, q, null, false, cancellationToken));
+        var tasks = queries.Select(q => QueryAsync(database, q, null, false, cancellationToken));
         var results = await Task.WhenAll(tasks).ConfigureAwait(false);
         return results;
     }

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -24,7 +24,7 @@ public class SqlServer : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public virtual object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public virtual object? Query(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
         var connectionStringBuilder = new SqlConnectionStringBuilder
         {
@@ -95,7 +95,7 @@ public class SqlServer : DatabaseClientBase
         return result;
     }
 
-    public virtual int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public virtual int ExecuteNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
         var connectionStringBuilder = new SqlConnectionStringBuilder
         {
@@ -146,7 +146,7 @@ public class SqlServer : DatabaseClientBase
         }
     }
 
-    public virtual async Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public virtual async Task<object?> QueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
         var connectionStringBuilder = new SqlConnectionStringBuilder
         {
@@ -210,17 +210,17 @@ public class SqlServer : DatabaseClientBase
     public virtual object? ExecuteStoredProcedure(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
         var query = BuildStoredProcedureQuery(procedure, parameters);
-        return SqlQuery(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, parameterTypes, username, password);
+        return Query(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, parameterTypes, username, password);
     }
 
     public virtual Task<object?> ExecuteStoredProcedureAsync(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
         var query = BuildStoredProcedureQuery(procedure, parameters);
-        return SqlQueryAsync(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, cancellationToken, parameterTypes, username, password);
+        return QueryAsync(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, cancellationToken, parameterTypes, username, password);
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-    public virtual IAsyncEnumerable<DataRow> SqlQueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public virtual IAsyncEnumerable<DataRow> QueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
         return Stream();
 
@@ -396,7 +396,7 @@ public class SqlServer : DatabaseClientBase
             throw new ArgumentNullException(nameof(queries));
         }
 
-        var tasks = queries.Select(q => SqlQueryAsync(serverOrInstance, database, integratedSecurity, q, null, false, cancellationToken, username: username, password: password));
+        var tasks = queries.Select(q => QueryAsync(serverOrInstance, database, integratedSecurity, q, null, false, cancellationToken, username: username, password: password));
         var results = await Task.WhenAll(tasks).ConfigureAwait(false);
         return results;
     }

--- a/DbaClientX.Tests/ParallelQueriesTests.cs
+++ b/DbaClientX.Tests/ParallelQueriesTests.cs
@@ -17,7 +17,7 @@ public class ParallelQueriesTests
             _responses = responses;
         }
 
-        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override Task<object?> QueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             _responses.TryGetValue(query, out var result);
             return Task.FromResult(result);

--- a/DbaClientX.Tests/SqlQueryStreamTests.cs
+++ b/DbaClientX.Tests/SqlQueryStreamTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace DbaClientX.Tests;
 
-public class SqlQueryStreamTests
+public class QueryStreamTests
 {
     private class DummySqlServer : DBAClientX.SqlServer
     {
@@ -30,7 +30,7 @@ public class SqlQueryStreamTests
             _rows = table.Rows.Cast<DataRow>().ToList();
         }
 
-        public override async IAsyncEnumerable<DataRow> SqlQueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override async IAsyncEnumerable<DataRow> QueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             foreach (var row in _rows)
             {
@@ -41,12 +41,12 @@ public class SqlQueryStreamTests
     }
 
     [Fact]
-    public async Task SqlQueryStreamAsync_EnumeratesRows()
+    public async Task QueryStreamAsync_EnumeratesRows()
     {
         var server = new DummySqlServer();
         var list = new List<int>();
 
-        await foreach (DataRow row in server.SqlQueryStreamAsync("s", "d", true, "q"))
+        await foreach (DataRow row in server.QueryStreamAsync("s", "d", true, "q"))
         {
             list.Add((int)row["id"]);
         }

--- a/DbaClientX.Tests/SqlServerNonQueryTests.cs
+++ b/DbaClientX.Tests/SqlServerNonQueryTests.cs
@@ -22,7 +22,7 @@ public class SqlServerNonQueryTests
             return 1;
         }
 
-        public override int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override int ExecuteNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             IDictionary<string, DbType>? dbTypes = null;
             if (parameterTypes != null)
@@ -39,7 +39,7 @@ public class SqlServerNonQueryTests
     }
 
     [Fact]
-    public void SqlQueryNonQuery_BindsParameters()
+    public void ExecuteNonQuery_BindsParameters()
     {
         var sqlServer = new CaptureParametersSqlServer();
         var parameters = new Dictionary<string, object?>
@@ -48,14 +48,14 @@ public class SqlServerNonQueryTests
             ["@name"] = "test"
         };
 
-        sqlServer.SqlQueryNonQuery("s", "db", true, "UPDATE t SET c=1 WHERE id=@id", parameters);
+        sqlServer.ExecuteNonQuery("s", "db", true, "UPDATE t SET c=1 WHERE id=@id", parameters);
 
         Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && (int)p.Value == 5);
         Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && (string)p.Value == "test");
     }
 
     [Fact]
-    public void SqlQueryNonQuery_PreservesParameterTypes()
+    public void ExecuteNonQuery_PreservesParameterTypes()
     {
         var sqlServer = new CaptureParametersSqlServer();
         var parameters = new Dictionary<string, object?>
@@ -69,7 +69,7 @@ public class SqlServerNonQueryTests
             ["@name"] = SqlDbType.NVarChar
         };
 
-        sqlServer.SqlQueryNonQuery("s", "db", true, "UPDATE t SET name=@name WHERE id=@id", parameters, parameterTypes: types);
+        sqlServer.ExecuteNonQuery("s", "db", true, "UPDATE t SET name=@name WHERE id=@id", parameters, parameterTypes: types);
 
         Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && p.Type == DbType.Int32);
         Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && p.Type == DbType.String);
@@ -96,7 +96,7 @@ public class SqlServerNonQueryTests
             TransactionStarted = false;
         }
 
-        public override int SqlQueryNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override int ExecuteNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             if (useTransaction && !TransactionStarted) throw new DBAClientX.DbaTransactionException("Transaction has not been started.");
             return 0;
@@ -104,18 +104,18 @@ public class SqlServerNonQueryTests
     }
 
     [Fact]
-    public void SqlQueryNonQuery_WithTransactionNotStarted_Throws()
+    public void ExecuteNonQuery_WithTransactionNotStarted_Throws()
     {
         var sqlServer = new FakeTransactionSqlServer();
-        Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlServer.SqlQueryNonQuery("s", "db", true, "q", useTransaction: true));
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlServer.ExecuteNonQuery("s", "db", true, "q", useTransaction: true));
     }
 
     [Fact]
-    public void SqlQueryNonQuery_UsesTransaction_WhenStarted()
+    public void ExecuteNonQuery_UsesTransaction_WhenStarted()
     {
         var sqlServer = new FakeTransactionSqlServer();
         sqlServer.BeginTransaction("s", "db", true);
-        var ex = Record.Exception(() => sqlServer.SqlQueryNonQuery("s", "db", true, "q", useTransaction: true));
+        var ex = Record.Exception(() => sqlServer.ExecuteNonQuery("s", "db", true, "q", useTransaction: true));
         Assert.Null(ex);
     }
 }

--- a/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
@@ -72,7 +72,7 @@ public class SqlServerTransactionAsyncTests
             Transaction = null;
         }
 
-        public override Task<object?> SqlQueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override Task<object?> QueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             if (useTransaction && Transaction == null)
             {

--- a/DbaClientX.Tests/SqlServerTransactionTests.cs
+++ b/DbaClientX.Tests/SqlServerTransactionTests.cs
@@ -61,7 +61,7 @@ public class SqlServerTransactionTests
             Transaction = null;
         }
 
-        public override object? SqlQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override object? Query(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
             if (useTransaction && Transaction == null)
             {

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -9,15 +9,15 @@ namespace DbaClientX.Tests;
 public class SqliteTests
 {
     [Fact]
-    public void SqliteQueryNonQuery_CreatesAndReadsData()
+    public void ExecuteNonQuery_CreatesAndReadsData()
     {
         var path = Path.GetTempFileName();
         try
         {
             var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
-            sqlite.SqliteQueryNonQuery(path, "CREATE TABLE t(id INTEGER);");
-            sqlite.SqliteQueryNonQuery(path, "INSERT INTO t(id) VALUES (1);");
-            var result = sqlite.SqliteQuery(path, "SELECT id FROM t;");
+            sqlite.ExecuteNonQuery(path, "CREATE TABLE t(id INTEGER);");
+            sqlite.ExecuteNonQuery(path, "INSERT INTO t(id) VALUES (1);");
+            var result = sqlite.Query(path, "SELECT id FROM t;");
             var table = Assert.IsType<DataTable>(result);
             Assert.Single(table.Rows);
             Assert.Equal(1L, table.Rows[0]["id"]);
@@ -29,13 +29,13 @@ public class SqliteTests
     }
 
     [Fact]
-    public void SqliteQuery_WithTransactionNotStarted_Throws()
+    public void Query_WithTransactionNotStarted_Throws()
     {
         var path = Path.GetTempFileName();
         try
         {
             var sqlite = new DBAClientX.SQLite();
-            var ex = Assert.Throws<DBAClientX.DbaQueryExecutionException>(() => sqlite.SqliteQuery(path, "SELECT 1", useTransaction: true));
+            var ex = Assert.Throws<DBAClientX.DbaQueryExecutionException>(() => sqlite.Query(path, "SELECT 1", useTransaction: true));
             Assert.IsType<DBAClientX.DbaTransactionException>(ex.InnerException);
         }
         finally
@@ -51,11 +51,11 @@ public class SqliteTests
         try
         {
             var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
-            sqlite.SqliteQueryNonQuery(path, "CREATE TABLE t(id INTEGER);");
+            sqlite.ExecuteNonQuery(path, "CREATE TABLE t(id INTEGER);");
             sqlite.BeginTransaction(path);
-            sqlite.SqliteQueryNonQuery(path, "INSERT INTO t(id) VALUES (1);", useTransaction: true);
+            sqlite.ExecuteNonQuery(path, "INSERT INTO t(id) VALUES (1);", useTransaction: true);
             sqlite.Commit();
-            var result = sqlite.SqliteQuery(path, "SELECT id FROM t;");
+            var result = sqlite.Query(path, "SELECT id FROM t;");
             var table = Assert.IsType<DataTable>(result);
             Assert.Single(table.Rows);
             Assert.Equal(1L, table.Rows[0]["id"]);
@@ -73,11 +73,11 @@ public class SqliteTests
         try
         {
             var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
-            sqlite.SqliteQueryNonQuery(path, "CREATE TABLE t(id INTEGER);");
+            sqlite.ExecuteNonQuery(path, "CREATE TABLE t(id INTEGER);");
             sqlite.BeginTransaction(path);
-            sqlite.SqliteQueryNonQuery(path, "INSERT INTO t(id) VALUES (1);", useTransaction: true);
+            sqlite.ExecuteNonQuery(path, "INSERT INTO t(id) VALUES (1);", useTransaction: true);
             sqlite.Rollback();
-            var result = sqlite.SqliteQuery(path, "SELECT id FROM t;");
+            var result = sqlite.Query(path, "SELECT id FROM t;");
             var table = Assert.IsType<DataTable>(result);
             Assert.Equal(0, table.Rows.Count);
         }

--- a/Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1
@@ -17,7 +17,7 @@ Describe 'Invoke-DbaXNonQuery cmdlet' {
             [string] $User
             [string] $Pass
             TestSqlServer () { [TestSqlServer]::Last = $this }
-            [int] SqlQueryNonQuery([string]$serverOrInstance, [string]$database, [bool]$integratedSecurity, [string]$query, [System.Collections.Generic.IDictionary[[string],[object]]] $parameters = $null, [bool]$useTransaction = $false, [System.Collections.Generic.IDictionary[[string],[System.Data.SqlDbType]]] $parameterTypes = $null, [string]$username = $null, [string]$password = $null) {
+            [int] ExecuteNonQuery([string]$serverOrInstance, [string]$database, [bool]$integratedSecurity, [string]$query, [System.Collections.Generic.IDictionary[[string],[object]]] $parameters = $null, [bool]$useTransaction = $false, [System.Collections.Generic.IDictionary[[string],[System.Data.SqlDbType]]] $parameterTypes = $null, [string]$username = $null, [string]$password = $null) {
                 $this.Integrated = $integratedSecurity
                 $this.User = $username
                 $this.Pass = $password

--- a/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
@@ -25,7 +25,7 @@ describe 'Invoke-DbaXQuery cmdlet' {
             [string] $User
             [string] $Pass
             TestSqlServer () { [TestSqlServer]::Last = $this }
-            [object] SqlQuery([string]$serverOrInstance, [string]$database, [bool]$integratedSecurity, [string]$query, [System.Collections.Generic.IDictionary[[string],[object]]] $parameters = $null, [bool]$useTransaction = $false, [System.Collections.Generic.IDictionary[[string],[System.Data.SqlDbType]]] $parameterTypes = $null, [string]$username = $null, [string]$password = $null) {
+            [object] Query([string]$serverOrInstance, [string]$database, [bool]$integratedSecurity, [string]$query, [System.Collections.Generic.IDictionary[[string],[object]]] $parameters = $null, [bool]$useTransaction = $false, [System.Collections.Generic.IDictionary[[string],[System.Data.SqlDbType]]] $parameterTypes = $null, [string]$username = $null, [string]$password = $null) {
                 $this.Integrated = $integratedSecurity
                 $this.User = $username
                 $this.Pass = $password


### PR DESCRIPTION
## Summary
- align provider APIs on common Query/QueryAsync/ExecuteNonQuery naming
- update PowerShell cmdlets, examples, and tests for new method names

## Testing
- `dotnet build`
- `dotnet test`
- `pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File Module/DbaClientX.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6894577896d0832eb2483a3dba45ebbd