### PR TITLE
Apply ConfigureAwait to asynchronous operations

### DIFF
--- a/DbaClientX.Examples/CancellationExample.cs
+++ b/DbaClientX.Examples/CancellationExample.cs
@@ -11,7 +11,7 @@ public static class CancellationExample
         using var sqlServer = new SqlServer();
         try
         {
-            await sqlServer.QueryAsync("SQL1", "master", true, "WAITFOR DELAY '00:00:05'", cancellationToken: cts.Token);
+            await sqlServer.QueryAsync("SQL1", "master", true, "WAITFOR DELAY '00:00:05'", cancellationToken: cts.Token).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {

--- a/DbaClientX.Examples/ParallelQueriesExample.cs
+++ b/DbaClientX.Examples/ParallelQueriesExample.cs
@@ -20,7 +20,7 @@ public static class ParallelQueriesExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var results = await sqlServer.RunQueriesInParallel(queries, "SQL1", "master", true, CancellationToken.None);
+        var results = await sqlServer.RunQueriesInParallel(queries, "SQL1", "master", true, CancellationToken.None).ConfigureAwait(false);
 
         var index = 0;
         foreach (var result in results)

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -8,28 +8,28 @@ public class Program
         switch (example)
         {
             case "asyncquery":
-                await QuerySqlServerAsyncExample.RunAsync();
+                await QuerySqlServerAsyncExample.RunAsync().ConfigureAwait(false);
                 break;
             case "pgasyncquery":
-                await QueryPostgreSqlAsyncExample.RunAsync();
+                await QueryPostgreSqlAsyncExample.RunAsync().ConfigureAwait(false);
                 break;
             case "mysqlasyncquery":
-                await QueryMySqlAsyncExample.RunAsync();
+                await QueryMySqlAsyncExample.RunAsync().ConfigureAwait(false);
                 break;
             case "nestedquery":
                 NestedQueryExample.Run();
                 break;
             case "parallelqueries":
-                await ParallelQueriesExample.RunAsync();
+                await ParallelQueriesExample.RunAsync().ConfigureAwait(false);
                 break;
             case "transaction":
-                await TransactionExample.RunAsync();
+                await TransactionExample.RunAsync().ConfigureAwait(false);
                 break;
             case "cancellation":
-                await CancellationExample.RunAsync();
+                await CancellationExample.RunAsync().ConfigureAwait(false);
                 break;
             case "streamquery":
-                await StreamQueryExample.RunAsync();
+                await StreamQueryExample.RunAsync().ConfigureAwait(false);
                 break;
             case "orderby":
                 OrderByExample.Run();

--- a/DbaClientX.Examples/QueryMySqlAsyncExample.cs
+++ b/DbaClientX.Examples/QueryMySqlAsyncExample.cs
@@ -11,7 +11,7 @@ public static class QueryMySqlAsyncExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var result = await mySql.QueryAsync("MYSQL1", "mysql", "user", "password", "SELECT 1", cancellationToken: CancellationToken.None);
+        var result = await mySql.QueryAsync("MYSQL1", "mysql", "user", "password", "SELECT 1", cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
         if (result is DataTable table)
         {

--- a/DbaClientX.Examples/QueryPostgreSqlAsyncExample.cs
+++ b/DbaClientX.Examples/QueryPostgreSqlAsyncExample.cs
@@ -12,7 +12,7 @@ public static class QueryPostgreSqlAsyncExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var result = await pg.QueryAsync("localhost", "postgres", "user", "password", "SELECT 1", cancellationToken: CancellationToken.None);
+        var result = await pg.QueryAsync("localhost", "postgres", "user", "password", "SELECT 1", cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
         if (result is DataTable table)
         {

--- a/DbaClientX.Examples/QuerySqlServerAsyncExample.cs
+++ b/DbaClientX.Examples/QuerySqlServerAsyncExample.cs
@@ -11,7 +11,7 @@ public static class QuerySqlServerAsyncExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var result = await sqlServer.QueryAsync("SQL1", "master", true, "SELECT TOP 1 * FROM sys.databases", cancellationToken: CancellationToken.None);
+        var result = await sqlServer.QueryAsync("SQL1", "master", true, "SELECT TOP 1 * FROM sys.databases", cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
         if (result is DataTable table)
         {

--- a/DbaClientX.Examples/StreamQueryExample.cs
+++ b/DbaClientX.Examples/StreamQueryExample.cs
@@ -11,7 +11,7 @@ public static class StreamQueryExample
             ReturnType = ReturnType.DataRow
         };
 
-        await foreach (DataRow row in sqlServer.QueryStreamAsync("SQL1", "master", true, "SELECT TOP 5 * FROM sys.databases", cancellationToken: CancellationToken.None))
+        await foreach (DataRow row in sqlServer.QueryStreamAsync("SQL1", "master", true, "SELECT TOP 5 * FROM sys.databases", cancellationToken: CancellationToken.None).ConfigureAwait(false))
         {
             foreach (DataColumn col in row.Table.Columns)
             {

--- a/DbaClientX.Examples/TransactionAsyncExample.cs
+++ b/DbaClientX.Examples/TransactionAsyncExample.cs
@@ -8,16 +8,16 @@ public static class TransactionAsyncExample
     public static async Task RunAsync(CancellationToken cancellationToken = default)
     {
         using var sql = new SqlServer();
-        await sql.BeginTransactionAsync("SQL1", "master", true, cancellationToken);
+        await sql.BeginTransactionAsync("SQL1", "master", true, cancellationToken).ConfigureAwait(false);
         try
         {
-            await sql.QueryAsync("SQL1", "master", true, "CREATE TABLE #temp(id int)", null, true, cancellationToken);
-            await sql.CommitAsync(cancellationToken);
+            await sql.QueryAsync("SQL1", "master", true, "CREATE TABLE #temp(id int)", null, true, cancellationToken).ConfigureAwait(false);
+            await sql.CommitAsync(cancellationToken).ConfigureAwait(false);
             Console.WriteLine("Committed");
         }
         catch
         {
-            await sql.RollbackAsync(cancellationToken);
+            await sql.RollbackAsync(cancellationToken).ConfigureAwait(false);
             Console.WriteLine("Rolled back");
         }
     }

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -92,14 +92,14 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
                 switch (ReturnType)
                 {
                     case ReturnType.DataRow:
-                        await foreach (var row in enumerable)
+                        await foreach (var row in enumerable.ConfigureAwait(false))
                         {
                             WriteObject(row);
                         }
                         break;
                     case ReturnType.DataTable:
                         DataTable? table = null;
-                        await foreach (var row in enumerable)
+                        await foreach (var row in enumerable.ConfigureAwait(false))
                         {
                             table ??= row.Table.Clone();
                             table.ImportRow(row);
@@ -111,7 +111,7 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
                         break;
                     case ReturnType.DataSet:
                         DataTable? dataTable = null;
-                        await foreach (var row in enumerable)
+                        await foreach (var row in enumerable.ConfigureAwait(false))
                         {
                             dataTable ??= row.Table.Clone();
                             dataTable.ImportRow(row);
@@ -124,7 +124,7 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
                         WriteObject(set);
                         break;
                     default:
-                        await foreach (var row in enumerable)
+                        await foreach (var row in enumerable.ConfigureAwait(false))
                         {
                             WriteObject(DataRowToPSObject(row));
                         }

--- a/DbaClientX.PowerShell/Communication/AsyncPSCmdlet.cs
+++ b/DbaClientX.PowerShell/Communication/AsyncPSCmdlet.cs
@@ -87,7 +87,7 @@ public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
             try {
                 _currentOutPipe = outPipe;
                 _currentReplyPipe = replyPipe;
-                await task();
+                await task().ConfigureAwait(false);
             } finally {
                 _currentOutPipe = null;
                 _currentReplyPipe = null;

--- a/DbaClientX.Tests/MySqlTests.cs
+++ b/DbaClientX.Tests/MySqlTests.cs
@@ -18,8 +18,8 @@ public class MySqlTests
         using var mySql = new DBAClientX.MySql();
         var ex = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(async () =>
         {
-            await mySql.QueryAsync("invalid", "mysql", "user", "pass", "SELECT 1");
-        });
+            await mySql.QueryAsync("invalid", "mysql", "user", "pass", "SELECT 1").ConfigureAwait(false);
+        }).ConfigureAwait(false);
         Assert.Contains("SELECT 1", ex.Message);
     }
 
@@ -34,7 +34,7 @@ public class MySqlTests
 
         public override async Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
         {
-            await Task.Delay(_delay, cancellationToken);
+            await Task.Delay(_delay, cancellationToken).ConfigureAwait(false);
             return null;
         }
     }
@@ -48,12 +48,12 @@ public class MySqlTests
         var sequential = Stopwatch.StartNew();
         foreach (var query in queries)
         {
-            await mySql.QueryAsync("h", "d", "u", "p", query);
+            await mySql.QueryAsync("h", "d", "u", "p", query).ConfigureAwait(false);
         }
         sequential.Stop();
 
         var parallel = Stopwatch.StartNew();
-        await mySql.RunQueriesInParallel(queries, "h", "d", "u", "p");
+        await mySql.RunQueriesInParallel(queries, "h", "d", "u", "p").ConfigureAwait(false);
         parallel.Stop();
 
         Assert.True(parallel.Elapsed < sequential.Elapsed);
@@ -66,8 +66,8 @@ public class MySqlTests
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
-            await mySql.QueryAsync("h", "d", "u", "p", "q", cancellationToken: cts.Token);
-        });
+            await mySql.QueryAsync("h", "d", "u", "p", "q", cancellationToken: cts.Token).ConfigureAwait(false);
+        }).ConfigureAwait(false);
     }
 
     [Fact]
@@ -78,8 +78,8 @@ public class MySqlTests
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
-            await mySql.RunQueriesInParallel(queries, "h", "d", "u", "p", cts.Token);
-        });
+            await mySql.RunQueriesInParallel(queries, "h", "d", "u", "p", cts.Token).ConfigureAwait(false);
+        }).ConfigureAwait(false);
     }
 
     private class CaptureParametersMySql : DBAClientX.MySql
