### PR TITLE
Implement IDisposable pattern across database clients

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -10,11 +10,12 @@ using System.Runtime.CompilerServices;
 
 namespace DBAClientX;
 
-public abstract class DatabaseClientBase
+public abstract class DatabaseClientBase : IDisposable
 {
     private readonly object _syncRoot = new();
     private ReturnType _returnType;
     private int _commandTimeout;
+    private bool _disposed;
 
     public ReturnType ReturnType
     {
@@ -195,6 +196,21 @@ public abstract class DatabaseClientBase
             return dataSet;
         }
         return null;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+        _disposed = true;
     }
 }
 

--- a/DbaClientX.Examples/CancellationExample.cs
+++ b/DbaClientX.Examples/CancellationExample.cs
@@ -8,7 +8,7 @@ public static class CancellationExample
     public static async Task RunAsync()
     {
         using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
-        var sqlServer = new SqlServer();
+        using var sqlServer = new SqlServer();
         try
         {
             await sqlServer.QueryAsync("SQL1", "master", true, "WAITFOR DELAY '00:00:05'", cancellationToken: cts.Token);

--- a/DbaClientX.Examples/NonQueryExample.cs
+++ b/DbaClientX.Examples/NonQueryExample.cs
@@ -5,7 +5,7 @@ public static class NonQueryExample
 {
     public static void Run()
     {
-        var sqlServer = new DBAClientX.SqlServer();
+        using var sqlServer = new DBAClientX.SqlServer();
         var affected = sqlServer.ExecuteNonQuery("SQL1", "master", true, "CREATE TABLE #Example (Id INT)");
         Console.WriteLine($"Rows affected: {affected}");
     }

--- a/DbaClientX.Examples/ParallelQueriesExample.cs
+++ b/DbaClientX.Examples/ParallelQueriesExample.cs
@@ -15,7 +15,7 @@ public static class ParallelQueriesExample
             "SELECT TOP 1 * FROM sys.schemas"
         };
 
-        var sqlServer = new SqlServer
+        using var sqlServer = new SqlServer
         {
             ReturnType = ReturnType.DataTable,
         };

--- a/DbaClientX.Examples/QueryMySqlAsyncExample.cs
+++ b/DbaClientX.Examples/QueryMySqlAsyncExample.cs
@@ -6,7 +6,7 @@ public static class QueryMySqlAsyncExample
 {
     public static async Task RunAsync()
     {
-        var mySql = new MySql
+        using var mySql = new MySql
         {
             ReturnType = ReturnType.DataTable,
         };

--- a/DbaClientX.Examples/QueryPostgreSqlAsyncExample.cs
+++ b/DbaClientX.Examples/QueryPostgreSqlAsyncExample.cs
@@ -7,7 +7,7 @@ public static class QueryPostgreSqlAsyncExample
 {
     public static async Task RunAsync()
     {
-        var pg = new PostgreSql
+        using var pg = new PostgreSql
         {
             ReturnType = ReturnType.DataTable,
         };

--- a/DbaClientX.Examples/QuerySqlServerAsyncExample.cs
+++ b/DbaClientX.Examples/QuerySqlServerAsyncExample.cs
@@ -6,7 +6,7 @@ public static class QuerySqlServerAsyncExample
 {
     public static async Task RunAsync()
     {
-        var sqlServer = new SqlServer
+        using var sqlServer = new SqlServer
         {
             ReturnType = ReturnType.DataTable,
         };

--- a/DbaClientX.Examples/QuerySqliteExample.cs
+++ b/DbaClientX.Examples/QuerySqliteExample.cs
@@ -5,7 +5,7 @@ public static class QuerySqliteExample
 {
     public static void Run()
     {
-        var sqlite = new SQLite
+        using var sqlite = new SQLite
         {
             ReturnType = ReturnType.DataTable,
         };

--- a/DbaClientX.Examples/StoredProcedureExample.cs
+++ b/DbaClientX.Examples/StoredProcedureExample.cs
@@ -6,7 +6,7 @@ public static class StoredProcedureExample
 {
     public static void Run()
     {
-        var sqlServer = new SqlServer
+        using var sqlServer = new SqlServer
         {
             ReturnType = ReturnType.DataTable,
         };

--- a/DbaClientX.Examples/StoredProcedurePostgreSqlExample.cs
+++ b/DbaClientX.Examples/StoredProcedurePostgreSqlExample.cs
@@ -6,7 +6,7 @@ public static class StoredProcedurePostgreSqlExample
 {
     public static void Run()
     {
-        var pg = new PostgreSql
+        using var pg = new PostgreSql
         {
             ReturnType = ReturnType.DataTable,
         };

--- a/DbaClientX.Examples/StreamQueryExample.cs
+++ b/DbaClientX.Examples/StreamQueryExample.cs
@@ -6,7 +6,7 @@ public static class StreamQueryExample
 {
     public static async Task RunAsync()
     {
-        var sqlServer = new SqlServer
+        using var sqlServer = new SqlServer
         {
             ReturnType = ReturnType.DataRow
         };

--- a/DbaClientX.Examples/TransactionAsyncExample.cs
+++ b/DbaClientX.Examples/TransactionAsyncExample.cs
@@ -7,7 +7,7 @@ public static class TransactionAsyncExample
 {
     public static async Task RunAsync(CancellationToken cancellationToken = default)
     {
-        var sql = new SqlServer();
+        using var sql = new SqlServer();
         await sql.BeginTransactionAsync("SQL1", "master", true, cancellationToken);
         try
         {

--- a/DbaClientX.Examples/TransactionExample.cs
+++ b/DbaClientX.Examples/TransactionExample.cs
@@ -6,7 +6,7 @@ public static class TransactionExample
 {
     public static Task RunAsync()
     {
-        var sql = new SqlServer();
+        using var sql = new SqlServer();
         sql.BeginTransaction("SQL1", "master", true);
         try
         {

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -233,6 +233,15 @@ public class MySql : DatabaseClientBase
         _transactionConnection = null;
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            DisposeTransaction();
+        }
+        base.Dispose(disposing);
+    }
+
     public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string host, string database, string username, string password, CancellationToken cancellationToken = default)
     {
         if (queries == null)

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -301,6 +301,15 @@ public class PostgreSql : DatabaseClientBase
         _transactionConnection = null;
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            DisposeTransaction();
+        }
+        base.Dispose(disposing);
+    }
+
     public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string host, string database, string username, string password, CancellationToken cancellationToken = default)
     {
         if (queries == null)

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
@@ -42,7 +42,7 @@ public sealed class CmdletIInvokeDbaXNonQuery : PSCmdlet {
     }
 
     protected override void ProcessRecord() {
-        var sqlServer = SqlServerFactory();
+        using var sqlServer = SqlServerFactory();
         sqlServer.CommandTimeout = QueryTimeout;
         var integratedSecurity = string.IsNullOrEmpty(Username) && string.IsNullOrEmpty(Password);
         try {

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -71,7 +71,7 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
     /// Process method for PowerShell cmdlet
     /// </summary>
     protected override async Task ProcessRecordAsync() {
-        var sqlServer = SqlServerFactory();
+        using var sqlServer = SqlServerFactory();
         sqlServer.ReturnType = ReturnType;
         sqlServer.CommandTimeout = QueryTimeout;
         var integratedSecurity = string.IsNullOrEmpty(Username) && string.IsNullOrEmpty(Password);

--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -271,6 +271,15 @@ public class SQLite : DatabaseClientBase
         _transactionConnection = null;
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            DisposeTransaction();
+        }
+        base.Dispose(disposing);
+    }
+
     public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string database, CancellationToken cancellationToken = default)
     {
         if (queries == null)

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -351,6 +351,15 @@ public class SqlServer : DatabaseClientBase
         _transactionConnection = null;
     }
 
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            DisposeTransaction();
+        }
+        base.Dispose(disposing);
+    }
+
     public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null)
     {
         if (queries == null)

--- a/DbaClientX.Tests/InferDbTypeTests.cs
+++ b/DbaClientX.Tests/InferDbTypeTests.cs
@@ -18,7 +18,7 @@ public class InferDbTypeTests
     [Fact]
     public void AddParameters_InfersGuidType()
     {
-        var client = new TestClient();
+        using var client = new TestClient();
         using var command = new SqlCommand();
         var guid = Guid.NewGuid();
         client.InvokeAddParameters(command, new Dictionary<string, object?> { ["@id"] = guid });
@@ -30,7 +30,7 @@ public class InferDbTypeTests
     [Fact]
     public void AddParameters_InfersBinaryType()
     {
-        var client = new TestClient();
+        using var client = new TestClient();
         using var command = new SqlCommand();
         var bytes = new byte[] { 1, 2, 3 };
         client.InvokeAddParameters(command, new Dictionary<string, object?> { ["@data"] = bytes });

--- a/DbaClientX.Tests/MySqlTests.cs
+++ b/DbaClientX.Tests/MySqlTests.cs
@@ -15,7 +15,7 @@ public class MySqlTests
     [Fact]
     public async Task QueryAsync_InvalidServer_ThrowsDbaQueryExecutionException()
     {
-        var mySql = new DBAClientX.MySql();
+        using var mySql = new DBAClientX.MySql();
         var ex = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(async () =>
         {
             await mySql.QueryAsync("invalid", "mysql", "user", "pass", "SELECT 1");
@@ -43,7 +43,7 @@ public class MySqlTests
     public async Task RunQueriesInParallel_ExecutesConcurrently()
     {
         var queries = Enumerable.Repeat("SELECT 1", 3).ToArray();
-        var mySql = new DelayMySql(TimeSpan.FromMilliseconds(200));
+        using var mySql = new DelayMySql(TimeSpan.FromMilliseconds(200));
 
         var sequential = Stopwatch.StartNew();
         foreach (var query in queries)
@@ -62,7 +62,7 @@ public class MySqlTests
     [Fact]
     public async Task QueryAsync_CanBeCancelled()
     {
-        var mySql = new DelayMySql(TimeSpan.FromSeconds(5));
+        using var mySql = new DelayMySql(TimeSpan.FromSeconds(5));
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
@@ -73,7 +73,7 @@ public class MySqlTests
     [Fact]
     public async Task RunQueriesInParallel_ForwardsCancellation()
     {
-        var mySql = new DelayMySql(TimeSpan.FromSeconds(5));
+        using var mySql = new DelayMySql(TimeSpan.FromSeconds(5));
         var queries = new[] { "q1", "q2" };
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
@@ -119,7 +119,7 @@ public class MySqlTests
     [Fact]
     public async Task QueryAsync_BindsParameters()
     {
-        var mySql = new CaptureParametersMySql();
+        using var mySql = new CaptureParametersMySql();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 5,
@@ -135,7 +135,7 @@ public class MySqlTests
     [Fact]
     public async Task QueryAsync_PreservesParameterTypes()
     {
-        var mySql = new CaptureParametersMySql();
+        using var mySql = new CaptureParametersMySql();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 5,
@@ -189,14 +189,14 @@ public class MySqlTests
     [Fact]
     public void Query_WithTransactionNotStarted_Throws()
     {
-        var mySql = new FakeTransactionMySql();
+        using var mySql = new FakeTransactionMySql();
         Assert.Throws<DBAClientX.DbaTransactionException>(() => mySql.Query("h", "d", "u", "p", "q", null, true));
     }
 
     [Fact]
     public void Commit_EndsTransaction()
     {
-        var mySql = new FakeTransactionMySql();
+        using var mySql = new FakeTransactionMySql();
         mySql.BeginTransaction("h", "d", "u", "p");
         mySql.Commit();
         Assert.Throws<DBAClientX.DbaTransactionException>(() => mySql.Query("h", "d", "u", "p", "q", null, true));
@@ -205,7 +205,7 @@ public class MySqlTests
     [Fact]
     public void Rollback_EndsTransaction()
     {
-        var mySql = new FakeTransactionMySql();
+        using var mySql = new FakeTransactionMySql();
         mySql.BeginTransaction("h", "d", "u", "p");
         mySql.Rollback();
         Assert.Throws<DBAClientX.DbaTransactionException>(() => mySql.Query("h", "d", "u", "p", "q", null, true));
@@ -214,7 +214,7 @@ public class MySqlTests
     [Fact]
     public void Query_UsesTransaction_WhenStarted()
     {
-        var mySql = new FakeTransactionMySql();
+        using var mySql = new FakeTransactionMySql();
         mySql.BeginTransaction("h", "d", "u", "p");
         var ex = Record.Exception(() => mySql.Query("h", "d", "u", "p", "q", null, true));
         Assert.Null(ex);

--- a/DbaClientX.Tests/ParallelQueriesTests.cs
+++ b/DbaClientX.Tests/ParallelQueriesTests.cs
@@ -35,7 +35,7 @@ public class ParallelQueriesTests
             ["q3"] = 3
         };
 
-        var sqlServer = new MockSqlServer(mapping);
+        using var sqlServer = new MockSqlServer(mapping);
         var results = await sqlServer.RunQueriesInParallel(queries, "s", "db", true, CancellationToken.None);
 
         Assert.Equal(new object?[] { 1, 2, 3 }, results);

--- a/DbaClientX.Tests/PostgreSqlTests.cs
+++ b/DbaClientX.Tests/PostgreSqlTests.cs
@@ -17,7 +17,7 @@ public class PostgreSqlTests
     [Fact]
     public async Task QueryAsync_InvalidServer_ThrowsDbaQueryExecutionException()
     {
-        var pg = new DBAClientX.PostgreSql();
+        using var pg = new DBAClientX.PostgreSql();
         var ex = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(async () =>
         {
             await pg.QueryAsync("invalid", "postgres", "user", "pass", "SELECT 1");
@@ -45,7 +45,7 @@ public class PostgreSqlTests
     public async Task RunQueriesInParallel_ExecutesConcurrently()
     {
         var queries = Enumerable.Repeat("SELECT 1", 3).ToArray();
-        var pg = new DelayPostgreSql(TimeSpan.FromMilliseconds(200));
+        using var pg = new DelayPostgreSql(TimeSpan.FromMilliseconds(200));
 
         var sequential = Stopwatch.StartNew();
         foreach (var query in queries)
@@ -64,7 +64,7 @@ public class PostgreSqlTests
     [Fact]
     public async Task QueryAsync_CanBeCancelled()
     {
-        var pg = new DelayPostgreSql(TimeSpan.FromSeconds(5));
+        using var pg = new DelayPostgreSql(TimeSpan.FromSeconds(5));
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
@@ -75,7 +75,7 @@ public class PostgreSqlTests
     [Fact]
     public async Task RunQueriesInParallel_ForwardsCancellation()
     {
-        var pg = new DelayPostgreSql(TimeSpan.FromSeconds(5));
+        using var pg = new DelayPostgreSql(TimeSpan.FromSeconds(5));
         var queries = new[] { "q1", "q2" };
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
@@ -121,7 +121,7 @@ public class PostgreSqlTests
     [Fact]
     public async Task QueryAsync_BindsParameters()
     {
-        var pg = new CaptureParametersPostgreSql();
+        using var pg = new CaptureParametersPostgreSql();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 5,
@@ -137,7 +137,7 @@ public class PostgreSqlTests
     [Fact]
     public async Task QueryAsync_PreservesParameterTypes()
     {
-        var pg = new CaptureParametersPostgreSql();
+        using var pg = new CaptureParametersPostgreSql();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 5,
@@ -178,7 +178,7 @@ public class PostgreSqlTests
     [Fact]
     public void ExecuteStoredProcedure_BuildsCallStatement()
     {
-        var pg = new CaptureStoredProcPostgreSql();
+        using var pg = new CaptureStoredProcPostgreSql();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 1,
@@ -191,7 +191,7 @@ public class PostgreSqlTests
     [Fact]
     public async Task ExecuteStoredProcedureAsync_BuildsCallStatement()
     {
-        var pg = new CaptureStoredProcPostgreSql();
+        using var pg = new CaptureStoredProcPostgreSql();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 1
@@ -203,7 +203,7 @@ public class PostgreSqlTests
     [Fact]
     public void ExecuteStoredProcedure_NoParameters_AddsEmptyParentheses()
     {
-        var pg = new CaptureStoredProcPostgreSql();
+        using var pg = new CaptureStoredProcPostgreSql();
         pg.ExecuteStoredProcedure("h", "d", "u", "p", "sp_test", null);
         Assert.Equal("CALL sp_test()", pg.CapturedQuery);
     }

--- a/DbaClientX.Tests/SQLiteTransactionConcurrencyTests.cs
+++ b/DbaClientX.Tests/SQLiteTransactionConcurrencyTests.cs
@@ -8,7 +8,7 @@ public class SQLiteTransactionConcurrencyTests
     [Fact]
     public async Task CommitAndRollback_AreThreadSafe()
     {
-        var sqlite = new DBAClientX.SQLite();
+        using var sqlite = new DBAClientX.SQLite();
         sqlite.BeginTransaction(":memory:");
 
         bool commitThrows = false;

--- a/DbaClientX.Tests/SqlQueryStreamTests.cs
+++ b/DbaClientX.Tests/SqlQueryStreamTests.cs
@@ -43,7 +43,7 @@ public class QueryStreamTests
     [Fact]
     public async Task QueryStreamAsync_EnumeratesRows()
     {
-        var server = new DummySqlServer();
+        using var server = new DummySqlServer();
         var list = new List<int>();
 
         await foreach (DataRow row in server.QueryStreamAsync("s", "d", true, "q"))

--- a/DbaClientX.Tests/SqlServerNonQueryTests.cs
+++ b/DbaClientX.Tests/SqlServerNonQueryTests.cs
@@ -41,7 +41,7 @@ public class SqlServerNonQueryTests
     [Fact]
     public void ExecuteNonQuery_BindsParameters()
     {
-        var sqlServer = new CaptureParametersSqlServer();
+        using var sqlServer = new CaptureParametersSqlServer();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 5,
@@ -57,7 +57,7 @@ public class SqlServerNonQueryTests
     [Fact]
     public void ExecuteNonQuery_PreservesParameterTypes()
     {
-        var sqlServer = new CaptureParametersSqlServer();
+        using var sqlServer = new CaptureParametersSqlServer();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 5,
@@ -106,14 +106,14 @@ public class SqlServerNonQueryTests
     [Fact]
     public void ExecuteNonQuery_WithTransactionNotStarted_Throws()
     {
-        var sqlServer = new FakeTransactionSqlServer();
+        using var sqlServer = new FakeTransactionSqlServer();
         Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlServer.ExecuteNonQuery("s", "db", true, "q", useTransaction: true));
     }
 
     [Fact]
     public void ExecuteNonQuery_UsesTransaction_WhenStarted()
     {
-        var sqlServer = new FakeTransactionSqlServer();
+        using var sqlServer = new FakeTransactionSqlServer();
         sqlServer.BeginTransaction("s", "db", true);
         var ex = Record.Exception(() => sqlServer.ExecuteNonQuery("s", "db", true, "q", useTransaction: true));
         Assert.Null(ex);

--- a/DbaClientX.Tests/SqlServerTests.cs
+++ b/DbaClientX.Tests/SqlServerTests.cs
@@ -16,7 +16,7 @@ public class SqlServerTests
     [Fact]
     public async Task QueryAsync_InvalidServer_ThrowsDbaQueryExecutionException()
     {
-        var sqlServer = new DBAClientX.SqlServer();
+        using var sqlServer = new DBAClientX.SqlServer();
         var ex = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(async () =>
         {
             await sqlServer.QueryAsync("invalid", "master", true, "SELECT 1");
@@ -44,7 +44,7 @@ public class SqlServerTests
     public async Task RunQueriesInParallel_ExecutesConcurrently()
     {
         var queries = Enumerable.Repeat("SELECT 1", 3).ToArray();
-        var sqlServer = new DelaySqlServer(TimeSpan.FromMilliseconds(200));
+        using var sqlServer = new DelaySqlServer(TimeSpan.FromMilliseconds(200));
 
         var sequential = Stopwatch.StartNew();
         foreach (var query in queries)
@@ -63,7 +63,7 @@ public class SqlServerTests
     [Fact]
     public async Task QueryAsync_CanBeCancelled()
     {
-        var sqlServer = new DelaySqlServer(TimeSpan.FromSeconds(5));
+        using var sqlServer = new DelaySqlServer(TimeSpan.FromSeconds(5));
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
@@ -74,7 +74,7 @@ public class SqlServerTests
     [Fact]
     public async Task RunQueriesInParallel_ForwardsCancellation()
     {
-        var sqlServer = new DelaySqlServer(TimeSpan.FromSeconds(5));
+        using var sqlServer = new DelaySqlServer(TimeSpan.FromSeconds(5));
         var queries = new[] { "q1", "q2" };
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
@@ -120,7 +120,7 @@ public class SqlServerTests
     [Fact]
     public async Task QueryAsync_BindsParameters()
     {
-        var sqlServer = new CaptureParametersSqlServer();
+        using var sqlServer = new CaptureParametersSqlServer();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 5,
@@ -136,7 +136,7 @@ public class SqlServerTests
     [Fact]
     public async Task QueryAsync_PreservesParameterTypes()
     {
-        var sqlServer = new CaptureParametersSqlServer();
+        using var sqlServer = new CaptureParametersSqlServer();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 5,
@@ -177,7 +177,7 @@ public class SqlServerTests
     [Fact]
     public void ExecuteStoredProcedure_BuildsExecStatement()
     {
-        var sqlServer = new CaptureStoredProcSqlServer();
+        using var sqlServer = new CaptureStoredProcSqlServer();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 1,
@@ -190,7 +190,7 @@ public class SqlServerTests
     [Fact]
     public async Task ExecuteStoredProcedureAsync_BuildsExecStatement()
     {
-        var sqlServer = new CaptureStoredProcSqlServer();
+        using var sqlServer = new CaptureStoredProcSqlServer();
         var parameters = new Dictionary<string, object?>
         {
             ["@id"] = 1
@@ -235,14 +235,14 @@ public class SqlServerTests
     [Fact]
     public void Query_WithTransactionNotStarted_Throws()
     {
-        var sqlServer = new FakeTransactionSqlServer();
+        using var sqlServer = new FakeTransactionSqlServer();
         Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlServer.Query("s", "db", true, "q", null, true));
     }
 
     [Fact]
     public void Commit_EndsTransaction()
     {
-        var sqlServer = new FakeTransactionSqlServer();
+        using var sqlServer = new FakeTransactionSqlServer();
         sqlServer.BeginTransaction("s", "db", true);
         sqlServer.Commit();
         Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlServer.Query("s", "db", true, "q", null, true));
@@ -251,7 +251,7 @@ public class SqlServerTests
     [Fact]
     public void Rollback_EndsTransaction()
     {
-        var sqlServer = new FakeTransactionSqlServer();
+        using var sqlServer = new FakeTransactionSqlServer();
         sqlServer.BeginTransaction("s", "db", true);
         sqlServer.Rollback();
         Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlServer.Query("s", "db", true, "q", null, true));
@@ -260,7 +260,7 @@ public class SqlServerTests
     [Fact]
     public void Query_UsesTransaction_WhenStarted()
     {
-        var sqlServer = new FakeTransactionSqlServer();
+        using var sqlServer = new FakeTransactionSqlServer();
         sqlServer.BeginTransaction("s", "db", true);
         var ex = Record.Exception(() => sqlServer.Query("s", "db", true, "q", null, true));
         Assert.Null(ex);
@@ -273,7 +273,7 @@ public class SqlServerTests
     [Fact]
     public void BuildResult_ReturnsDataTable_ForDataTableReturnType()
     {
-        var client = new TestClient { ReturnType = DBAClientX.ReturnType.DataTable };
+        using var client = new TestClient { ReturnType = DBAClientX.ReturnType.DataTable };
         var ds = new DataSet();
         var table = new DataTable();
         table.Columns.Add("id", typeof(int));
@@ -291,7 +291,7 @@ public class SqlServerTests
     [Fact]
     public void BuildResult_ReturnsDataRow_ForDataRowReturnType()
     {
-        var client = new TestClient { ReturnType = DBAClientX.ReturnType.DataRow };
+        using var client = new TestClient { ReturnType = DBAClientX.ReturnType.DataRow };
         var ds = new DataSet();
         var table = new DataTable();
         table.Columns.Add("id", typeof(int));

--- a/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
@@ -85,7 +85,7 @@ public class SqlServerTransactionAsyncTests
     [Fact]
     public async Task BeginTransactionAsync_UsesConnection()
     {
-        var server = new TestSqlServer();
+        using var server = new TestSqlServer();
         await server.BeginTransactionAsync("s", "db", true);
         Assert.NotNull(server.Connection);
         Assert.True(server.Connection!.BeginCalled);
@@ -95,7 +95,7 @@ public class SqlServerTransactionAsyncTests
     [Fact]
     public async Task CommitAsync_CallsCommitOnTransaction()
     {
-        var server = new TestSqlServer();
+        using var server = new TestSqlServer();
         await server.BeginTransactionAsync("s", "db", true);
         var txn = server.Transaction!;
         await server.CommitAsync();
@@ -106,7 +106,7 @@ public class SqlServerTransactionAsyncTests
     [Fact]
     public async Task RollbackAsync_CallsRollbackOnTransaction()
     {
-        var server = new TestSqlServer();
+        using var server = new TestSqlServer();
         await server.BeginTransactionAsync("s", "db", true);
         var txn = server.Transaction!;
         await server.RollbackAsync();

--- a/DbaClientX.Tests/SqlServerTransactionTests.cs
+++ b/DbaClientX.Tests/SqlServerTransactionTests.cs
@@ -74,7 +74,7 @@ public class SqlServerTransactionTests
     [Fact]
     public void BeginTransaction_UsesConnection()
     {
-        var server = new TestSqlServer();
+        using var server = new TestSqlServer();
         server.BeginTransaction("s", "db", true);
         Assert.NotNull(server.Connection);
         Assert.True(server.Connection!.BeginCalled);
@@ -84,7 +84,7 @@ public class SqlServerTransactionTests
     [Fact]
     public void Commit_CallsCommitOnTransaction()
     {
-        var server = new TestSqlServer();
+        using var server = new TestSqlServer();
         server.BeginTransaction("s", "db", true);
         var txn = server.Transaction!;
         server.Commit();
@@ -95,7 +95,7 @@ public class SqlServerTransactionTests
     [Fact]
     public void Rollback_CallsRollbackOnTransaction()
     {
-        var server = new TestSqlServer();
+        using var server = new TestSqlServer();
         server.BeginTransaction("s", "db", true);
         var txn = server.Transaction!;
         server.Rollback();

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -14,7 +14,7 @@ public class SqliteTests
         var path = Path.GetTempFileName();
         try
         {
-            var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
+            using var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
             sqlite.ExecuteNonQuery(path, "CREATE TABLE t(id INTEGER);");
             sqlite.ExecuteNonQuery(path, "INSERT INTO t(id) VALUES (1);");
             var result = sqlite.Query(path, "SELECT id FROM t;");
@@ -34,7 +34,7 @@ public class SqliteTests
         var path = Path.GetTempFileName();
         try
         {
-            var sqlite = new DBAClientX.SQLite();
+            using var sqlite = new DBAClientX.SQLite();
             var ex = Assert.Throws<DBAClientX.DbaQueryExecutionException>(() => sqlite.Query(path, "SELECT 1", useTransaction: true));
             Assert.IsType<DBAClientX.DbaTransactionException>(ex.InnerException);
         }
@@ -50,7 +50,7 @@ public class SqliteTests
         var path = Path.GetTempFileName();
         try
         {
-            var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
+            using var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
             sqlite.ExecuteNonQuery(path, "CREATE TABLE t(id INTEGER);");
             sqlite.BeginTransaction(path);
             sqlite.ExecuteNonQuery(path, "INSERT INTO t(id) VALUES (1);", useTransaction: true);
@@ -72,7 +72,7 @@ public class SqliteTests
         var path = Path.GetTempFileName();
         try
         {
-            var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
+            using var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
             sqlite.ExecuteNonQuery(path, "CREATE TABLE t(id INTEGER);");
             sqlite.BeginTransaction(path);
             sqlite.ExecuteNonQuery(path, "INSERT INTO t(id) VALUES (1);", useTransaction: true);
@@ -85,6 +85,16 @@ public class SqliteTests
         {
             Cleanup(path);
         }
+    }
+
+    [Fact]
+    public void Dispose_EndsTransaction()
+    {
+        var sqlite = new DBAClientX.SQLite();
+        sqlite.BeginTransaction(":memory:");
+        Assert.True(sqlite.IsInTransaction);
+        sqlite.Dispose();
+        Assert.False(sqlite.IsInTransaction);
     }
 
     private static void Cleanup(string path)


### PR DESCRIPTION
## Summary
- implement `IDisposable` in `DatabaseClientBase` and dispose transactions in derived clients
- adopt using-pattern in examples, tests, and PowerShell cmdlets
- add test ensuring disposal ends active SQLite transaction

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689479e9c0dc832e9d8de01d3ed95f3d