### PR TITLE
Support output DbParameters in stored procedure calls

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -54,6 +54,19 @@ public abstract class DatabaseClientBase : IDisposable
         }
     }
 
+    protected virtual void AddParameters(DbCommand command, IEnumerable<DbParameter>? parameters)
+    {
+        if (parameters == null)
+        {
+            return;
+        }
+
+        foreach (var parameter in parameters)
+        {
+            command.Parameters.Add(parameter);
+        }
+    }
+
     private static DbType InferDbType(object? value)
     {
         if (value == null || value == DBNull.Value) return DbType.Object;
@@ -204,7 +217,7 @@ public abstract class DatabaseClientBase : IDisposable
     }
 #endif
 
-    private object? BuildResult(DataSet dataSet)
+    protected object? BuildResult(DataSet dataSet)
     {
         var returnType = ReturnType;
         if (returnType == ReturnType.DataRow)

--- a/DbaClientX.Examples/StoredProcedureExample.cs
+++ b/DbaClientX.Examples/StoredProcedureExample.cs
@@ -1,6 +1,7 @@
 using DBAClientX;
 using System.Data;
 using System.Collections.Generic;
+using System.Data.SqlClient;
 
 public static class StoredProcedureExample
 {
@@ -11,9 +12,9 @@ public static class StoredProcedureExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var parameters = new Dictionary<string, object?>
+        var parameters = new List<SqlParameter>
         {
-            ["@dbname"] = "master"
+            new("@dbname", "master")
         };
 
         var result = sqlServer.ExecuteStoredProcedure("SQL1", "master", true, "sp_helpdb", parameters);

--- a/DbaClientX.Examples/StoredProcedurePostgreSqlExample.cs
+++ b/DbaClientX.Examples/StoredProcedurePostgreSqlExample.cs
@@ -1,6 +1,7 @@
 using DBAClientX;
 using System.Collections.Generic;
 using System.Data;
+using Npgsql;
 
 public static class StoredProcedurePostgreSqlExample
 {
@@ -11,9 +12,9 @@ public static class StoredProcedurePostgreSqlExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var parameters = new Dictionary<string, object?>
+        var parameters = new List<NpgsqlParameter>
         {
-            ["@id"] = 1
+            new("@id", 1)
         };
 
         var result = pg.ExecuteStoredProcedure("localhost", "postgres", "user", "password", "sp_test", parameters);

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -261,26 +261,124 @@ public class PostgreSql : DatabaseClientBase
         }
     }
 
-    private static string BuildStoredProcedureQuery(string procedure, IDictionary<string, object?>? parameters)
+    public virtual object? ExecuteStoredProcedure(string host, string database, string username, string password, string procedure, IEnumerable<DbParameter>? parameters = null, bool useTransaction = false)
     {
-        if (parameters == null || parameters.Count == 0)
+        var connectionString = BuildConnectionString(host, database, username, password);
+
+        NpgsqlConnection? connection = null;
+        bool dispose = false;
+        try
         {
-            return $"CALL {procedure}()";
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new NpgsqlConnection(connectionString);
+                connection.Open();
+                dispose = true;
+            }
+
+            using var command = connection.CreateCommand();
+            command.CommandText = procedure;
+            command.CommandType = CommandType.StoredProcedure;
+            command.Transaction = useTransaction ? _transaction : null;
+            AddParameters(command, parameters);
+            var commandTimeout = CommandTimeout;
+            if (commandTimeout > 0)
+            {
+                command.CommandTimeout = commandTimeout;
+            }
+
+            var dataSet = new DataSet();
+            using var reader = command.ExecuteReader();
+            var tableIndex = 0;
+            do
+            {
+                var table = new DataTable($"Table{tableIndex}");
+                table.Load(reader);
+                dataSet.Tables.Add(table);
+                tableIndex++;
+            } while (!reader.IsClosed && reader.NextResult());
+
+            return BuildResult(dataSet);
         }
-        var joined = string.Join(", ", parameters.Keys);
-        return $"CALL {procedure}({joined})";
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
     }
 
-    public virtual object? ExecuteStoredProcedure(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    public virtual async Task<object?> ExecuteStoredProcedureAsync(string host, string database, string username, string password, string procedure, IEnumerable<DbParameter>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default)
     {
-        var query = BuildStoredProcedureQuery(procedure, parameters);
-        return Query(host, database, username, password, query, parameters, useTransaction, parameterTypes);
-    }
+        var connectionString = BuildConnectionString(host, database, username, password);
 
-    public virtual Task<object?> ExecuteStoredProcedureAsync(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
-    {
-        var query = BuildStoredProcedureQuery(procedure, parameters);
-        return QueryAsync(host, database, username, password, query, parameters, useTransaction, cancellationToken, parameterTypes);
+        NpgsqlConnection? connection = null;
+        bool dispose = false;
+        try
+        {
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new NpgsqlConnection(connectionString);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                dispose = true;
+            }
+
+            using var command = connection.CreateCommand();
+            command.CommandText = procedure;
+            command.CommandType = CommandType.StoredProcedure;
+            command.Transaction = useTransaction ? _transaction : null;
+            AddParameters(command, parameters);
+            var commandTimeout = CommandTimeout;
+            if (commandTimeout > 0)
+            {
+                command.CommandTimeout = commandTimeout;
+            }
+
+            var dataSet = new DataSet();
+            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            var tableIndex = 0;
+            do
+            {
+                var table = new DataTable($"Table{tableIndex}");
+                table.Load(reader);
+                dataSet.Tables.Add(table);
+                tableIndex++;
+            } while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+
+            return BuildResult(dataSet);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER


### PR DESCRIPTION
## Summary
- allow AddParameters to take DbParameter collections
- enable SqlServer and PostgreSql stored procedures to accept DbParameters with output directions
- add tests demonstrating output parameter retrieval

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689615cbe484832e815c4b90ab5cba84