@@ -126,7 +126,7 @@ public class MySqlTests
             ["@name"] = "test"
         };
 
-        await mySql.QueryAsync("h", "d", "u", "p", "SELECT 1", parameters);
+        await mySql.QueryAsync("h", "d", "u", "p", "SELECT 1", parameters).ConfigureAwait(false);
 
         Assert.Contains(mySql.Captured, p => p.Name == "@id" && (int)p.Value == 5);
         Assert.Contains(mySql.Captured, p => p.Name == "@name" && (string)p.Value == "test");
@@ -147,7 +147,7 @@ public class MySqlTests
             ["@name"] = MySqlDbType.VarChar
         };
 
-        await mySql.QueryAsync("h", "d", "u", "p", "SELECT 1", parameters, cancellationToken: CancellationToken.None, parameterTypes: types);
+        await mySql.QueryAsync("h", "d", "u", "p", "SELECT 1", parameters, cancellationToken: CancellationToken.None, parameterTypes: types).ConfigureAwait(false);
 
         Assert.Contains(mySql.Captured, p => p.Name == "@id" && p.Type == MySqlDbType.Int32);
         Assert.Contains(mySql.Captured, p => p.Name == "@name" && p.Type == MySqlDbType.VarChar);

--- a/DbaClientX.Tests/ParallelQueriesTests.cs
+++ b/DbaClientX.Tests/ParallelQueriesTests.cs
@@ -36,7 +36,7 @@ public class ParallelQueriesTests
         };
 
         using var sqlServer = new MockSqlServer(mapping);
