### PR TITLE
feat: allow direct connection strings

### DIFF
--- a/DbaClientX.Examples/ConnectionStringExamples.cs
+++ b/DbaClientX.Examples/ConnectionStringExamples.cs
@@ -1,0 +1,25 @@
+using DBAClientX;
+using System.Threading.Tasks;
+
+public static class ConnectionStringExamples
+{
+    public static async Task RunAsync()
+    {
+        var sqlServerConnection = SqlServer.BuildConnectionString("SQL1", "master", true);
+        using var sqlServer = new SqlServer();
+        // Builder parameters are ignored when connectionString is supplied
+        await sqlServer.QueryAsync("", "", true, "SELECT 1", connectionString: sqlServerConnection).ConfigureAwait(false);
+
+        var mySqlConnection = MySql.BuildConnectionString("localhost", "mydb", "user", "password");
+        using var mySql = new MySql();
+        await mySql.QueryAsync("", "", "", "", "SELECT 1", connectionString: mySqlConnection).ConfigureAwait(false);
+
+        var postgreConnection = PostgreSql.BuildConnectionString("localhost", "postgres", "user", "password");
+        using var postgre = new PostgreSql();
+        await postgre.QueryAsync("", "", "", "", "SELECT 1", connectionString: postgreConnection).ConfigureAwait(false);
+
+        var sqliteConnection = SQLite.BuildConnectionString("data.db");
+        using var sqlite = new SQLite();
+        await sqlite.QueryAsync("", "SELECT 1", connectionString: sqliteConnection).ConfigureAwait(false);
+    }
+}

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -40,11 +40,11 @@ public class SqlServer : DatabaseClientBase
         return connectionStringBuilder.ConnectionString;
     }
 
-    public virtual bool Ping(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null)
+    public virtual bool Ping(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null, string? connectionString = null)
     {
         try
         {
-            Query(serverOrInstance, database, integratedSecurity, "SELECT 1", username: username, password: password);
+            Query(serverOrInstance, database, integratedSecurity, "SELECT 1", username: username, password: password, connectionString: connectionString);
             return true;
         }
         catch
@@ -53,11 +53,11 @@ public class SqlServer : DatabaseClientBase
         }
     }
 
-    public virtual async Task<bool> PingAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null)
+    public virtual async Task<bool> PingAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null, string? connectionString = null)
     {
         try
         {
-            await QueryAsync(serverOrInstance, database, integratedSecurity, "SELECT 1", cancellationToken: cancellationToken, username: username, password: password).ConfigureAwait(false);
+            await QueryAsync(serverOrInstance, database, integratedSecurity, "SELECT 1", cancellationToken: cancellationToken, username: username, password: password, connectionString: connectionString).ConfigureAwait(false);
             return true;
         }
         catch
@@ -66,9 +66,9 @@ public class SqlServer : DatabaseClientBase
         }
     }
 
-    public virtual object? Query(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public virtual object? Query(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
     {
-        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        var cs = connectionString ?? BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
         SqlConnection? connection = null;
         bool dispose = false;
@@ -84,7 +84,7 @@ public class SqlServer : DatabaseClientBase
             }
             else
             {
-                connection = new SqlConnection(connectionString);
+                connection = new SqlConnection(cs);
                 connection.Open();
                 dispose = true;
             }
@@ -108,9 +108,9 @@ public class SqlServer : DatabaseClientBase
     private static IDictionary<string, DbType>? ConvertParameterTypes(IDictionary<string, SqlDbType>? types) =>
         DbTypeConverter.ConvertParameterTypes(types, static () => new SqlParameter(), static (p, t) => p.SqlDbType = t);
 
-    public virtual int ExecuteNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public virtual int ExecuteNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
     {
-        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        var cs = connectionString ?? BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
         SqlConnection? connection = null;
         bool dispose = false;
@@ -126,7 +126,7 @@ public class SqlServer : DatabaseClientBase
             }
             else
             {
-                connection = new SqlConnection(connectionString);
+                connection = new SqlConnection(cs);
                 connection.Open();
                 dispose = true;
             }
@@ -147,9 +147,9 @@ public class SqlServer : DatabaseClientBase
         }
     }
 
-    public virtual async Task<object?> QueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public virtual async Task<object?> QueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
     {
-        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        var cs = connectionString ?? BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
         SqlConnection? connection = null;
         bool dispose = false;
@@ -165,7 +165,7 @@ public class SqlServer : DatabaseClientBase
             }
             else
             {
-                connection = new SqlConnection(connectionString);
+                connection = new SqlConnection(cs);
                 await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
                 dispose = true;
             }
@@ -196,26 +196,26 @@ public class SqlServer : DatabaseClientBase
         return $"EXEC {procedure} {joined}";
     }
 
