### PR TITLE
Add optional logging callback for executed commands

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -16,6 +16,7 @@ public abstract class DatabaseClientBase : IDisposable
     private ReturnType _returnType;
     private int _commandTimeout;
     private bool _disposed;
+    private Action<string>? _logAction;
 
     public ReturnType ReturnType
     {
@@ -27,6 +28,12 @@ public abstract class DatabaseClientBase : IDisposable
     {
         get { lock (_syncRoot) { return _commandTimeout; } }
         set { lock (_syncRoot) { _commandTimeout = value; } }
+    }
+
+    public Action<string>? LogAction
+    {
+        get { lock (_syncRoot) { return _logAction; } }
+        set { lock (_syncRoot) { _logAction = value; } }
     }
 
     protected virtual void AddParameters(DbCommand command, IDictionary<string, object?>? parameters, IDictionary<string, DbType>? parameterTypes = null)
@@ -99,7 +106,8 @@ public abstract class DatabaseClientBase : IDisposable
         {
             command.CommandTimeout = commandTimeout;
         }
-
+        var logAction = LogAction;
+        logAction?.Invoke(command.CommandText);
         var dataSet = new DataSet();
         using var reader = command.ExecuteReader();
         var tableIndex = 0;
@@ -125,7 +133,8 @@ public abstract class DatabaseClientBase : IDisposable
         {
             command.CommandTimeout = commandTimeout;
         }
-
+        var logAction = LogAction;
+        logAction?.Invoke(command.CommandText);
         return command.ExecuteNonQuery();
     }
 
@@ -140,7 +149,8 @@ public abstract class DatabaseClientBase : IDisposable
         {
             command.CommandTimeout = commandTimeout;
         }
-
+        var logAction = LogAction;
+        logAction?.Invoke(command.CommandText);
         return command.ExecuteScalar();
     }
 
@@ -155,7 +165,8 @@ public abstract class DatabaseClientBase : IDisposable
         {
             command.CommandTimeout = commandTimeout;
         }
-
+        var logAction = LogAction;
+        logAction?.Invoke(command.CommandText);
         var dataSet = new DataSet();
         using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         var tableIndex = 0;
@@ -181,7 +192,8 @@ public abstract class DatabaseClientBase : IDisposable
         {
             command.CommandTimeout = commandTimeout;
         }
-
+        var logAction = LogAction;
+        logAction?.Invoke(command.CommandText);
         return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
     }
 
@@ -197,7 +209,8 @@ public abstract class DatabaseClientBase : IDisposable
         {
             command.CommandTimeout = commandTimeout;
         }
-
+        var logAction = LogAction;
+        logAction?.Invoke(command.CommandText);
         using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         var table = new DataTable();
         for (int i = 0; i < reader.FieldCount; i++)

--- a/DbaClientX.Examples/LoggingExample.cs
+++ b/DbaClientX.Examples/LoggingExample.cs
@@ -1,0 +1,10 @@
+using System;
+
+public static class LoggingExample
+{
+    public static void Run()
+    {
+        using var client = new DBAClientX.SQLite { LogAction = Console.WriteLine };
+        client.ExecuteScalar(":memory:", "SELECT 1");
+    }
+}

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -49,8 +49,11 @@ public class Program
             case "upsert":
                 InsertOrUpdateExample.Run();
                 break;
+            case "logging":
+                LoggingExample.Run();
+                break;
             default:
-                Console.WriteLine("Available examples: asyncquery, pgasyncquery, mysqlasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized, joins, upsert");
+                Console.WriteLine("Available examples: asyncquery, pgasyncquery, mysqlasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized, joins, upsert, logging");
                 break;
         }
     }

--- a/DbaClientX.Tests/LoggingTests.cs
+++ b/DbaClientX.Tests/LoggingTests.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DbaClientX.Tests;
+
+public class LoggingTests
+{
+    [Fact]
+    public void LogAction_IsCalled_ForExecuteNonQuery()
+    {
+        var logs = new List<string>();
+        using var client = new DBAClientX.SQLite { LogAction = logs.Add };
+        client.ExecuteNonQuery(":memory:", "CREATE TABLE Test(Id INTEGER)");
+        Assert.Contains("CREATE TABLE Test(Id INTEGER)", logs);
+    }
+
+    [Fact]
+    public async Task LogAction_IsCalled_ForExecuteScalarAsync()
+    {
+        var logs = new List<string>();
+        using var client = new DBAClientX.SQLite { LogAction = logs.Add };
+        await client.ExecuteScalarAsync(":memory:", "SELECT 1");
+        Assert.Contains("SELECT 1", logs);
+    }
+}


### PR DESCRIPTION
## Summary
- allow consumers to attach an `Action<string>` via `LogAction` to `DatabaseClientBase`
- invoke the callback before executing queries and non-queries
- demonstrate usage with a logging example and associated tests

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test DbaClientX.sln`

------
https://chatgpt.com/codex/tasks/task_e_6896351be158832eb909de9ebdb4188c