-        var results = await sqlServer.RunQueriesInParallel(queries, "s", "db", true, CancellationToken.None);
+        var results = await sqlServer.RunQueriesInParallel(queries, "s", "db", true, CancellationToken.None).ConfigureAwait(false);
 
         Assert.Equal(new object?[] { 1, 2, 3 }, results);
     }

--- a/DbaClientX.Tests/PostgreSqlTests.cs
+++ b/DbaClientX.Tests/PostgreSqlTests.cs
@@ -20,8 +20,8 @@ public class PostgreSqlTests
         using var pg = new DBAClientX.PostgreSql();
         var ex = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(async () =>
         {
-            await pg.QueryAsync("invalid", "postgres", "user", "pass", "SELECT 1");
-        });
+            await pg.QueryAsync("invalid", "postgres", "user", "pass", "SELECT 1").ConfigureAwait(false);
+        }).ConfigureAwait(false);
         Assert.Contains("SELECT 1", ex.Message);
     }
 
@@ -36,7 +36,7 @@ public class PostgreSqlTests
 
         public override async Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
         {
-            await Task.Delay(_delay, cancellationToken);
+            await Task.Delay(_delay, cancellationToken).ConfigureAwait(false);
             return null;
         }
     }
@@ -50,12 +50,12 @@ public class PostgreSqlTests
         var sequential = Stopwatch.StartNew();
         foreach (var query in queries)
         {
-            await pg.QueryAsync("h", "d", "u", "p", query);
+            await pg.QueryAsync("h", "d", "u", "p", query).ConfigureAwait(false);
         }
         sequential.Stop();
 
         var parallel = Stopwatch.StartNew();
