### PR TITLE
Add validation for Invoke-DbaXNonQuery parameters

### DIFF
--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
@@ -6,12 +6,15 @@ public sealed class CmdletIInvokeDbaXNonQuery : PSCmdlet {
     internal static Func<DBAClientX.SqlServer> SqlServerFactory { get; set; } = () => new DBAClientX.SqlServer();
     [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
     [Alias("DBServer", "SqlInstance", "Instance")]
+    [ValidateNotNullOrEmpty]
     public string Server { get; set; }
 
     [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
+    [ValidateNotNullOrEmpty]
     public string Database { get; set; }
 
     [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
+    [ValidateNotNullOrEmpty]
     public string Query { get; set; }
 
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]

--- a/Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1
@@ -37,4 +37,16 @@ Describe 'Invoke-DbaXNonQuery cmdlet' {
             $prop.SetValue($null, $orig)
         }
     }
+
+    It 'fails when Server is empty' {
+        { Invoke-DbaXNonQuery -Server '' -Database db -Query 'Q' } | Should -Throw
+    }
+
+    It 'fails when Database is empty' {
+        { Invoke-DbaXNonQuery -Server s -Database '' -Query 'Q' } | Should -Throw
+    }
+
+    It 'fails when Query is empty' {
+        { Invoke-DbaXNonQuery -Server s -Database db -Query '' } | Should -Throw
+    }
 }


### PR DESCRIPTION
## Summary
- ensure Invoke-DbaXNonQuery rejects empty Server, Database, and Query values
- test empty string handling for Invoke-DbaXNonQuery

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test DbaClientX.sln --no-build`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1"` *(fails: Unable to find type [DBAClientX.SqlServer])*

------
https://chatgpt.com/codex/tasks/task_e_689467de19a8832e82ee4729696aa610