### PR TITLE
Add tests for commit/rollback without transaction across providers

### DIFF
--- a/DbaClientX.Tests/MySqlTests.cs
+++ b/DbaClientX.Tests/MySqlTests.cs
@@ -194,6 +194,20 @@ public class MySqlTests
     }
 
     [Fact]
+    public void Commit_WithoutTransaction_Throws()
+    {
+        using var mySql = new DBAClientX.MySql();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => mySql.Commit());
+    }
+
+    [Fact]
+    public void Rollback_WithoutTransaction_Throws()
+    {
+        using var mySql = new DBAClientX.MySql();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => mySql.Rollback());
+    }
+
+    [Fact]
     public void Commit_EndsTransaction()
     {
         using var mySql = new FakeTransactionMySql();

--- a/DbaClientX.Tests/PostgreSqlTests.cs
+++ b/DbaClientX.Tests/PostgreSqlTests.cs
@@ -207,4 +207,18 @@ public class PostgreSqlTests
         pg.ExecuteStoredProcedure("h", "d", "u", "p", "sp_test", null);
         Assert.Equal("CALL sp_test()", pg.CapturedQuery);
     }
+
+    [Fact]
+    public void Commit_WithoutTransaction_Throws()
+    {
+        using var pg = new DBAClientX.PostgreSql();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => pg.Commit());
+    }
+
+    [Fact]
+    public void Rollback_WithoutTransaction_Throws()
+    {
+        using var pg = new DBAClientX.PostgreSql();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => pg.Rollback());
+    }
 }

--- a/DbaClientX.Tests/SqlServerTests.cs
+++ b/DbaClientX.Tests/SqlServerTests.cs
@@ -240,6 +240,20 @@ public class SqlServerTests
     }
 
     [Fact]
+    public void Commit_WithoutTransaction_Throws()
+    {
+        using var sqlServer = new DBAClientX.SqlServer();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlServer.Commit());
+    }
+
+    [Fact]
+    public void Rollback_WithoutTransaction_Throws()
+    {
+        using var sqlServer = new DBAClientX.SqlServer();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlServer.Rollback());
+    }
+
+    [Fact]
     public void Commit_EndsTransaction()
     {
         using var sqlServer = new FakeTransactionSqlServer();

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -45,6 +45,20 @@ public class SqliteTests
     }
 
     [Fact]
+    public void Commit_WithoutTransaction_Throws()
+    {
+        using var sqlite = new DBAClientX.SQLite();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlite.Commit());
+    }
+
+    [Fact]
+    public void Rollback_WithoutTransaction_Throws()
+    {
+        using var sqlite = new DBAClientX.SQLite();
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlite.Rollback());
+    }
+
+    [Fact]
     public void Commit_PersistsChanges()
     {
         var path = Path.GetTempFileName();


### PR DESCRIPTION
## Summary
- add MySql tests asserting Commit/Rollback throw when no transaction started
- verify PostgreSql Commit/Rollback require an active transaction
- ensure SqlServer and SQLite Commit/Rollback without BeginTransaction raise `DbaTransactionException`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6894dcf3f1d4832ea45edd896e673114