### PR TITLE
Add database cmdlets for MySql, PostgreSql and SQLite

### DIFF
--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
@@ -1,0 +1,156 @@
+using System.Runtime.CompilerServices;
+
+namespace DBAClientX.PowerShell;
+
+[Cmdlet(VerbsLifecycle.Invoke, "DbaXMySql", DefaultParameterSetName = "Query", SupportsShouldProcess = true)]
+[CmdletBinding()]
+public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
+    internal static Func<DBAClientX.MySql> MySqlFactory { get; set; } = () => new DBAClientX.MySql();
+
+    [Parameter(Mandatory = true)]
+    [Alias("DBServer", "SqlInstance", "Instance")]
+    [ValidateNotNullOrEmpty]
+    public string Server { get; set; }
+
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string Database { get; set; }
+
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string Query { get; set; }
+
+    [Parameter]
+    public int QueryTimeout { get; set; }
+
+    [Parameter]
+    public SwitchParameter Stream { get; set; }
+
+    [Parameter]
+    [Alias("As")]
+    public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
+
+    [Parameter]
+    public Hashtable Parameters { get; set; }
+
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string Username { get; set; }
+
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string Password { get; set; }
+
+    private ActionPreference ErrorAction;
+
+    protected override Task BeginProcessingAsync() {
+        ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
+        if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
+            string errorActionString = this.MyInvocation.BoundParameters["ErrorAction"].ToString();
+            if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
+                ErrorAction = actionPreference;
+            }
+        }
+        return Task.CompletedTask;
+    }
+
+    protected override async Task ProcessRecordAsync() {
+        using var mySql = MySqlFactory();
+        mySql.ReturnType = ReturnType;
+        mySql.CommandTimeout = QueryTimeout;
+        try {
+            IDictionary<string, object?>? parameters = null;
+            if (Parameters != null) {
+                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
+                    de => de.Key.ToString(),
+                    de => de.Value);
+            }
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            if (Stream.IsPresent) {
+                var enumerable = mySql.QueryStreamAsync(Server, Database, Username, Password, Query, parameters, cancellationToken: CancelToken);
+                switch (ReturnType) {
+                    case ReturnType.DataRow:
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            WriteObject(row);
+                        }
+                        break;
+                    case ReturnType.DataTable:
+                        DataTable? table = null;
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            table ??= row.Table.Clone();
+                            table.ImportRow(row);
+                        }
+                        if (table != null) {
+                            WriteObject(table);
+                        }
+                        break;
+                    case ReturnType.DataSet:
+                        DataTable? dataTable = null;
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            dataTable ??= row.Table.Clone();
+                            dataTable.ImportRow(row);
+                        }
+                        DataSet set = new DataSet();
+                        if (dataTable != null) {
+                            set.Tables.Add(dataTable);
+                        }
+                        WriteObject(set);
+                        break;
+                    default:
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            WriteObject(DataRowToPSObject(row));
+                        }
+                        break;
+                }
+                return;
+            }
+#else
+            if (Stream.IsPresent) {
+                throw new NotSupportedException("Streaming is not supported on this platform.");
+            }
+#endif
+            var result = await mySql.QueryAsync(Server, Database, Username, Password, Query, parameters, cancellationToken: CancelToken).ConfigureAwait(false);
+            if (result != null) {
+                if (ReturnType == ReturnType.PSObject) {
+                    foreach (DataRow row in ((DataTable)result).Rows) {
+                        WriteObject(DataRowToPSObject(row));
+                    }
+                } else {
+                    WriteObject(result, true);
+                }
+            }
+        } catch (Exception ex) {
+            WriteWarning($"Invoke-DbaXMySql - Error querying MySql: {ex.Message}");
+            if (ErrorAction == ActionPreference.Stop) {
+                throw;
+            }
+        }
+    }
+
+    private static readonly ConditionalWeakTable<DataTable, PSNoteProperty[]> _psNotePropertyCache = new();
+
+    private static PSObject DataRowToPSObject(DataRow row) {
+        PSObject psObject = new PSObject();
+
+        if (row != null && (row.RowState & DataRowState.Detached) != DataRowState.Detached) {
+            var table = row.Table;
+            if (!_psNotePropertyCache.TryGetValue(table, out var propertyTemplates)) {
+                propertyTemplates = new PSNoteProperty[table.Columns.Count];
+                for (int i = 0; i < table.Columns.Count; i++) {
+                    propertyTemplates[i] = new PSNoteProperty(table.Columns[i].ColumnName, null);
+                }
+                _psNotePropertyCache.Add(table, propertyTemplates);
+            }
+
+            for (int i = 0; i < propertyTemplates.Length; i++) {
+                var prop = (PSNoteProperty)propertyTemplates[i].Copy();
+                if (!row.IsNull(i)) {
+                    prop.Value = row[i];
+                }
+                psObject.Properties.Add(prop);
+            }
+        }
+
+        return psObject;
+    }
+}

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSql.cs
@@ -1,0 +1,172 @@
+using System.Runtime.CompilerServices;
+
+namespace DBAClientX.PowerShell;
+
+[Cmdlet(VerbsLifecycle.Invoke, "DbaXPostgreSql", DefaultParameterSetName = "Query", SupportsShouldProcess = true)]
+[CmdletBinding()]
+public sealed class CmdletInvokeDbaXPostgreSql : AsyncPSCmdlet {
+    internal static Func<DBAClientX.PostgreSql> PostgreSqlFactory { get; set; } = () => new DBAClientX.PostgreSql();
+
+    [Parameter(Mandatory = true, ParameterSetName = "Query")]
+    [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
+    [Alias("DBServer", "SqlInstance", "Instance")]
+    [ValidateNotNullOrEmpty]
+    public string Server { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "Query")]
+    [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
+    [ValidateNotNullOrEmpty]
+    public string Database { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "Query")]
+    [ValidateNotNullOrEmpty]
+    public string Query { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
+    [ValidateNotNullOrEmpty]
+    public string StoredProcedure { get; set; }
+
+    [Parameter(ParameterSetName = "Query")]
+    [Parameter(ParameterSetName = "StoredProcedure")]
+    public int QueryTimeout { get; set; }
+
+    [Parameter(ParameterSetName = "Query")]
+    public SwitchParameter Stream { get; set; }
+
+    [Parameter(ParameterSetName = "Query")]
+    [Parameter(ParameterSetName = "StoredProcedure")]
+    [Alias("As")]
+    public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
+
+    [Parameter(ParameterSetName = "Query")]
+    [Parameter(ParameterSetName = "StoredProcedure")]
+    public Hashtable Parameters { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "Query")]
+    [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
+    [ValidateNotNullOrEmpty]
+    public string Username { get; set; }
+
+    [Parameter(Mandatory = true, ParameterSetName = "Query")]
+    [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
+    [ValidateNotNullOrEmpty]
+    public string Password { get; set; }
+
+    private ActionPreference ErrorAction;
+
+    protected override Task BeginProcessingAsync() {
+        ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
+        if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
+            string errorActionString = this.MyInvocation.BoundParameters["ErrorAction"].ToString();
+            if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
+                ErrorAction = actionPreference;
+            }
+        }
+        return Task.CompletedTask;
+    }
+
+    protected override async Task ProcessRecordAsync() {
+        using var postgreSql = PostgreSqlFactory();
+        postgreSql.ReturnType = ReturnType;
+        postgreSql.CommandTimeout = QueryTimeout;
+        try {
+            IDictionary<string, object?>? parameters = null;
+            if (Parameters != null) {
+                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
+                    de => de.Key.ToString(),
+                    de => de.Value);
+            }
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            if (Stream.IsPresent) {
+                var enumerable = postgreSql.QueryStreamAsync(Server, Database, Username, Password, Query, parameters, cancellationToken: CancelToken);
+                switch (ReturnType) {
+                    case ReturnType.DataRow:
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            WriteObject(row);
+                        }
+                        break;
+                    case ReturnType.DataTable:
+                        DataTable? table = null;
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            table ??= row.Table.Clone();
+                            table.ImportRow(row);
+                        }
+                        if (table != null) {
+                            WriteObject(table);
+                        }
+                        break;
+                    case ReturnType.DataSet:
+                        DataTable? dataTable = null;
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            dataTable ??= row.Table.Clone();
+                            dataTable.ImportRow(row);
+                        }
+                        DataSet set = new DataSet();
+                        if (dataTable != null) {
+                            set.Tables.Add(dataTable);
+                        }
+                        WriteObject(set);
+                        break;
+                    default:
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            WriteObject(DataRowToPSObject(row));
+                        }
+                        break;
+                }
+                return;
+            }
+#else
+            if (Stream.IsPresent) {
+                throw new NotSupportedException("Streaming is not supported on this platform.");
+            }
+#endif
+            object? result;
+            if (!string.IsNullOrEmpty(StoredProcedure)) {
+                result = postgreSql.ExecuteStoredProcedure(Server, Database, Username, Password, StoredProcedure, parameters);
+            } else {
+                result = postgreSql.Query(Server, Database, Username, Password, Query, parameters);
+            }
+            if (result != null) {
+                if (ReturnType == ReturnType.PSObject) {
+                    foreach (DataRow row in ((DataTable)result).Rows) {
+                        WriteObject(DataRowToPSObject(row));
+                    }
+                } else {
+                    WriteObject(result, true);
+                }
+            }
+        } catch (Exception ex) {
+            WriteWarning($"Invoke-DbaXPostgreSql - Error querying PostgreSql: {ex.Message}");
+            if (ErrorAction == ActionPreference.Stop) {
+                throw;
+            }
+        }
+    }
+
+    private static readonly ConditionalWeakTable<DataTable, PSNoteProperty[]> _psNotePropertyCache = new();
+
+    private static PSObject DataRowToPSObject(DataRow row) {
+        PSObject psObject = new PSObject();
+
+        if (row != null && (row.RowState & DataRowState.Detached) != DataRowState.Detached) {
+            var table = row.Table;
+            if (!_psNotePropertyCache.TryGetValue(table, out var propertyTemplates)) {
+                propertyTemplates = new PSNoteProperty[table.Columns.Count];
+                for (int i = 0; i < table.Columns.Count; i++) {
+                    propertyTemplates[i] = new PSNoteProperty(table.Columns[i].ColumnName, null);
+                }
+                _psNotePropertyCache.Add(table, propertyTemplates);
+            }
+
+            for (int i = 0; i < propertyTemplates.Length; i++) {
+                var prop = (PSNoteProperty)propertyTemplates[i].Copy();
+                if (!row.IsNull(i)) {
+                    prop.Value = row[i];
+                }
+                psObject.Properties.Add(prop);
+            }
+        }
+
+        return psObject;
+    }
+}

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
@@ -1,0 +1,143 @@
+using System.Runtime.CompilerServices;
+
+namespace DBAClientX.PowerShell;
+
+[Cmdlet(VerbsLifecycle.Invoke, "DbaXSQLite", DefaultParameterSetName = "Query", SupportsShouldProcess = true)]
+[CmdletBinding()]
+public sealed class CmdletInvokeDbaXSQLite : AsyncPSCmdlet {
+    internal static Func<DBAClientX.SQLite> SQLiteFactory { get; set; } = () => new DBAClientX.SQLite();
+
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string Database { get; set; }
+
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string Query { get; set; }
+
+    [Parameter]
+    public int QueryTimeout { get; set; }
+
+    [Parameter]
+    public SwitchParameter Stream { get; set; }
+
+    [Parameter]
+    [Alias("As")]
+    public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
+
+    [Parameter]
+    public Hashtable Parameters { get; set; }
+
+    private ActionPreference ErrorAction;
+
+    protected override Task BeginProcessingAsync() {
+        ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
+        if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
+            string errorActionString = this.MyInvocation.BoundParameters["ErrorAction"].ToString();
+            if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
+                ErrorAction = actionPreference;
+            }
+        }
+        return Task.CompletedTask;
+    }
+
+    protected override async Task ProcessRecordAsync() {
+        using var sqlite = SQLiteFactory();
+        sqlite.ReturnType = ReturnType;
+        sqlite.CommandTimeout = QueryTimeout;
+        try {
+            IDictionary<string, object?>? parameters = null;
+            if (Parameters != null) {
+                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
+                    de => de.Key.ToString(),
+                    de => de.Value);
+            }
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+            if (Stream.IsPresent) {
+                var enumerable = sqlite.QueryStreamAsync(Database, Query, parameters, cancellationToken: CancelToken);
+                switch (ReturnType) {
+                    case ReturnType.DataRow:
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            WriteObject(row);
+                        }
+                        break;
+                    case ReturnType.DataTable:
+                        DataTable? table = null;
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            table ??= row.Table.Clone();
+                            table.ImportRow(row);
+                        }
+                        if (table != null) {
+                            WriteObject(table);
+                        }
+                        break;
+                    case ReturnType.DataSet:
+                        DataTable? dataTable = null;
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            dataTable ??= row.Table.Clone();
+                            dataTable.ImportRow(row);
+                        }
+                        DataSet set = new DataSet();
+                        if (dataTable != null) {
+                            set.Tables.Add(dataTable);
+                        }
+                        WriteObject(set);
+                        break;
+                    default:
+                        await foreach (var row in enumerable.ConfigureAwait(false)) {
+                            WriteObject(DataRowToPSObject(row));
+                        }
+                        break;
+                }
+                return;
+            }
+#else
+            if (Stream.IsPresent) {
+                throw new NotSupportedException("Streaming is not supported on this platform.");
+            }
+#endif
+            var result = sqlite.Query(Database, Query, parameters);
+            if (result != null) {
+                if (ReturnType == ReturnType.PSObject) {
+                    foreach (DataRow row in ((DataTable)result).Rows) {
+                        WriteObject(DataRowToPSObject(row));
+                    }
+                } else {
+                    WriteObject(result, true);
+                }
+            }
+        } catch (Exception ex) {
+            WriteWarning($"Invoke-DbaXSQLite - Error querying SQLite: {ex.Message}");
+            if (ErrorAction == ActionPreference.Stop) {
+                throw;
+            }
+        }
+    }
+
+    private static readonly ConditionalWeakTable<DataTable, PSNoteProperty[]> _psNotePropertyCache = new();
+
+    private static PSObject DataRowToPSObject(DataRow row) {
+        PSObject psObject = new PSObject();
+
+        if (row != null && (row.RowState & DataRowState.Detached) != DataRowState.Detached) {
+            var table = row.Table;
+            if (!_psNotePropertyCache.TryGetValue(table, out var propertyTemplates)) {
+                propertyTemplates = new PSNoteProperty[table.Columns.Count];
+                for (int i = 0; i < table.Columns.Count; i++) {
+                    propertyTemplates[i] = new PSNoteProperty(table.Columns[i].ColumnName, null);
+                }
+                _psNotePropertyCache.Add(table, propertyTemplates);
+            }
+
+            for (int i = 0; i < propertyTemplates.Length; i++) {
+                var prop = (PSNoteProperty)propertyTemplates[i].Copy();
+                if (!row.IsNull(i)) {
+                    prop.Value = row[i];
+                }
+                psObject.Properties.Add(prop);
+            }
+        }
+
+        return psObject;
+    }
+}

