### PR TITLE
Validate grouped where clauses

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -23,6 +23,7 @@ public class Query
     private int? _offset;
     private bool _useTop;
     private readonly List<(string Type, Query Query)> _compoundQueries = new();
+    private int _openGroups;
 
     public Query Select(params string[] columns)
     {
@@ -204,12 +205,18 @@ public class Query
     {
         AddDefaultAndIfRequired();
         _where.Add(new GroupStartToken());
+        _openGroups++;
         return this;
     }
 
     public Query EndGroup()
     {
+        if (_openGroups == 0)
+        {
+            throw new InvalidOperationException("EndGroup called without a matching BeginGroup.");
+        }
         _where.Add(new GroupEndToken());
+        _openGroups--;
         return this;
     }
 
@@ -511,6 +518,7 @@ public class Query
     public int? LimitValue => _limit;
     public int? OffsetValue => _offset;
     public bool UseTop => _useTop;
+    public int OpenGroups => _openGroups;
 }
 
 public interface IWhereToken { }

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -18,6 +19,10 @@ public class QueryCompiler
 
     private string CompileInternal(Query query, List<object>? parameters)
     {
+        if (query.OpenGroups != 0)
+        {
+            throw new InvalidOperationException("Unbalanced groupings: some groups have not been closed.");
+        }
         var sb = new StringBuilder();
 
         if (!string.IsNullOrWhiteSpace(query.InsertTable))

--- a/DbaClientX.Examples/GroupExample.cs
+++ b/DbaClientX.Examples/GroupExample.cs
@@ -1,0 +1,18 @@
+using DBAClientX.QueryBuilder;
+
+public static class GroupExample
+{
+    public static void Run()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .BeginGroup()
+                .Where("age", "<", 18)
+                .OrWhere("age", ">", 60)
+            .EndGroup()
+            .Where("active", true);
+
+        Console.WriteLine(QueryBuilder.Compile(query));
+    }
+}

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -383,6 +383,28 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void EndGroupWithoutBegin_Throws()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users");
+
+        Assert.Throws<InvalidOperationException>(() => query.EndGroup());
+    }
+
+    [Fact]
+    public void UnclosedGroup_ThrowsOnCompile()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .BeginGroup()
+            .Where("age", "<", 18);
+
+        Assert.Throws<InvalidOperationException>(() => QueryBuilder.Compile(query));
+    }
+
+    [Fact]
     public void JoinQueries()
     {
         var query = new Query()


### PR DESCRIPTION
## Summary
- ensure `EndGroup` can only be used after a matching `BeginGroup`
- detect unclosed `BeginGroup` calls during query compilation
- add query builder tests and example for grouped conditions

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test DbaClientX.Tests/DbaClientX.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68947fae7618832e91feeff5a32fcb16