### PR TITLE
Add SQL dialect-aware query compilation

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -488,15 +488,15 @@ public class Query
         }
     }
 
-    public string Compile()
+    public string Compile(SqlDialect dialect = SqlDialect.SqlServer)
     {
-        var compiler = new QueryCompiler();
+        var compiler = new QueryCompiler(dialect);
         return compiler.Compile(this);
     }
 
-    public (string Sql, IReadOnlyList<object> Parameters) CompileWithParameters()
+    public (string Sql, IReadOnlyList<object> Parameters) CompileWithParameters(SqlDialect dialect = SqlDialect.SqlServer)
     {
-        var compiler = new QueryCompiler();
+        var compiler = new QueryCompiler(dialect);
         return compiler.CompileWithParameters(this);
     }
 

--- a/DbaClientX.Core/QueryBuilder/QueryBuilder.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryBuilder.cs
@@ -6,15 +6,15 @@ public static class QueryBuilder
 {
     public static Query Query() => new Query();
 
-    public static string Compile(Query query)
+    public static string Compile(Query query, SqlDialect dialect = SqlDialect.SqlServer)
     {
-        var compiler = new QueryCompiler();
+        var compiler = new QueryCompiler(dialect);
         return compiler.Compile(query);
     }
 
-    public static (string Sql, IReadOnlyList<object> Parameters) CompileWithParameters(Query query)
+    public static (string Sql, IReadOnlyList<object> Parameters) CompileWithParameters(Query query, SqlDialect dialect = SqlDialect.SqlServer)
     {
-        var compiler = new QueryCompiler();
+        var compiler = new QueryCompiler(dialect);
         return compiler.CompileWithParameters(query);
     }
 }

--- a/DbaClientX.Core/QueryBuilder/SqlDialect.cs
+++ b/DbaClientX.Core/QueryBuilder/SqlDialect.cs
@@ -1,0 +1,12 @@
+namespace DBAClientX.QueryBuilder;
+
+/// <summary>
+/// Supported SQL dialects for query compilation.
+/// </summary>
+public enum SqlDialect
+{
+    SqlServer,
+    PostgreSql,
+    MySql,
+    SQLite
+}

--- a/DbaClientX.Examples/DialectExample.cs
+++ b/DbaClientX.Examples/DialectExample.cs
@@ -1,0 +1,19 @@
+using DBAClientX.QueryBuilder;
+
+public static class DialectExample
+{
+    public static void Run()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .OrderBy("name")
+            .Limit(5)
+            .Offset(2);
+
+        Console.WriteLine("PostgreSql: " + QueryBuilder.Compile(query, SqlDialect.PostgreSql));
+        Console.WriteLine("MySql:      " + QueryBuilder.Compile(query, SqlDialect.MySql));
+        Console.WriteLine("SQLite:     " + QueryBuilder.Compile(query, SqlDialect.SQLite));
+        Console.WriteLine("SqlServer:  " + QueryBuilder.Compile(query, SqlDialect.SqlServer));
+    }
+}


### PR DESCRIPTION
## Summary
- add `SqlDialect` enum to represent supported database dialects
- make `QueryCompiler` quote identifiers and paginate based on dialect
- expose dialect selection through query builder helpers
- set default SQL dialect to `SqlServer` and update tests accordingly
- document usage with new dialect example and tests for PostgreSQL, MySQL, SQLite, and SQL Server

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68950fed38d4832e844f20263205a0da