--- a/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
+++ b/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
@@ -22,6 +22,8 @@
                 <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
                 <ProjectReference Include="..\DbaClientX.SqlServer\DbaClientX.SqlServer.csproj" />
                 <ProjectReference Include="..\DbaClientX.SQLite\DbaClientX.SQLite.csproj" />
+                <ProjectReference Include="..\DbaClientX.MySql\DbaClientX.MySql.csproj" />
+                <ProjectReference Include="..\DbaClientX.PostgreSql\DbaClientX.PostgreSql.csproj" />
         </ItemGroup>
 
 	<ItemGroup>

--- a/Module/DbaClientX.psd1
+++ b/Module/DbaClientX.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Invoke-DbaXQuery', 'Invoke-DbaXNonQuery', 'New-DbaXQuery')
+    CmdletsToExport      = @('Invoke-DbaXQuery', 'Invoke-DbaXNonQuery', 'New-DbaXQuery', 'Invoke-DbaXMySql', 'Invoke-DbaXPostgreSql', 'Invoke-DbaXSQLite')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2024 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/Examples/Example.QueryMySql.ps1
+++ b/Module/Examples/Example.QueryMySql.ps1
@@ -1,0 +1,5 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+
+$T = Invoke-DbaXMySql -Query "SELECT 1" -Server "MySqlServer" -Database "master" -Username "user" -Password "pass"
+$T | Format-Table