-        await pg.RunQueriesInParallel(queries, "h", "d", "u", "p");
+        await pg.RunQueriesInParallel(queries, "h", "d", "u", "p").ConfigureAwait(false);
         parallel.Stop();
 
         Assert.True(parallel.Elapsed < sequential.Elapsed);
@@ -68,8 +68,8 @@ public class PostgreSqlTests
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
-            await pg.QueryAsync("h", "d", "u", "p", "q", cancellationToken: cts.Token);
-        });
+            await pg.QueryAsync("h", "d", "u", "p", "q", cancellationToken: cts.Token).ConfigureAwait(false);
+        }).ConfigureAwait(false);
     }
 
     [Fact]
@@ -80,8 +80,8 @@ public class PostgreSqlTests
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
-            await pg.RunQueriesInParallel(queries, "h", "d", "u", "p", cts.Token);
-        });
+            await pg.RunQueriesInParallel(queries, "h", "d", "u", "p", cts.Token).ConfigureAwait(false);
+        }).ConfigureAwait(false);
     }
 
     private class CaptureParametersPostgreSql : DBAClientX.PostgreSql
@@ -128,7 +128,7 @@ public class PostgreSqlTests
             ["@name"] = "test"
         };
 
-        await pg.QueryAsync("h", "d", "u", "p", "SELECT 1", parameters);
+        await pg.QueryAsync("h", "d", "u", "p", "SELECT 1", parameters).ConfigureAwait(false);
 
         Assert.Contains(pg.Captured, p => p.Name == "@id" && (int)p.Value == 5);
         Assert.Contains(pg.Captured, p => p.Name == "@name" && (string)p.Value == "test");
@@ -149,7 +149,7 @@ public class PostgreSqlTests
             ["@name"] = NpgsqlDbType.Text
         };
 
-        await pg.QueryAsync("h", "d", "u", "p", "SELECT 1", parameters, cancellationToken: CancellationToken.None, parameterTypes: types);
+        await pg.QueryAsync("h", "d", "u", "p", "SELECT 1", parameters, cancellationToken: CancellationToken.None, parameterTypes: types).ConfigureAwait(false);
 
         Assert.Contains(pg.Captured, p => p.Name == "@id" && p.Type == NpgsqlDbType.Integer);
         Assert.Contains(pg.Captured, p => p.Name == "@name" && p.Type == NpgsqlDbType.Text);
@@ -196,7 +196,7 @@ public class PostgreSqlTests
         {
             ["@id"] = 1
         };
-        await pg.ExecuteStoredProcedureAsync("h", "d", "u", "p", "sp_test", parameters);
+        await pg.ExecuteStoredProcedureAsync("h", "d", "u", "p", "sp_test", parameters).ConfigureAwait(false);
         Assert.Equal("CALL sp_test(@id)", pg.CapturedQuery);
     }
 

