### PR TITLE
Ensure thread-safe transaction lifecycle across providers

### DIFF
--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -221,43 +221,60 @@ public class SQLite : DatabaseClientBase
 
     public virtual void BeginTransaction(string database)
     {
-        if (_transaction != null)
+        lock (_syncRoot)
         {
-            throw new DbaTransactionException("Transaction already started.");
+            if (_transaction != null)
+            {
+                throw new DbaTransactionException("Transaction already started.");
+            }
+
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = database,
+                Pooling = true
+            }.ConnectionString;
+
+            _transactionConnection = new SqliteConnection(connectionString);
+            _transactionConnection.Open();
+            _transaction = _transactionConnection.BeginTransaction();
         }
-
-        var connectionString = new SqliteConnectionStringBuilder
-        {
-            DataSource = database,
-            Pooling = true
-        }.ConnectionString;
-
-        _transactionConnection = new SqliteConnection(connectionString);
-        _transactionConnection.Open();
-        _transaction = _transactionConnection.BeginTransaction();
     }
 
     public virtual void Commit()
     {
-        if (_transaction == null)
+        lock (_syncRoot)
         {
-            throw new DbaTransactionException("No active transaction.");
+            if (_transaction == null)
+            {
+                throw new DbaTransactionException("No active transaction.");
+            }
+            _transaction.Commit();
+            DisposeTransactionLocked();
         }
-        _transaction.Commit();
-        DisposeTransaction();
     }
 
     public virtual void Rollback()
     {
-        if (_transaction == null)
+        lock (_syncRoot)
         {
-            throw new DbaTransactionException("No active transaction.");
+            if (_transaction == null)
+            {
+                throw new DbaTransactionException("No active transaction.");
+            }
+            _transaction.Rollback();
+            DisposeTransactionLocked();
         }
-        _transaction.Rollback();
-        DisposeTransaction();
     }
 
     private void DisposeTransaction()
+    {
+        lock (_syncRoot)
+        {
+            DisposeTransactionLocked();
+        }
+    }
+
+    private void DisposeTransactionLocked()
     {
         _transaction?.Dispose();
         _transaction = null;

--- a/DbaClientX.Tests/SQLiteTransactionConcurrencyTests.cs
+++ b/DbaClientX.Tests/SQLiteTransactionConcurrencyTests.cs
@@ -1,0 +1,46 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class SQLiteTransactionConcurrencyTests
+{
+    [Fact]
+    public async Task CommitAndRollback_AreThreadSafe()
+    {
+        var sqlite = new DBAClientX.SQLite();
+        sqlite.BeginTransaction(":memory:");
+
+        bool commitThrows = false;
+        bool rollbackThrows = false;
+
+        var commitTask = Task.Run(() =>
+        {
+            try
+            {
+                sqlite.Commit();
+            }
+            catch (DBAClientX.DbaTransactionException)
+            {
+                commitThrows = true;
+            }
+        });
+
+        var rollbackTask = Task.Run(() =>
+        {
+            try
+            {
+                sqlite.Rollback();
+            }
+            catch (DBAClientX.DbaTransactionException)
+            {
+                rollbackThrows = true;
+            }
+        });
+
+        await Task.WhenAll(commitTask, rollbackTask);
+
+        Assert.True(commitThrows ^ rollbackThrows);
+        Assert.False(sqlite.IsInTransaction);
+    }
+}


### PR DESCRIPTION
## Summary
- synchronize transaction begin, commit, rollback and cleanup with `lock(_syncRoot)` for MySql, PostgreSql, SQLite and SqlServer providers
- add SQLite concurrency test to confirm transaction methods are thread-safe

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689467e3741c832eb89bda56149d90fc