--- a/Module/Examples/Example.QueryPostgreSql.ps1
+++ b/Module/Examples/Example.QueryPostgreSql.ps1
@@ -1,0 +1,5 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+
+$T = Invoke-DbaXPostgreSql -Query "SELECT 1" -Server "PostgreServer" -Database "postgres" -Username "user" -Password "pass"
+$T | Format-Table

--- a/Module/Examples/Example.QuerySQLite.ps1
+++ b/Module/Examples/Example.QuerySQLite.ps1
@@ -1,0 +1,5 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+
+$T = Invoke-DbaXSQLite -Query "SELECT 1" -Database "data.db"
+$T | Format-Table

--- a/Module/Tests/CmdletInvokeDbaXMySql.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXMySql.Tests.ps1
@@ -1,0 +1,12 @@
+Import-Module "$PSScriptRoot/../DbaClientX.psd1" -Force
+
+describe 'Invoke-DbaXMySql cmdlet' {
+    it 'is exported' {
+        Get-Command Invoke-DbaXMySql | Should -Not -BeNullOrEmpty
+    }
+
+    it 'supports Username and Password parameters' {
+        (Get-Command Invoke-DbaXMySql).Parameters.Keys | Should -Contain 'Username'
+        (Get-Command Invoke-DbaXMySql).Parameters.Keys | Should -Contain 'Password'
+    }
+}