-    public virtual object? ExecuteStoredProcedure(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public virtual object? ExecuteStoredProcedure(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
     {
         var query = BuildStoredProcedureQuery(procedure, parameters);
-        return Query(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, parameterTypes, username, password);
+        return Query(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, parameterTypes, username, password, connectionString);
     }
 
-    public virtual Task<object?> ExecuteStoredProcedureAsync(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public virtual Task<object?> ExecuteStoredProcedureAsync(string serverOrInstance, string database, bool integratedSecurity, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
     {
         var query = BuildStoredProcedureQuery(procedure, parameters);
-        return QueryAsync(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, cancellationToken, parameterTypes, username, password);
+        return QueryAsync(serverOrInstance, database, integratedSecurity, query, parameters, useTransaction, cancellationToken, parameterTypes, username, password, connectionString);
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-    public virtual IAsyncEnumerable<DataRow> QueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public virtual IAsyncEnumerable<DataRow> QueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
     {
         return Stream();
 
         async IAsyncEnumerable<DataRow> Stream()
         {
-            var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+            var cs = connectionString ?? BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
             SqlConnection? connection = null;
             bool dispose = false;
@@ -229,7 +229,7 @@ public class SqlServer : DatabaseClientBase
             }
             else
             {
-                connection = new SqlConnection(connectionString);
+                connection = new SqlConnection(cs);
                 await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
                 dispose = true;
             }
@@ -254,7 +254,7 @@ public class SqlServer : DatabaseClientBase
 #endif
 
 
-    public virtual void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null)
+    public virtual void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null, string? connectionString = null)
     {
         lock (_syncRoot)
         {
@@ -263,24 +263,24 @@ public class SqlServer : DatabaseClientBase
                 throw new DbaTransactionException("Transaction already started.");
             }
 
-            var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+            var cs = connectionString ?? BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
-            _transactionConnection = new SqlConnection(connectionString);
+            _transactionConnection = new SqlConnection(cs);
             _transactionConnection.Open();
             _transaction = _transactionConnection.BeginTransaction();
         }
     }
 
-    public virtual async Task BeginTransactionAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null)
+    public virtual async Task BeginTransactionAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null, string? connectionString = null)
     {
         if (_transaction != null)
         {
             throw new DbaTransactionException("Transaction already started.");
         }
 
-        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        var cs = connectionString ?? BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
-        _transactionConnection = new SqlConnection(connectionString);
+        _transactionConnection = new SqlConnection(cs);
         await _transactionConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
         _transaction = (SqlTransaction)await _transactionConnection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -368,14 +368,14 @@ public class SqlServer : DatabaseClientBase
         base.Dispose(disposing);
     }
 
-    public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null)
+    public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null, string? connectionString = null)
     {
         if (queries == null)
         {
             throw new ArgumentNullException(nameof(queries));
         }
 
-        var tasks = queries.Select(q => QueryAsync(serverOrInstance, database, integratedSecurity, q, null, false, cancellationToken, username: username, password: password));
+        var tasks = queries.Select(q => QueryAsync(serverOrInstance, database, integratedSecurity, q, null, false, cancellationToken, null, username, password, connectionString));
         var results = await Task.WhenAll(tasks).ConfigureAwait(false);
         return results;
     }

--- a/DbaClientX.Tests/MySqlQueryStreamTests.cs
+++ b/DbaClientX.Tests/MySqlQueryStreamTests.cs
@@ -31,7 +31,7 @@ public class MySqlQueryStreamTests
             _rows = table.Rows.Cast<DataRow>().ToList();
         }
 