--- a/DbaClientX.Tests/SQLiteTransactionConcurrencyTests.cs
+++ b/DbaClientX.Tests/SQLiteTransactionConcurrencyTests.cs
@@ -38,7 +38,7 @@ public class SQLiteTransactionConcurrencyTests
             }
         });
 
-        await Task.WhenAll(commitTask, rollbackTask);
+        await Task.WhenAll(commitTask, rollbackTask).ConfigureAwait(false);
 
         Assert.True(commitThrows ^ rollbackThrows);
         Assert.False(sqlite.IsInTransaction);

--- a/DbaClientX.Tests/SqlQueryStreamTests.cs
+++ b/DbaClientX.Tests/SqlQueryStreamTests.cs
@@ -46,7 +46,7 @@ public class QueryStreamTests
         using var server = new DummySqlServer();
         var list = new List<int>();
 
-        await foreach (DataRow row in server.QueryStreamAsync("s", "d", true, "q"))
+        await foreach (DataRow row in server.QueryStreamAsync("s", "d", true, "q").ConfigureAwait(false))
         {
             list.Add((int)row["id"]);
         }

--- a/DbaClientX.Tests/SqlServerTests.cs
+++ b/DbaClientX.Tests/SqlServerTests.cs
@@ -19,8 +19,8 @@ public class SqlServerTests
         using var sqlServer = new DBAClientX.SqlServer();
         var ex = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(async () =>
         {
-            await sqlServer.QueryAsync("invalid", "master", true, "SELECT 1");
-        });
+            await sqlServer.QueryAsync("invalid", "master", true, "SELECT 1").ConfigureAwait(false);
+        }).ConfigureAwait(false);
         Assert.Contains("SELECT 1", ex.Message);
     }
 
@@ -35,7 +35,7 @@ public class SqlServerTests
 
         public override async Task<object?> QueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
         {
-            await Task.Delay(_delay, cancellationToken);
+            await Task.Delay(_delay, cancellationToken).ConfigureAwait(false);
             return null;
         }
     }
@@ -49,12 +49,12 @@ public class SqlServerTests
         var sequential = Stopwatch.StartNew();
         foreach (var query in queries)
         {
-            await sqlServer.QueryAsync("ignored", "ignored", true, query);
+            await sqlServer.QueryAsync("ignored", "ignored", true, query).ConfigureAwait(false);
         }
         sequential.Stop();
 
         var parallel = Stopwatch.StartNew();
-        await sqlServer.RunQueriesInParallel(queries, "ignored", "ignored", true);
+        await sqlServer.RunQueriesInParallel(queries, "ignored", "ignored", true).ConfigureAwait(false);
         parallel.Stop();
 
         Assert.True(parallel.Elapsed < sequential.Elapsed);
@@ -67,8 +67,8 @@ public class SqlServerTests
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
-            await sqlServer.QueryAsync("s", "db", true, "q", cancellationToken: cts.Token);
-        });
+            await sqlServer.QueryAsync("s", "db", true, "q", cancellationToken: cts.Token).ConfigureAwait(false);
+        }).ConfigureAwait(false);
     }
 
     [Fact]
@@ -79,8 +79,8 @@ public class SqlServerTests
         using var cts = new CancellationTokenSource(100);
         await Assert.ThrowsAsync<TaskCanceledException>(async () =>
         {
-            await sqlServer.RunQueriesInParallel(queries, "s", "db", true, cts.Token);
-        });
+            await sqlServer.RunQueriesInParallel(queries, "s", "db", true, cts.Token).ConfigureAwait(false);
+        }).ConfigureAwait(false);
     }
 
     private class CaptureParametersSqlServer : DBAClientX.SqlServer
@@ -127,7 +127,7 @@ public class SqlServerTests
             ["@name"] = "test"
         };
 
-        await sqlServer.QueryAsync("ignored", "ignored", true, "SELECT 1", parameters);
+        await sqlServer.QueryAsync("ignored", "ignored", true, "SELECT 1", parameters).ConfigureAwait(false);
 
         Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && (int)p.Value == 5);
         Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && (string)p.Value == "test");
