### PR TITLE
Add upsert support with dialect-specific compilation

### DIFF
--- a/DbaClientX.Examples/InsertOrUpdateExample.cs
+++ b/DbaClientX.Examples/InsertOrUpdateExample.cs
@@ -1,0 +1,19 @@
+using System;
+using DBAClientX.QueryBuilder;
+
+namespace DbaClientX.Examples;
+
+public static class InsertOrUpdateExample
+{
+    public static void Run()
+    {
+        var values = new[] { ("id", (object)1), ("name", "Alice") };
+        var query = new Query()
+            .InsertOrUpdate("users", values, "id");
+
+        Console.WriteLine(QueryBuilder.Compile(query, SqlDialect.PostgreSql));
+        Console.WriteLine(QueryBuilder.Compile(query, SqlDialect.MySql));
+        Console.WriteLine(QueryBuilder.Compile(query, SqlDialect.SqlServer));
+        Console.WriteLine(QueryBuilder.Compile(query, SqlDialect.SQLite));
+    }
+}

--- a/DbaClientX.Examples/InsertOrUpdateExample.cs
+++ b/DbaClientX.Examples/InsertOrUpdateExample.cs
@@ -1,8 +1,6 @@
 using System;
 using DBAClientX.QueryBuilder;
 
-namespace DbaClientX.Examples;
-
 public static class InsertOrUpdateExample
 {
     public static void Run()

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -46,8 +46,11 @@ public class Program
             case "joins":
                 JoinExample.Run();
                 break;
+            case "upsert":
+                InsertOrUpdateExample.Run();
+                break;
             default:
-                Console.WriteLine("Available examples: asyncquery, pgasyncquery, mysqlasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized, joins");
+                Console.WriteLine("Available examples: asyncquery, pgasyncquery, mysqlasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized, joins, upsert");
                 break;
         }
     }

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -53,6 +53,46 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void InsertOrUpdate_PostgreSql_UsesOnConflict()
+    {
+        var query = new Query()
+            .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", "Bob") }, "id");
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
+        Assert.Equal("INSERT INTO \"users\" (\"id\", \"name\") VALUES (1, 'Bob') ON CONFLICT (\"id\") DO UPDATE SET \"id\" = EXCLUDED.\"id\", \"name\" = EXCLUDED.\"name\"", sql);
+    }
+
+    [Fact]
+    public void InsertOrUpdate_MySql_UsesOnDuplicateKey()
+    {
+        var query = new Query()
+            .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", "Bob") }, "id");
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.MySql);
+        Assert.Equal("INSERT INTO `users` (`id`, `name`) VALUES (1, 'Bob') ON DUPLICATE KEY UPDATE `id` = VALUES(`id`), `name` = VALUES(`name`)", sql);
+    }
+
+    [Fact]
+    public void InsertOrUpdate_Sqlite_UsesOnConflict()
+    {
+        var query = new Query()
+            .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", "Bob") }, "id");
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.SQLite);
+        Assert.Equal("INSERT INTO \"users\" (\"id\", \"name\") VALUES (1, 'Bob') ON CONFLICT (\"id\") DO UPDATE SET \"id\" = EXCLUDED.\"id\", \"name\" = EXCLUDED.\"name\"", sql);
+    }
+
+    [Fact]
+    public void InsertOrUpdate_SqlServer_UsesMerge()
+    {
+        var query = new Query()
+            .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", "Bob") }, "id");
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.SqlServer);
+        Assert.Equal("MERGE INTO [users] AS target USING (VALUES (1, 'Bob')) AS source ([id], [name]) ON (target.[id] = source.[id]) WHEN MATCHED THEN UPDATE SET target.[id] = source.[id], target.[name] = source.[name] WHEN NOT MATCHED THEN INSERT ([id], [name]) VALUES (source.[id], source.[name])", sql);
+    }
+
+    [Fact]
     public void UpdateWithWhere()
     {
         var query = new Query()


### PR DESCRIPTION
## Summary
- add `InsertOrUpdate` query builder method
- compile upsert to `ON CONFLICT`, `ON DUPLICATE KEY`, or `MERGE` depending on SQL dialect
- document upsert usage with new example and tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689615cf3b18832e88b72536277fe4ba