### PR TITLE
Refactor provider connection string creation

### DIFF
--- a/DbaClientX.Examples/BuildConnectionStringExample.cs
+++ b/DbaClientX.Examples/BuildConnectionStringExample.cs
@@ -1,0 +1,16 @@
+using System;
+
+public static class BuildConnectionStringExample
+{
+    public static void Run()
+    {
+        var mysql = DBAClientX.MySql.BuildConnectionString("localhost", "mydb", "user", "password");
+        var postgres = DBAClientX.PostgreSql.BuildConnectionString("localhost", "mydb", "user", "password");
+        var sqlite = DBAClientX.SQLite.BuildConnectionString("data.db");
+        var sqlServer = DBAClientX.SqlServer.BuildConnectionString("SQL1", "master", true);
+        Console.WriteLine(mysql);
+        Console.WriteLine(postgres);
+        Console.WriteLine(sqlite);
+        Console.WriteLine(sqlServer);
+    }
+}

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -25,9 +25,9 @@ public class MySql : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public virtual object? Query(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    public static string BuildConnectionString(string host, string database, string username, string password)
     {
-        var connectionString = new MySqlConnectionStringBuilder
+        return new MySqlConnectionStringBuilder
         {
             Server = host,
             Database = database,
@@ -35,6 +35,11 @@ public class MySql : DatabaseClientBase
             Password = password,
             Pooling = true
         }.ConnectionString;
+    }
+
+    public virtual object? Query(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    {
+        var connectionString = BuildConnectionString(host, database, username, password);
 
         MySqlConnection? connection = null;
         bool dispose = false;
@@ -93,14 +98,7 @@ public class MySql : DatabaseClientBase
 
     public virtual int ExecuteNonQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
     {
-        var connectionString = new MySqlConnectionStringBuilder
-        {
-            Server = host,
-            Database = database,
-            UserID = username,
-            Password = password,
-            Pooling = true
-        }.ConnectionString;
+        var connectionString = BuildConnectionString(host, database, username, password);
 
         MySqlConnection? connection = null;
         bool dispose = false;
@@ -139,14 +137,7 @@ public class MySql : DatabaseClientBase
 
     public virtual async Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
     {
-        var connectionString = new MySqlConnectionStringBuilder
-        {
-            Server = host,
-            Database = database,
-            UserID = username,
-            Password = password,
-            Pooling = true
-        }.ConnectionString;
+        var connectionString = BuildConnectionString(host, database, username, password);
 
         MySqlConnection? connection = null;
         bool dispose = false;
@@ -192,14 +183,7 @@ public class MySql : DatabaseClientBase
                 throw new DbaTransactionException("Transaction already started.");
             }
 
-            var connectionString = new MySqlConnectionStringBuilder
-            {
-                Server = host,
-                Database = database,
-                UserID = username,
-                Password = password,
-                Pooling = true
-            }.ConnectionString;
+            var connectionString = BuildConnectionString(host, database, username, password);
 
             _transactionConnection = new MySqlConnection(connectionString);
             _transactionConnection.Open();

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -26,9 +26,9 @@ public class PostgreSql : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public virtual object? Query(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    public static string BuildConnectionString(string host, string database, string username, string password)
     {
-        var connectionString = new NpgsqlConnectionStringBuilder
+        return new NpgsqlConnectionStringBuilder
         {
             Host = host,
             Database = database,
@@ -36,6 +36,11 @@ public class PostgreSql : DatabaseClientBase
             Password = password,
             Pooling = true
         }.ConnectionString;
+    }
+
+    public virtual object? Query(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    {
+        var connectionString = BuildConnectionString(host, database, username, password);
 
         NpgsqlConnection? connection = null;
         bool dispose = false;
@@ -94,14 +99,7 @@ public class PostgreSql : DatabaseClientBase
 
     public virtual int ExecuteNonQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
     {
-        var connectionString = new NpgsqlConnectionStringBuilder
-        {
-            Host = host,
-            Database = database,
-            Username = username,
-            Password = password,
-            Pooling = true
-        }.ConnectionString;
+        var connectionString = BuildConnectionString(host, database, username, password);
 
         NpgsqlConnection? connection = null;
         bool dispose = false;
@@ -140,14 +138,7 @@ public class PostgreSql : DatabaseClientBase
 
     public virtual async Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
     {
-        var connectionString = new NpgsqlConnectionStringBuilder
-        {
-            Host = host,
-            Database = database,
-            Username = username,
-            Password = password,
-            Pooling = true
-        }.ConnectionString;
+        var connectionString = BuildConnectionString(host, database, username, password);
 
         NpgsqlConnection? connection = null;
         bool dispose = false;
@@ -213,14 +204,7 @@ public class PostgreSql : DatabaseClientBase
 
         async IAsyncEnumerable<DataRow> Stream()
         {
-            var connectionString = new NpgsqlConnectionStringBuilder
-            {
-                Host = host,
-                Database = database,
-                Username = username,
-                Password = password,
-                Pooling = true
-            }.ConnectionString;
+            var connectionString = BuildConnectionString(host, database, username, password);
 
             NpgsqlConnection? connection = null;
             bool dispose = false;
@@ -267,14 +251,7 @@ public class PostgreSql : DatabaseClientBase
                 throw new DbaTransactionException("Transaction already started.");
             }
 
-            var connectionString = new NpgsqlConnectionStringBuilder
-            {
-                Host = host,
-                Database = database,
-                Username = username,
-                Password = password,
-                Pooling = true
-            }.ConnectionString;
+            var connectionString = BuildConnectionString(host, database, username, password);
 
             _transactionConnection = new NpgsqlConnection(connectionString);
             _transactionConnection.Open();

--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -25,13 +25,18 @@ public class SQLite : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public virtual object? Query(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null)
+    public static string BuildConnectionString(string database)
     {
-        var connectionString = new SqliteConnectionStringBuilder
+        return new SqliteConnectionStringBuilder
         {
             DataSource = database,
             Pooling = true
         }.ConnectionString;
+    }
+
+    public virtual object? Query(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null)
+    {
+        var connectionString = BuildConnectionString(database);
 
         SqliteConnection? connection = null;
         bool dispose = false;
@@ -90,11 +95,7 @@ public class SQLite : DatabaseClientBase
 
     public virtual int ExecuteNonQuery(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null)
     {
-        var connectionString = new SqliteConnectionStringBuilder
-        {
-            DataSource = database,
-            Pooling = true
-        }.ConnectionString;
+        var connectionString = BuildConnectionString(database);
 
         SqliteConnection? connection = null;
         bool dispose = false;
@@ -133,11 +134,7 @@ public class SQLite : DatabaseClientBase
 
     public virtual async Task<object?> QueryAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null)
     {
-        var connectionString = new SqliteConnectionStringBuilder
-        {
-            DataSource = database,
-            Pooling = true
-        }.ConnectionString;
+        var connectionString = BuildConnectionString(database);
 
         SqliteConnection? connection = null;
         bool dispose = false;
@@ -177,11 +174,7 @@ public class SQLite : DatabaseClientBase
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
     public virtual async IAsyncEnumerable<DataRow> QueryStreamAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null)
     {
-        var connectionString = new SqliteConnectionStringBuilder
-        {
-            DataSource = database,
-            Pooling = true
-        }.ConnectionString;
+        var connectionString = BuildConnectionString(database);
 
         SqliteConnection? connection = null;
         bool dispose = false;
@@ -228,11 +221,7 @@ public class SQLite : DatabaseClientBase
                 throw new DbaTransactionException("Transaction already started.");
             }
 
-            var connectionString = new SqliteConnectionStringBuilder
-            {
-                DataSource = database,
-                Pooling = true
-            }.ConnectionString;
+            var connectionString = BuildConnectionString(database);
 
             _transactionConnection = new SqliteConnection(connectionString);
             _transactionConnection.Open();

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -24,7 +24,7 @@ public class SqlServer : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public virtual object? Query(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public static string BuildConnectionString(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null)
     {
         var connectionStringBuilder = new SqlConnectionStringBuilder
         {
@@ -38,7 +38,12 @@ public class SqlServer : DatabaseClientBase
             connectionStringBuilder.UserID = username;
             connectionStringBuilder.Password = password;
         }
-        var connectionString = connectionStringBuilder.ConnectionString;
+        return connectionStringBuilder.ConnectionString;
+    }
+
+    public virtual object? Query(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    {
+        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
         SqlConnection? connection = null;
         bool dispose = false;
@@ -97,19 +102,7 @@ public class SqlServer : DatabaseClientBase
 
     public virtual int ExecuteNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
-        var connectionStringBuilder = new SqlConnectionStringBuilder
-        {
-            DataSource = serverOrInstance,
-            InitialCatalog = database,
-            IntegratedSecurity = integratedSecurity,
-            Pooling = true
-        };
-        if (!integratedSecurity)
-        {
-            connectionStringBuilder.UserID = username;
-            connectionStringBuilder.Password = password;
-        }
-        var connectionString = connectionStringBuilder.ConnectionString;
+        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
         SqlConnection? connection = null;
         bool dispose = false;
@@ -148,19 +141,7 @@ public class SqlServer : DatabaseClientBase
 
     public virtual async Task<object?> QueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
     {
-        var connectionStringBuilder = new SqlConnectionStringBuilder
-        {
-            DataSource = serverOrInstance,
-            InitialCatalog = database,
-            IntegratedSecurity = integratedSecurity,
-            Pooling = true
-        };
-        if (!integratedSecurity)
-        {
-            connectionStringBuilder.UserID = username;
-            connectionStringBuilder.Password = password;
-        }
-        var connectionString = connectionStringBuilder.ConnectionString;
+        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
         SqlConnection? connection = null;
         bool dispose = false;
@@ -226,19 +207,7 @@ public class SqlServer : DatabaseClientBase
 
         async IAsyncEnumerable<DataRow> Stream()
         {
-            var connectionStringBuilder = new SqlConnectionStringBuilder
-            {
-                DataSource = serverOrInstance,
-                InitialCatalog = database,
-                IntegratedSecurity = integratedSecurity,
-                Pooling = true
-            };
-            if (!integratedSecurity)
-            {
-                connectionStringBuilder.UserID = username;
-                connectionStringBuilder.Password = password;
-            }
-            var connectionString = connectionStringBuilder.ConnectionString;
+            var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
             SqlConnection? connection = null;
             bool dispose = false;
@@ -286,19 +255,7 @@ public class SqlServer : DatabaseClientBase
                 throw new DbaTransactionException("Transaction already started.");
             }
 
-            var connectionStringBuilder = new SqlConnectionStringBuilder
-            {
-                DataSource = serverOrInstance,
-                InitialCatalog = database,
-                IntegratedSecurity = integratedSecurity,
-                Pooling = true
-            };
-            if (!integratedSecurity)
-            {
-                connectionStringBuilder.UserID = username;
-                connectionStringBuilder.Password = password;
-            }
-            var connectionString = connectionStringBuilder.ConnectionString;
+            var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
             _transactionConnection = new SqlConnection(connectionString);
             _transactionConnection.Open();
@@ -313,19 +270,7 @@ public class SqlServer : DatabaseClientBase
             throw new DbaTransactionException("Transaction already started.");
         }
 
-        var connectionStringBuilder = new SqlConnectionStringBuilder
-        {
-            DataSource = serverOrInstance,
-            InitialCatalog = database,
-            IntegratedSecurity = integratedSecurity,
-            Pooling = true
-        };
-        if (!integratedSecurity)
-        {
-            connectionStringBuilder.UserID = username;
-            connectionStringBuilder.Password = password;
-        }
-        var connectionString = connectionStringBuilder.ConnectionString;
+        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
         _transactionConnection = new SqlConnection(connectionString);
         await _transactionConnection.OpenAsync(cancellationToken).ConfigureAwait(false);

--- a/DbaClientX.Tests/ConnectionStringBuilderTests.cs
+++ b/DbaClientX.Tests/ConnectionStringBuilderTests.cs
@@ -1,0 +1,62 @@
+using System.Data.SqlClient;
+using Microsoft.Data.Sqlite;
+using MySqlConnector;
+using Npgsql;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class ConnectionStringBuilderTests
+{
+    [Fact]
+    public void MySql_BuildConnectionString_CreatesExpectedValues()
+    {
+        var cs = DBAClientX.MySql.BuildConnectionString("host", "db", "user", "pass");
+        var builder = new MySqlConnectionStringBuilder(cs);
+        Assert.Equal("host", builder.Server);
+        Assert.Equal("db", builder.Database);
+        Assert.Equal("user", builder.UserID);
+        Assert.Equal("pass", builder.Password);
+    }
+
+    [Fact]
+    public void PostgreSql_BuildConnectionString_CreatesExpectedValues()
+    {
+        var cs = DBAClientX.PostgreSql.BuildConnectionString("host", "db", "user", "pass");
+        var builder = new NpgsqlConnectionStringBuilder(cs);
+        Assert.Equal("host", builder.Host);
+        Assert.Equal("db", builder.Database);
+        Assert.Equal("user", builder.Username);
+        Assert.Equal("pass", builder.Password);
+    }
+
+    [Fact]
+    public void SQLite_BuildConnectionString_CreatesExpectedValues()
+    {
+        var cs = DBAClientX.SQLite.BuildConnectionString("data.db");
+        var builder = new SqliteConnectionStringBuilder(cs);
+        Assert.Equal("data.db", builder.DataSource);
+    }
+
+    [Fact]
+    public void SqlServer_BuildConnectionString_IntegratedSecurity()
+    {
+        var cs = DBAClientX.SqlServer.BuildConnectionString("srv", "db", true);
+        var builder = new SqlConnectionStringBuilder(cs);
+        Assert.Equal("srv", builder.DataSource);
+        Assert.Equal("db", builder.InitialCatalog);
+        Assert.True(builder.IntegratedSecurity);
+    }
+
+    [Fact]
+    public void SqlServer_BuildConnectionString_WithCredentials()
+    {
+        var cs = DBAClientX.SqlServer.BuildConnectionString("srv", "db", false, "user", "pass");
+        var builder = new SqlConnectionStringBuilder(cs);
+        Assert.Equal("srv", builder.DataSource);
+        Assert.Equal("db", builder.InitialCatalog);
+        Assert.False(builder.IntegratedSecurity);
+        Assert.Equal("user", builder.UserID);
+        Assert.Equal("pass", builder.Password);
+    }
+}


### PR DESCRIPTION
## Summary
- add BuildConnectionString helpers for MySql, PostgreSql, SQLite, and SqlServer providers
- replace inline connection string builder code with helper calls
- add unit tests and example demonstrating connection string construction

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68947279579c832ea4590aa62ed4bf86