### PR TITLE
Add MySql query streaming support

### DIFF
--- a/DbaClientX.Examples/StreamQueryMySqlExample.cs
+++ b/DbaClientX.Examples/StreamQueryMySqlExample.cs
@@ -1,0 +1,23 @@
+using DBAClientX;
+using System.Data;
+using System.Threading;
+
+public static class StreamQueryMySqlExample
+{
+    public static async Task RunAsync()
+    {
+        using var mySql = new MySql
+        {
+            ReturnType = ReturnType.DataRow
+        };
+
+        await foreach (DataRow row in mySql.QueryStreamAsync("MYSQL1", "mysql", "user", "password", "SELECT 1", cancellationToken: CancellationToken.None).ConfigureAwait(false))
+        {
+            foreach (DataColumn col in row.Table.Columns)
+            {
+                Console.Write($"{row[col]}\t");
+            }
+            Console.WriteLine();
+        }
+    }
+}

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -156,6 +156,51 @@ public class MySql : DatabaseClientBase
         }
     }
 
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    public virtual IAsyncEnumerable<DataRow> QueryStreamAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    {
+        return Stream();
+
+        async IAsyncEnumerable<DataRow> Stream()
+        {
+            var connectionString = BuildConnectionString(host, database, username, password);
+
+            MySqlConnection? connection = null;
+            bool dispose = false;
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new MySqlConnection(connectionString);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                dispose = true;
+            }
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            try
+            {
+                await foreach (var row in ExecuteQueryStreamAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes).ConfigureAwait(false))
+                {
+                    yield return row;
+                }
+            }
+            finally
+            {
+                if (dispose)
+                {
+                    connection?.Dispose();
+                }
+            }
+        }
+    }
+#endif
+
     public virtual void BeginTransaction(string host, string database, string username, string password)
     {
         lock (_syncRoot)

--- a/DbaClientX.Tests/MySqlQueryStreamTests.cs
+++ b/DbaClientX.Tests/MySqlQueryStreamTests.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using MySqlConnector;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class MySqlQueryStreamTests
+{
+    private class DummyMySql : DBAClientX.MySql
+    {
+        private readonly List<DataRow> _rows;
+
+        public DummyMySql()
+        {
+            var table = new DataTable();
+            table.Columns.Add("id", typeof(int));
+            table.Columns.Add("name", typeof(string));
+            var r1 = table.NewRow();
+            r1["id"] = 1;
+            r1["name"] = "one";
+            table.Rows.Add(r1);
+            var r2 = table.NewRow();
+            r2["id"] = 2;
+            r2["name"] = "two";
+            table.Rows.Add(r2);
+            _rows = table.Rows.Cast<DataRow>().ToList();
+        }
+
+        public override async IAsyncEnumerable<DataRow> QueryStreamAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
+        {
+            foreach (var row in _rows)
+            {
+                await Task.Yield();
+                yield return row;
+            }
+        }
+    }
+
+    [Fact]
+    public async Task QueryStreamAsync_EnumeratesRows()
+    {
+        using var mySql = new DummyMySql();
+        var list = new List<int>();
+
+        await foreach (DataRow row in mySql.QueryStreamAsync("h", "d", "u", "p", "q").ConfigureAwait(false))
+        {
+            list.Add((int)row["id"]);
+        }
+
+        Assert.Equal(new[] { 1, 2 }, list);
+    }
+}


### PR DESCRIPTION
## Summary
- add async streaming query support to MySql provider
- include example illustrating MySql query streaming
- test MySql query streaming enumeration

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6894e7d6df38832ea9e506bd72a758f2