### PR TITLE
Add Guid and binary inference

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -56,6 +56,8 @@ public abstract class DatabaseClientBase
     private static DbType InferDbType(object? value)
     {
         if (value == null || value == DBNull.Value) return DbType.Object;
+        if (value is Guid) return DbType.Guid;
+        if (value is byte[]) return DbType.Binary;
         return Type.GetTypeCode(value.GetType()) switch
         {
             TypeCode.Byte => DbType.Byte,

--- a/DbaClientX.Tests/InferDbTypeTests.cs
+++ b/DbaClientX.Tests/InferDbTypeTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Data.SqlClient;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class InferDbTypeTests
+{
+    private class TestClient : DBAClientX.DatabaseClientBase
+    {
+        public void InvokeAddParameters(DbCommand command, IDictionary<string, object?> parameters)
+            => base.AddParameters(command, parameters, null);
+    }
+
+    [Fact]
+    public void AddParameters_InfersGuidType()
+    {
+        var client = new TestClient();
+        using var command = new SqlCommand();
+        var guid = Guid.NewGuid();
+        client.InvokeAddParameters(command, new Dictionary<string, object?> { ["@id"] = guid });
+        var parameter = Assert.IsType<SqlParameter>(Assert.Single(command.Parameters));
+        Assert.Equal(DbType.Guid, parameter.DbType);
+        Assert.Equal(guid, parameter.Value);
+    }
+
+    [Fact]
+    public void AddParameters_InfersBinaryType()
+    {
+        var client = new TestClient();
+        using var command = new SqlCommand();
+        var bytes = new byte[] { 1, 2, 3 };
+        client.InvokeAddParameters(command, new Dictionary<string, object?> { ["@data"] = bytes });
+        var parameter = Assert.IsType<SqlParameter>(Assert.Single(command.Parameters));
+        Assert.Equal(DbType.Binary, parameter.DbType);
+        Assert.Equal(bytes, parameter.Value);
+    }
+}


### PR DESCRIPTION
## Summary
- infer DbType for Guid and byte[] automatically
- test Guid and binary parameter inference

## Testing
- `dotnet build DbaClientX.Core/DbaClientX.Core.csproj --no-restore -v minimal`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689467b4e5e0832e91c43b15cba3595f