### PR TITLE
Support multi-row VALUES in Query builder

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -12,7 +12,7 @@ public class Query
     private readonly List<IWhereToken> _where = new();
     private string _insertTable;
     private readonly List<string> _insertColumns = new();
-    private readonly List<object> _values = new();
+    private readonly List<IReadOnlyList<object>> _values = new();
     private string _updateTable;
     private readonly List<(string Column, object Value)> _set = new();
     private string _deleteTable;
@@ -463,7 +463,7 @@ public class Query
 
     public Query Values(params object[] values)
     {
-        _values.AddRange(values);
+        _values.Add(new List<object>(values));
         return this;
     }
 
@@ -506,7 +506,7 @@ public class Query
     public IReadOnlyList<IWhereToken> WhereTokens => _where;
     public string InsertTable => _insertTable;
     public IReadOnlyList<string> InsertColumns => _insertColumns;
-    public IReadOnlyList<object> InsertValues => _values;
+    public IReadOnlyList<IReadOnlyList<object>> InsertValues => _values;
     public string UpdateTable => _updateTable;
     public IReadOnlyList<(string Column, object Value)> SetValues => _set;
     public string DeleteTable => _deleteTable;

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -44,18 +44,26 @@ public class QueryCompiler
 
             if (query.InsertValues.Count > 0)
             {
-                sb.Append(" VALUES (");
-                bool firstValue = true;
-                foreach (var value in query.InsertValues)
+                sb.Append(" VALUES ");
+                bool firstRow = true;
+                foreach (var row in query.InsertValues)
                 {
-                    if (!firstValue)
+                    if (!firstRow)
                     {
                         sb.Append(", ");
                     }
-                    AppendValue(sb, value, parameters);
-                    firstValue = false;
+                    sb.Append('(');
+                    for (int i = 0; i < row.Count; i++)
+                    {
+                        if (i > 0)
+                        {
+                            sb.Append(", ");
+                        }
+                        AppendValue(sb, row[i], parameters);
+                    }
+                    sb.Append(')');
+                    firstRow = false;
                 }
-                sb.Append(')');
             }
 
             return sb.ToString();

--- a/DbaClientX.Examples/InsertValuesExample.cs
+++ b/DbaClientX.Examples/InsertValuesExample.cs
@@ -1,0 +1,14 @@
+using DBAClientX.QueryBuilder;
+
+public static class InsertValuesExample
+{
+    public static void Run()
+    {
+        var query = new Query()
+            .InsertInto("users", "name", "age")
+            .Values("Alice", 30)
+            .Values("Bob", 40);
+
+        Console.WriteLine(QueryBuilder.Compile(query, SqlDialect.PostgreSql));
+    }
+}

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -41,6 +41,18 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void InsertMultipleRows()
+    {
+        var query = new Query()
+            .InsertInto("users", "name", "age")
+            .Values("Alice", 30)
+            .Values("Bob", 40);
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
+        Assert.Equal("INSERT INTO \"users\" (\"name\", \"age\") VALUES ('Alice', 30), ('Bob', 40)", sql);
+    }
+
+    [Fact]
     public void UpdateWithWhere()
     {
         var query = new Query()


### PR DESCRIPTION
## Summary
- allow `Query` to capture multiple `Values` sets
- compile multi-row `VALUES` clauses
- add example and tests for multi-row inserts

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6895d8080c40832e8a83c6903d5ef613