### PR TITLE
Add configurable retries for transient database errors

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -15,6 +15,8 @@ public abstract class DatabaseClientBase : IDisposable
     private readonly object _syncRoot = new();
     private ReturnType _returnType;
     private int _commandTimeout;
+    private int _maxRetryAttempts = 3;
+    private TimeSpan _retryDelay = TimeSpan.FromMilliseconds(200);
     private bool _disposed;
 
     public ReturnType ReturnType
@@ -27,6 +29,78 @@ public abstract class DatabaseClientBase : IDisposable
     {
         get { lock (_syncRoot) { return _commandTimeout; } }
         set { lock (_syncRoot) { _commandTimeout = value; } }
+    }
+
+    public int MaxRetryAttempts
+    {
+        get { lock (_syncRoot) { return _maxRetryAttempts; } }
+        set { lock (_syncRoot) { _maxRetryAttempts = value; } }
+    }
+
+    public TimeSpan RetryDelay
+    {
+        get { lock (_syncRoot) { return _retryDelay; } }
+        set { lock (_syncRoot) { _retryDelay = value; } }
+    }
+
+    protected virtual bool IsTransient(Exception ex) => false;
+
+    protected T ExecuteWithRetry<T>(Func<T> operation)
+    {
+        var attempts = 0;
+        Exception? lastException = null;
+        var maxAttempts = MaxRetryAttempts < 1 ? 1 : MaxRetryAttempts;
+        while (attempts < maxAttempts)
+        {
+            try
+            {
+                return operation();
+            }
+            catch (Exception ex) when (IsTransient(ex))
+            {
+                lastException = ex;
+                attempts++;
+                if (attempts >= maxAttempts)
+                {
+                    break;
+                }
+                var delay = RetryDelay;
+                if (delay > TimeSpan.Zero)
+                {
+                    Thread.Sleep(delay);
+                }
+            }
+        }
+        throw lastException ?? new Exception("Operation failed.");
+    }
+
+    protected async Task<T> ExecuteWithRetryAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken = default)
+    {
+        var attempts = 0;
+        Exception? lastException = null;
+        var maxAttempts = MaxRetryAttempts < 1 ? 1 : MaxRetryAttempts;
+        while (attempts < maxAttempts)
+        {
+            try
+            {
+                return await operation().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (IsTransient(ex))
+            {
+                lastException = ex;
+                attempts++;
+                if (attempts >= maxAttempts || cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                var delay = RetryDelay;
+                if (delay > TimeSpan.Zero)
+                {
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        throw lastException ?? new Exception("Operation failed.");
     }
 
     protected virtual void AddParameters(DbCommand command, IDictionary<string, object?>? parameters, IDictionary<string, DbType>? parameterTypes = null)
@@ -90,129 +164,167 @@ public abstract class DatabaseClientBase : IDisposable
 
     protected virtual object? ExecuteQuery(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, IDictionary<string, DbType>? parameterTypes = null)
     {
-        using var command = connection.CreateCommand();
-        command.CommandText = query;
-        command.Transaction = transaction;
-        AddParameters(command, parameters, parameterTypes);
-        var commandTimeout = CommandTimeout;
-        if (commandTimeout > 0)
+        return ExecuteWithRetry<object?>(() =>
         {
-            command.CommandTimeout = commandTimeout;
-        }
+            using var command = connection.CreateCommand();
+            command.CommandText = query;
+            command.Transaction = transaction;
+            AddParameters(command, parameters, parameterTypes);
+            var commandTimeout = CommandTimeout;
+            if (commandTimeout > 0)
+            {
+                command.CommandTimeout = commandTimeout;
+            }
 
-        var dataSet = new DataSet();
-        using var reader = command.ExecuteReader();
-        var tableIndex = 0;
-        do
-        {
-            var table = new DataTable($"Table{tableIndex}");
-            table.Load(reader);
-            dataSet.Tables.Add(table);
-            tableIndex++;
-        } while (!reader.IsClosed && reader.NextResult());
+            var dataSet = new DataSet();
+            using var reader = command.ExecuteReader();
+            var tableIndex = 0;
+            do
+            {
+                var table = new DataTable($"Table{tableIndex}");
+                table.Load(reader);
+                dataSet.Tables.Add(table);
+                tableIndex++;
+            } while (!reader.IsClosed && reader.NextResult());
 
-        return BuildResult(dataSet);
+            return BuildResult(dataSet);
+        });
     }
 
     protected virtual int ExecuteNonQuery(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, IDictionary<string, DbType>? parameterTypes = null)
     {
-        using var command = connection.CreateCommand();
-        command.CommandText = query;
-        command.Transaction = transaction;
-        AddParameters(command, parameters, parameterTypes);
-        var commandTimeout = CommandTimeout;
-        if (commandTimeout > 0)
+        return ExecuteWithRetry(() =>
         {
-            command.CommandTimeout = commandTimeout;
-        }
+            using var command = connection.CreateCommand();
+            command.CommandText = query;
+            command.Transaction = transaction;
+            AddParameters(command, parameters, parameterTypes);
+            var commandTimeout = CommandTimeout;
+            if (commandTimeout > 0)
+            {
+                command.CommandTimeout = commandTimeout;
+            }
 
-        return command.ExecuteNonQuery();
+            return command.ExecuteNonQuery();
+        });
     }
 
     protected virtual object? ExecuteScalar(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, IDictionary<string, DbType>? parameterTypes = null)
     {
-        using var command = connection.CreateCommand();
-        command.CommandText = query;
-        command.Transaction = transaction;
-        AddParameters(command, parameters, parameterTypes);
-        var commandTimeout = CommandTimeout;
-        if (commandTimeout > 0)
+        return ExecuteWithRetry<object?>(() =>
         {
-            command.CommandTimeout = commandTimeout;
-        }
+            using var command = connection.CreateCommand();
+            command.CommandText = query;
+            command.Transaction = transaction;
+            AddParameters(command, parameters, parameterTypes);
+            var commandTimeout = CommandTimeout;
+            if (commandTimeout > 0)
+            {
+                command.CommandTimeout = commandTimeout;
+            }
 
-        return command.ExecuteScalar();
+            return command.ExecuteScalar();
+        });
     }
 
     protected virtual async Task<object?> ExecuteQueryAsync(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, CancellationToken cancellationToken = default, IDictionary<string, DbType>? parameterTypes = null)
     {
-        using var command = connection.CreateCommand();
-        command.CommandText = query;
-        command.Transaction = transaction;
-        AddParameters(command, parameters, parameterTypes);
-        var commandTimeout = CommandTimeout;
-        if (commandTimeout > 0)
+        return await ExecuteWithRetryAsync(async () =>
         {
-            command.CommandTimeout = commandTimeout;
-        }
+            using var command = connection.CreateCommand();
+            command.CommandText = query;
+            command.Transaction = transaction;
+            AddParameters(command, parameters, parameterTypes);
+            var commandTimeout = CommandTimeout;
+            if (commandTimeout > 0)
+            {
+                command.CommandTimeout = commandTimeout;
+            }
 
-        var dataSet = new DataSet();
-        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        var tableIndex = 0;
-        do
-        {
-            var table = new DataTable($"Table{tableIndex}");
-            table.Load(reader);
-            dataSet.Tables.Add(table);
-            tableIndex++;
-        } while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+            var dataSet = new DataSet();
+            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            var tableIndex = 0;
+            do
+            {
+                var table = new DataTable($"Table{tableIndex}");
+                table.Load(reader);
+                dataSet.Tables.Add(table);
+                tableIndex++;
+            } while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
 
-        return BuildResult(dataSet);
+            return BuildResult(dataSet);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
     protected virtual async Task<object?> ExecuteScalarAsync(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, CancellationToken cancellationToken = default, IDictionary<string, DbType>? parameterTypes = null)
     {
-        using var command = connection.CreateCommand();
-        command.CommandText = query;
-        command.Transaction = transaction;
-        AddParameters(command, parameters, parameterTypes);
-        var commandTimeout = CommandTimeout;
-        if (commandTimeout > 0)
+        return await ExecuteWithRetryAsync(async () =>
         {
-            command.CommandTimeout = commandTimeout;
-        }
+            using var command = connection.CreateCommand();
+            command.CommandText = query;
+            command.Transaction = transaction;
+            AddParameters(command, parameters, parameterTypes);
+            var commandTimeout = CommandTimeout;
+            if (commandTimeout > 0)
+            {
+                command.CommandTimeout = commandTimeout;
+            }
 
-        return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
     protected virtual async IAsyncEnumerable<DataRow> ExecuteQueryStreamAsync(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, DbType>? parameterTypes = null)
     {
-        using var command = connection.CreateCommand();
-        command.CommandText = query;
-        command.Transaction = transaction;
-        AddParameters(command, parameters, parameterTypes);
-        var commandTimeout = CommandTimeout;
-        if (commandTimeout > 0)
+        var maxAttempts = MaxRetryAttempts < 1 ? 1 : MaxRetryAttempts;
+        var attempt = 0;
+        while (true)
         {
-            command.CommandTimeout = commandTimeout;
-        }
-
-        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        var table = new DataTable();
-        for (int i = 0; i < reader.FieldCount; i++)
-        {
-            table.Columns.Add(reader.GetName(i), reader.GetFieldType(i));
-        }
-
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-        {
-            var row = table.NewRow();
-            for (int i = 0; i < reader.FieldCount; i++)
+            using var command = connection.CreateCommand();
+            command.CommandText = query;
+            command.Transaction = transaction;
+            AddParameters(command, parameters, parameterTypes);
+            var commandTimeout = CommandTimeout;
+            if (commandTimeout > 0)
             {
-                row[i] = reader.IsDBNull(i) ? DBNull.Value : reader.GetValue(i);
+                command.CommandTimeout = commandTimeout;
             }
-            yield return row;
+
+            DbDataReader reader;
+            try
+            {
+                reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (IsTransient(ex) && ++attempt < maxAttempts)
+            {
+                var delay = RetryDelay;
+                if (delay > TimeSpan.Zero)
+                {
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                }
+                continue;
+            }
+
+            using (reader)
+            {
+                var table = new DataTable();
+                for (int i = 0; i < reader.FieldCount; i++)
+                {
+                    table.Columns.Add(reader.GetName(i), reader.GetFieldType(i));
+                }
+
+                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    var row = table.NewRow();
+                    for (int i = 0; i < reader.FieldCount; i++)
+                    {
+                        row[i] = reader.IsDBNull(i) ? DBNull.Value : reader.GetValue(i);
+                    }
+                    yield return row;
+                }
+                yield break;
+            }
         }
     }
 #endif

--- a/DbaClientX.Tests/RetryTests.cs
+++ b/DbaClientX.Tests/RetryTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DbaClientX.Tests;
+
+public class RetryTests
+{
+    private class TransientTestException : Exception { }
+
+    private class TransientConnection : DbConnection
+    {
+        private readonly int _failuresBeforeSuccess;
+        private int _attempts;
+        public TransientConnection(int failuresBeforeSuccess)
+        {
+            _failuresBeforeSuccess = failuresBeforeSuccess;
+        }
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new NotSupportedException();
+        public override void Close() { }
+        public override void ChangeDatabase(string databaseName) { }
+        public override void Open() { }
+        public override string ConnectionString { get; set; } = string.Empty;
+        public override string Database => string.Empty;
+        public override ConnectionState State => ConnectionState.Open;
+        public override string DataSource => string.Empty;
+        public override string ServerVersion => string.Empty;
+        protected override DbCommand CreateDbCommand() => new TransientCommand(this);
+        internal bool ShouldThrow() => Interlocked.Increment(ref _attempts) <= _failuresBeforeSuccess;
+        internal int Attempts => _attempts;
+
+        private class TransientCommand : DbCommand
+        {
+            private readonly TransientConnection _connection;
+            public TransientCommand(TransientConnection connection) => _connection = connection;
+            public override string CommandText { get; set; } = string.Empty;
+            public override int CommandTimeout { get; set; }
+            public override CommandType CommandType { get; set; }
+            public override bool DesignTimeVisible { get; set; }
+            public override UpdateRowSource UpdatedRowSource { get; set; }
+            protected override DbConnection DbConnection { get => _connection; set { } }
+            protected override DbParameterCollection DbParameterCollection { get; } = new FakeParameterCollection();
+            protected override DbTransaction DbTransaction { get; set; } = null!;
+            public override void Cancel() { }
+            public override int ExecuteNonQuery() => throw new NotSupportedException();
+            public override object? ExecuteScalar()
+            {
+                if (_connection.ShouldThrow())
+                {
+                    throw new TransientTestException();
+                }
+                return 1;
+            }
+            public override void Prepare() { }
+            protected override DbParameter CreateDbParameter() => new FakeParameter();
+            protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => throw new NotSupportedException();
+            public override Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken) => Task.FromResult(ExecuteScalar());
+        }
+
+        private class FakeParameterCollection : DbParameterCollection
+        {
+            public override int Count => 0;
+            public override object SyncRoot { get; } = new();
+            public override int Add(object value) => 0;
+            public override void AddRange(Array values) { }
+            public override void Clear() { }
+            public override bool Contains(object value) => false;
+            public override bool Contains(string value) => false;
+            public override void CopyTo(Array array, int index) { }
+            public override IEnumerator GetEnumerator() => Array.Empty<object>().GetEnumerator();
+            public override int IndexOf(object value) => -1;
+            public override int IndexOf(string parameterName) => -1;
+            public override void Insert(int index, object value) { }
+            public override void Remove(object value) { }
+            public override void RemoveAt(int index) { }
+            public override void RemoveAt(string parameterName) { }
+            protected override DbParameter GetParameter(int index) => throw new NotSupportedException();
+            protected override DbParameter GetParameter(string parameterName) => throw new NotSupportedException();
+            protected override void SetParameter(int index, DbParameter value) { }
+            protected override void SetParameter(string parameterName, DbParameter value) { }
+        }
+
+        private class FakeParameter : DbParameter
+        {
+            public override DbType DbType { get; set; }
+            public override ParameterDirection Direction { get; set; }
+            public override bool IsNullable { get; set; }
+            public override string ParameterName { get; set; } = string.Empty;
+            public override string SourceColumn { get; set; } = string.Empty;
+            public override object? Value { get; set; }
+            public override bool SourceColumnNullMapping { get; set; }
+            public override int Size { get; set; }
+            public override void ResetDbType() { }
+        }
+    }
+
+    private class RetryClient : DBAClientX.DatabaseClientBase
+    {
+        protected override bool IsTransient(Exception ex) => ex is TransientTestException;
+        public object? Run(DbConnection connection) => ExecuteScalar(connection, null, "q");
+        public Task<object?> RunAsync(DbConnection connection, CancellationToken token = default) => ExecuteScalarAsync(connection, null, "q", cancellationToken: token);
+    }
+
+    [Fact]
+    public void ExecuteScalar_RetriesTransientErrors()
+    {
+        using var client = new RetryClient { MaxRetryAttempts = 3, RetryDelay = TimeSpan.Zero };
+        var connection = new TransientConnection(2);
+        var result = client.Run(connection);
+        Assert.Equal(1, result);
+        Assert.Equal(3, connection.Attempts);
+    }
+
+    [Fact]
+    public void ExecuteScalar_ThrowsAfterMaxRetries()
+    {
+        using var client = new RetryClient { MaxRetryAttempts = 2, RetryDelay = TimeSpan.Zero };
+        var connection = new TransientConnection(5);
+        Assert.Throws<TransientTestException>(() => client.Run(connection));
+        Assert.Equal(2, connection.Attempts);
+    }
+
+    [Fact]
+    public async Task ExecuteScalarAsync_RetriesTransientErrors()
+    {
+        using var client = new RetryClient { MaxRetryAttempts = 3, RetryDelay = TimeSpan.Zero };
+        var connection = new TransientConnection(1);
+        var result = await client.RunAsync(connection);
+        Assert.Equal(1, result);
+        Assert.Equal(2, connection.Attempts);
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable retry attempts and delays to `DatabaseClientBase`
- wrap query executions in retry helper methods
- test retry logic against simulated transient failures

## Testing
- `dotnet test | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_689635110bc4832ea0fd4b8af3e34f64