### PR TITLE
Add cross and full outer join support

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -8,7 +8,7 @@ public class Query
     private readonly List<string> _select = new();
     private string _from;
     private (Query Query, string Alias)? _fromSubquery;
-    private readonly List<(string Type, string Table, string Condition)> _joins = new();
+    private readonly List<(string Type, string Table, string? Condition)> _joins = new();
     private readonly List<IWhereToken> _where = new();
     private string _insertTable;
     private readonly List<string> _insertColumns = new();
@@ -72,6 +72,21 @@ public class Query
         ValidateString(table, nameof(table));
         ValidateString(condition, nameof(condition));
         _joins.Add(("RIGHT JOIN", table, condition));
+        return this;
+    }
+
+    public Query CrossJoin(string table)
+    {
+        ValidateString(table, nameof(table));
+        _joins.Add(("CROSS JOIN", table, null));
+        return this;
+    }
+
+    public Query FullOuterJoin(string table, string condition)
+    {
+        ValidateString(table, nameof(table));
+        ValidateString(condition, nameof(condition));
+        _joins.Add(("FULL OUTER JOIN", table, condition));
         return this;
     }
 
@@ -491,7 +506,7 @@ public class Query
     public IReadOnlyList<string> OrderByColumns => _orderBy;
     public IReadOnlyList<string> GroupByColumns => _groupBy;
     public IReadOnlyList<(string Column, string Operator, object Value)> HavingClauses => _having;
-    public IReadOnlyList<(string Type, string Table, string Condition)> Joins => _joins;
+    public IReadOnlyList<(string Type, string Table, string? Condition)> Joins => _joins;
     public IReadOnlyList<(string Type, Query Query)> CompoundQueries => _compoundQueries;
     public int? LimitValue => _limit;
     public int? OffsetValue => _offset;

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -118,7 +118,11 @@ public class QueryCompiler
         {
             foreach (var join in query.Joins)
             {
-                sb.Append(' ').Append(join.Type).Append(' ').Append(join.Table).Append(" ON ").Append(join.Condition);
+                sb.Append(' ').Append(join.Type).Append(' ').Append(join.Table);
+                if (!string.IsNullOrWhiteSpace(join.Condition))
+                {
+                    sb.Append(" ON ").Append(join.Condition);
+                }
             }
         }
 

--- a/DbaClientX.Examples/JoinExample.cs
+++ b/DbaClientX.Examples/JoinExample.cs
@@ -1,0 +1,15 @@
+using DBAClientX.QueryBuilder;
+
+public static class JoinExample
+{
+    public static void Run()
+    {
+        var query = new Query()
+            .Select("u.name", "o.total")
+            .From("users u")
+            .FullOuterJoin("orders o", "u.id = o.user_id")
+            .CrossJoin("regions r");
+
+        Console.WriteLine(QueryBuilder.Compile(query));
+    }
+}

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -43,8 +43,11 @@ public class Program
             case "parameterized":
                 ParameterizedQueryExample.Run();
                 break;
+            case "joins":
+                JoinExample.Run();
+                break;
             default:
-                Console.WriteLine("Available examples: asyncquery, pgasyncquery, mysqlasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized");
+                Console.WriteLine("Available examples: asyncquery, pgasyncquery, mysqlasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized, joins");
                 break;
         }
     }

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -406,6 +406,30 @@ public class QueryBuilderTests
         var sql = QueryBuilder.Compile(query);
         Assert.Equal("SELECT * FROM users u LEFT JOIN profiles p ON u.id = p.user_id RIGHT JOIN photos ph ON u.id = ph.user_id", sql);
     }
+    [Fact]
+    public void CrossJoinQueries()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users u")
+            .CrossJoin("orders o");
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT * FROM users u CROSS JOIN orders o", sql);
+    }
+
+    [Fact]
+    public void FullOuterJoinQueries()
+    {
+        var query = new Query()
+            .Select("u.name", "o.total")
+            .From("users u")
+            .FullOuterJoin("orders o", "u.id = o.user_id");
+
+        var sql = QueryBuilder.Compile(query);
+        Assert.Equal("SELECT u.name, o.total FROM users u FULL OUTER JOIN orders o ON u.id = o.user_id", sql);
+    }
+
      
     [Fact]
     public void DecimalFormatting_UsesInvariantCulture()
@@ -541,6 +565,20 @@ public class QueryBuilderTests
     {
         var query = new Query();
         Assert.Throws<ArgumentException>(() => query.InsertInto("users"));
+    }
+
+    [Fact]
+    public void CrossJoin_WithEmptyTable_Throws()
+    {
+        var query = new Query();
+        Assert.Throws<ArgumentException>(() => query.CrossJoin(""));
+    }
+
+    [Fact]
+    public void FullOuterJoin_WithNullCondition_Throws()
+    {
+        var query = new Query();
+        Assert.Throws<ArgumentException>(() => query.FullOuterJoin("orders", null!));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- support CROSS JOIN and FULL OUTER JOIN in query builder
- compile joins without ON clauses for cross joins
- test and example coverage for new join types

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test DbaClientX.sln`


------
https://chatgpt.com/codex/tasks/task_e_689457a4a364832ebaf65554070fe743