--- a/Module/Tests/CmdletInvokeDbaXPostgreSql.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXPostgreSql.Tests.ps1
@@ -1,0 +1,16 @@
+Import-Module "$PSScriptRoot/../DbaClientX.psd1" -Force
+
+describe 'Invoke-DbaXPostgreSql cmdlet' {
+    it 'is exported' {
+        Get-Command Invoke-DbaXPostgreSql | Should -Not -BeNullOrEmpty
+    }
+
+    it 'supports StoredProcedure parameter' {
+        (Get-Command Invoke-DbaXPostgreSql).Parameters.Keys | Should -Contain 'StoredProcedure'
+    }
+
+    it 'supports Username and Password parameters' {
+        (Get-Command Invoke-DbaXPostgreSql).Parameters.Keys | Should -Contain 'Username'
+        (Get-Command Invoke-DbaXPostgreSql).Parameters.Keys | Should -Contain 'Password'
+    }
+}

--- a/Module/Tests/CmdletInvokeDbaXSQLite.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXSQLite.Tests.ps1
@@ -1,0 +1,7 @@
+Import-Module "$PSScriptRoot/../DbaClientX.psd1" -Force
+
+describe 'Invoke-DbaXSQLite cmdlet' {
+    it 'is exported' {
+        Get-Command Invoke-DbaXSQLite | Should -Not -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- add MySql, PostgreSql, and SQLite cmdlets mirroring Invoke-DbaXQuery
- wire up new cmdlets in module manifest and project references
- include examples and Pester tests for new cmdlets

## Testing
- `dotnet build`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester Module/Tests"`

------
https://chatgpt.com/codex/tasks/task_e_6894ee6fb78c832e9e7afa04de673dae