@@ -148,7 +148,7 @@ public class SqlServerTests
             ["@name"] = SqlDbType.NVarChar
         };
 
-        await sqlServer.QueryAsync("ignored", "ignored", true, "SELECT 1", parameters, cancellationToken: CancellationToken.None, parameterTypes: types);
+        await sqlServer.QueryAsync("ignored", "ignored", true, "SELECT 1", parameters, cancellationToken: CancellationToken.None, parameterTypes: types).ConfigureAwait(false);
 
         Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && p.Type == SqlDbType.Int);
         Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && p.Type == SqlDbType.NVarChar);
@@ -195,7 +195,7 @@ public class SqlServerTests
         {
             ["@id"] = 1
         };
-        await sqlServer.ExecuteStoredProcedureAsync("s", "db", true, "sp_test", parameters);
+        await sqlServer.ExecuteStoredProcedureAsync("s", "db", true, "sp_test", parameters).ConfigureAwait(false);
         Assert.Equal("EXEC sp_test @id", sqlServer.CapturedQuery);
     }
 

--- a/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
@@ -49,7 +49,7 @@ public class SqlServerTransactionAsyncTests
         public override async Task BeginTransactionAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null)
         {
             Connection = new FakeSqlConnection();
-            Transaction = await Connection.BeginTransactionAsync(cancellationToken);
+            Transaction = await Connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public override async Task CommitAsync(CancellationToken cancellationToken = default)
@@ -58,7 +58,7 @@ public class SqlServerTransactionAsyncTests
             {
                 throw new DBAClientX.DbaTransactionException("No active transaction.");
             }
-            await Transaction.CommitAsync(cancellationToken);
+            await Transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
             Transaction = null;
         }
 
@@ -68,7 +68,7 @@ public class SqlServerTransactionAsyncTests
             {
                 throw new DBAClientX.DbaTransactionException("No active transaction.");
             }
-            await Transaction.RollbackAsync(cancellationToken);
+            await Transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
             Transaction = null;
         }
 
@@ -86,7 +86,7 @@ public class SqlServerTransactionAsyncTests
     public async Task BeginTransactionAsync_UsesConnection()
     {
         using var server = new TestSqlServer();
-        await server.BeginTransactionAsync("s", "db", true);
+        await server.BeginTransactionAsync("s", "db", true).ConfigureAwait(false);
         Assert.NotNull(server.Connection);
         Assert.True(server.Connection!.BeginCalled);
         Assert.NotNull(server.Transaction);
@@ -96,9 +96,9 @@ public class SqlServerTransactionAsyncTests
     public async Task CommitAsync_CallsCommitOnTransaction()
     {
         using var server = new TestSqlServer();
-        await server.BeginTransactionAsync("s", "db", true);
+        await server.BeginTransactionAsync("s", "db", true).ConfigureAwait(false);
         var txn = server.Transaction!;
-        await server.CommitAsync();
+        await server.CommitAsync().ConfigureAwait(false);
         Assert.True(txn.CommitCalled);
         Assert.Null(server.Transaction);
     }
@@ -107,9 +107,9 @@ public class SqlServerTransactionAsyncTests
     public async Task RollbackAsync_CallsRollbackOnTransaction()
     {
         using var server = new TestSqlServer();
-        await server.BeginTransactionAsync("s", "db", true);
+        await server.BeginTransactionAsync("s", "db", true).ConfigureAwait(false);
         var txn = server.Transaction!;
-        await server.RollbackAsync();
+        await server.RollbackAsync().ConfigureAwait(false);
         Assert.True(txn.RollbackCalled);
         Assert.Null(server.Transaction);
     }


### PR DESCRIPTION
## Summary
- ensure all awaited calls across examples, PowerShell cmdlets, and tests use `ConfigureAwait(false)` to avoid capturing sync context

## Testing
- `dotnet build -p:Nullable=enable -p:NoWarn=CS1998`
- `dotnet test -p:Nullable=enable -p:NoWarn=CS1998`


------
https://chatgpt.com/codex/tasks/task_e_6894a84b98e0832e824b4ab8c6a625a9