### PR TITLE
Add MySQL stored procedure execution

### DIFF
--- a/DbaClientX.Examples/StoredProcedureMySqlExample.cs
+++ b/DbaClientX.Examples/StoredProcedureMySqlExample.cs
@@ -1,0 +1,33 @@
+using DBAClientX;
+using System.Collections.Generic;
+using System.Data;
+
+public static class StoredProcedureMySqlExample
+{
+    public static void Run()
+    {
+        using var mySql = new MySql
+        {
+            ReturnType = ReturnType.DataTable,
+        };
+
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 1
+        };
+
+        var result = mySql.ExecuteStoredProcedure("localhost", "mysql", "user", "password", "sp_test", parameters);
+
+        if (result is DataTable table)
+        {
+            foreach (DataRow row in table.Rows)
+            {
+                foreach (DataColumn col in table.Columns)
+                {
+                    Console.Write($"{row[col]}\t");
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -260,6 +260,28 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    private static string BuildStoredProcedureQuery(string procedure, IDictionary<string, object?>? parameters)
+    {
+        if (parameters == null || parameters.Count == 0)
+        {
+            return $"CALL {procedure}()";
+        }
+        var joined = string.Join(", ", parameters.Keys);
+        return $"CALL {procedure}({joined})";
+    }
+
+    public virtual object? ExecuteStoredProcedure(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    {
+        var query = BuildStoredProcedureQuery(procedure, parameters);
+        return Query(host, database, username, password, query, parameters, useTransaction, parameterTypes);
+    }
+
+    public virtual Task<object?> ExecuteStoredProcedureAsync(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    {
+        var query = BuildStoredProcedureQuery(procedure, parameters);
+        return QueryAsync(host, database, username, password, query, parameters, useTransaction, cancellationToken, parameterTypes);
+    }
+
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
     public virtual IAsyncEnumerable<DataRow> QueryStreamAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
     {


### PR DESCRIPTION
## Summary
- add stored procedure execution helpers for MySQL
- cover MySQL stored procedures with unit tests
- demonstrate MySQL stored procedure usage

## Testing
- `dotnet test`
- `dotnet build DbaClientX.MySql/DbaClientX.MySql.csproj -f netstandard2.0`


------
https://chatgpt.com/codex/tasks/task_e_6895d81147c0832e8542857cf401131d