### PR TITLE
Add parameter validation for Invoke-DbaXQuery

### DIFF
--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -7,16 +7,20 @@ public sealed class CmdletIInvokeDbaXQuery : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [Alias("DBServer", "SqlInstance", "Instance")]
+    [ValidateNotNullOrEmpty]
     public string Server { get; set; }
 
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
+    [ValidateNotNullOrEmpty]
     public string Database { get; set; }
 
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
+    [ValidateNotNullOrEmpty]
     public string Query { get; set; }
 
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
+    [ValidateNotNullOrEmpty]
     public string StoredProcedure { get; set; }
 
     [Parameter(Mandatory = false, ParameterSetName = "Query")]

--- a/Module/Examples/Example.QueryStoredProcedure.ps1
+++ b/Module/Examples/Example.QueryStoredProcedure.ps1
@@ -1,0 +1,5 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+
+Invoke-DbaXQuery -StoredProcedure "dbo.MyProcedure" -Server "SQL1" -Database "master"
+

--- a/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
@@ -18,6 +18,22 @@ describe 'Invoke-DbaXQuery cmdlet' {
         (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'Password'
     }
 
+    it 'fails when Server is empty' {
+        { Invoke-DbaXQuery -Server '' -Database db -Query 'SELECT 1' -ErrorAction Stop } | Should -Throw
+    }
+
+    it 'fails when Database is empty' {
+        { Invoke-DbaXQuery -Server s -Database '' -Query 'SELECT 1' -ErrorAction Stop } | Should -Throw
+    }
+
+    it 'fails when Query is empty' {
+        { Invoke-DbaXQuery -Server s -Database db -Query '' -ErrorAction Stop } | Should -Throw
+    }
+
+    it 'fails when StoredProcedure is empty' {
+        { Invoke-DbaXQuery -Server s -Database db -StoredProcedure '' -ErrorAction Stop } | Should -Throw
+    }
+
     it 'passes credentials to provider when supplied' {
         class TestSqlServer : DBAClientX.SqlServer {
             static [TestSqlServer] $Last


### PR DESCRIPTION
## Summary
- validate Server, Database, Query, and StoredProcedure parameters in Invoke-DbaXQuery
- test invalid input handling for Invoke-DbaXQuery
- add example of calling Invoke-DbaXQuery with a stored procedure

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test DbaClientX.sln`
- `pwsh -NoLogo -NoProfile Module/DbaClientX.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_689467ce7988832e9da6e8d4c9e6759e