-        public override async IAsyncEnumerable<DataRow> QueryStreamAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
+        public override async IAsyncEnumerable<DataRow> QueryStreamAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null, string? connectionString = null)
         {
             foreach (var row in _rows)
             {

--- a/DbaClientX.Tests/MySqlTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/MySqlTransactionAsyncTests.cs
@@ -47,7 +47,7 @@ public class MySqlTransactionAsyncTests
         public FakeMySqlConnection? Connection { get; private set; }
         public FakeMySqlTransaction? Transaction { get; private set; }
 
-        public override async Task BeginTransactionAsync(string host, string database, string username, string password, CancellationToken cancellationToken = default)
+        public override async Task BeginTransactionAsync(string host, string database, string username, string password, CancellationToken cancellationToken = default, string? connectionString = null)
         {
             Connection = new FakeMySqlConnection();
             Transaction = await Connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -73,7 +73,7 @@ public class MySqlTransactionAsyncTests
             Transaction = null;
         }
 
-        public override Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
+        public override Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null, string? connectionString = null)
         {
             if (useTransaction && Transaction == null)
             {

--- a/DbaClientX.Tests/ParallelQueriesTests.cs
+++ b/DbaClientX.Tests/ParallelQueriesTests.cs
@@ -17,7 +17,7 @@ public class ParallelQueriesTests
             _responses = responses;
         }
 
-        public override Task<object?> QueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override Task<object?> QueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
         {
             _responses.TryGetValue(query, out var result);
             return Task.FromResult(result);

--- a/DbaClientX.Tests/PostgreSqlTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/PostgreSqlTransactionAsyncTests.cs
@@ -47,7 +47,7 @@ public class PostgreSqlTransactionAsyncTests
         public FakeNpgsqlConnection? Connection { get; private set; }
         public FakeNpgsqlTransaction? Transaction { get; private set; }
 
-        public override async Task BeginTransactionAsync(string host, string database, string username, string password, CancellationToken cancellationToken = default)
+        public override async Task BeginTransactionAsync(string host, string database, string username, string password, CancellationToken cancellationToken = default, string? connectionString = null)
         {
             Connection = new FakeNpgsqlConnection();
             Transaction = await Connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -73,7 +73,7 @@ public class PostgreSqlTransactionAsyncTests
             Transaction = null;
         }
 
-        public override Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+        public override Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null, string? connectionString = null)
         {
             if (useTransaction && Transaction == null)
             {

--- a/DbaClientX.Tests/SQLiteTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/SQLiteTransactionAsyncTests.cs
@@ -47,7 +47,7 @@ public class SQLiteTransactionAsyncTests
         public FakeSqliteConnection? Connection { get; private set; }
         public FakeSqliteTransaction? Transaction { get; private set; }
 
-        public override async Task BeginTransactionAsync(string database, CancellationToken cancellationToken = default)
+        public override async Task BeginTransactionAsync(string database, CancellationToken cancellationToken = default, string? connectionString = null)
         {
             Connection = new FakeSqliteConnection();
             Transaction = await Connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -73,7 +73,7 @@ public class SQLiteTransactionAsyncTests
             Transaction = null;
         }
 
-        public override Task<object?> QueryAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null)
+        public override Task<object?> QueryAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null, string? connectionString = null)
         {
             if (useTransaction && Transaction == null)
             {

--- a/DbaClientX.Tests/SqlQueryStreamTests.cs
+++ b/DbaClientX.Tests/SqlQueryStreamTests.cs
@@ -30,7 +30,7 @@ public class QueryStreamTests
             _rows = table.Rows.Cast<DataRow>().ToList();
         }
 
-        public override async IAsyncEnumerable<DataRow> QueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override async IAsyncEnumerable<DataRow> QueryStreamAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
         {
             foreach (var row in _rows)
             {

--- a/DbaClientX.Tests/SqlServerNonQueryTests.cs
+++ b/DbaClientX.Tests/SqlServerNonQueryTests.cs
@@ -22,7 +22,7 @@ public class SqlServerNonQueryTests
             return 1;
         }
 
-        public override int ExecuteNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override int ExecuteNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
         {
             IDictionary<string, DbType>? dbTypes = null;
             if (parameterTypes != null)
@@ -79,7 +79,7 @@ public class SqlServerNonQueryTests
     {
         public bool TransactionStarted { get; private set; }
 
-        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null)
+        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null, string? connectionString = null)
         {
             TransactionStarted = true;
         }
@@ -96,7 +96,7 @@ public class SqlServerNonQueryTests
             TransactionStarted = false;
         }
 
-        public override int ExecuteNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override int ExecuteNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
         {
             if (useTransaction && !TransactionStarted) throw new DBAClientX.DbaTransactionException("Transaction has not been started.");
             return 0;

--- a/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
@@ -46,7 +46,7 @@ public class SqlServerTransactionAsyncTests
         public FakeSqlConnection? Connection { get; private set; }
         public FakeSqlTransaction? Transaction { get; private set; }
 
-        public override async Task BeginTransactionAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null)
+        public override async Task BeginTransactionAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null, string? connectionString = null)
         {
             Connection = new FakeSqlConnection();
             Transaction = await Connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -72,7 +72,7 @@ public class SqlServerTransactionAsyncTests
             Transaction = null;
         }
 
-        public override Task<object?> QueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override Task<object?> QueryAsync(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
         {
             if (useTransaction && Transaction == null)
             {

--- a/DbaClientX.Tests/SqlServerTransactionTests.cs
+++ b/DbaClientX.Tests/SqlServerTransactionTests.cs
@@ -35,7 +35,7 @@ public class SqlServerTransactionTests
         public FakeSqlConnection? Connection { get; private set; }
         public FakeSqlTransaction? Transaction { get; private set; }
 
-        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null)
+        public override void BeginTransaction(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null, string? connectionString = null)
         {
             Connection = new FakeSqlConnection();
             Transaction = Connection.BeginTransaction();
@@ -61,7 +61,7 @@ public class SqlServerTransactionTests
             Transaction = null;
         }
 
-        public override object? Query(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+        public override object? Query(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null, string? connectionString = null)
         {
             if (useTransaction && Transaction == null)
             {


### PR DESCRIPTION
## Summary
- allow providing raw connection strings to all database providers
- bypass automatic connection string builders when a connection string is supplied
- document connection string usage in example program

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68950fd63270832eb298b832ff16784c