### PR TITLE
Validate TableName in New-DbaXQuery

### DIFF
--- a/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
@@ -12,6 +12,7 @@ namespace DBAClientX.PowerShell;
 [CmdletBinding()]
 public sealed class CmdletNewDbaXQuery : PSCmdlet {
     [Parameter(Mandatory = true, Position = 0)]
+    [ValidateNotNullOrEmpty]
     public string TableName { get; set; }
 
     [Parameter(Mandatory = false)]

--- a/Module/Tests/CmdletNewDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletNewDbaXQuery.Tests.ps1
@@ -23,5 +23,13 @@ Describe 'New-DbaXQuery builder' {
     It 'Honors ErrorAction Stop for negative offset' {
         { New-DbaXQuery -TableName users -Compile -Offset -2 -ErrorAction Stop } | Should -Throw
     }
+
+    It 'Throws when TableName is empty' {
+        { New-DbaXQuery -TableName '' -Compile } | Should -Throw
+    }
+
+    It 'Throws when TableName is null' {
+        { New-DbaXQuery -TableName $null -Compile } | Should -Throw
+    }
 }
 


### PR DESCRIPTION
## Summary
- ensure `New-DbaXQuery` rejects empty or null `TableName`
- cover `TableName` validation in Pester tests

## Testing
- `dotnet build DbaClientX.PowerShell/DbaClientX.PowerShell.csproj`
- `pwsh Module/DbaClientX.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_689467c22f98832e91203fe251857d29