### PR TITLE
docs: expand PowerShell cmdlet XML docs

### DIFF
--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
@@ -1,31 +1,61 @@
 namespace DBAClientX.PowerShell;
 
+/// <summary>Executes a non-query SQL command against SQL Server.</summary>
+/// <para>Runs an SQL statement such as INSERT, UPDATE, or DELETE and returns the number of affected rows.</para>
+/// <para>Supports SQL authentication or integrated security based on provided credentials.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Use caution with destructive statements; the cmdlet respects <c>-WhatIf</c> and <c>-Confirm</c>.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Delete rows from a table.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Invoke-DbaXNonQuery -Server 'sqlsrv' -Database 'app' -Query 'DELETE FROM Users WHERE Disabled = 1'</code>
+/// <para>Removes disabled users and outputs the number of rows deleted.</para>
+/// </example>
+/// <example>
+/// <summary>Run a command with SQL authentication.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Invoke-DbaXNonQuery -Server 'sqlsrv' -Database 'app' -Query 'TRUNCATE TABLE Logs' -Username 'user' -Password 'p@ss'</code>
+/// <para>Executes the statement using the supplied credentials.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/framework/data/adonet/using-sqlclient">Using SqlClient</seealso>
+/// <seealso href="https://github.com/EvotecIT/DbaClientX">Project documentation</seealso>
 [Cmdlet(VerbsLifecycle.Invoke, "DbaXNonQuery", DefaultParameterSetName = "DefaultCredentials", SupportsShouldProcess = true)]
 [CmdletBinding()]
 public sealed class CmdletIInvokeDbaXNonQuery : PSCmdlet {
     internal static Func<DBAClientX.SqlServer> SqlServerFactory { get; set; } = () => new DBAClientX.SqlServer();
+    /// <summary>Specifies the SQL Server instance.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
     [Alias("DBServer", "SqlInstance", "Instance")]
     [ValidateNotNullOrEmpty]
     public string Server { get; set; }
 
+    /// <summary>Defines the target database.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
     [ValidateNotNullOrEmpty]
     public string Database { get; set; }
 
+    /// <summary>The SQL command to execute.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
     [ValidateNotNullOrEmpty]
     public string Query { get; set; }
 
+    /// <summary>Sets the command timeout in seconds.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
     public int QueryTimeout { get; set; }
 
+    /// <summary>Provides parameters for the SQL command.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
     public Hashtable Parameters { get; set; }
 
+    /// <summary>Optional user name for SQL authentication.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
     public string Username { get; set; }
 
+    /// <summary>Optional password for SQL authentication.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
     public string Password { get; set; }
 

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -4,49 +4,83 @@ using System.Data.SqlClient;
 
 namespace DBAClientX.PowerShell;
 
+/// <summary>Invokes a SQL Server query or stored procedure.</summary>
+/// <para>Connects to a SQL Server instance using integrated security or supplied credentials and executes the specified command.</para>
+/// <para>Supports streaming results and multiple return formats via the <see cref="ReturnType"/> parameter.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>When <c>-ErrorAction Stop</c> is used, execution will terminate on the first error.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Run a query with integrated security.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Invoke-DbaXQuery -Server 'sqlsrv' -Database 'app' -Query 'SELECT * FROM Users'</code>
+/// <para>Executes the query and returns each row as a <see cref="DataRow"/>.</para>
+/// </example>
+/// <example>
+/// <summary>Execute a stored procedure using credentials.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Invoke-DbaXQuery -Server 'sqlsrv' -Database 'app' -StoredProcedure 'usp_DoWork' -Username 'user' -Password 'p@ss' -ReturnType DataTable</code>
+/// <para>Runs the stored procedure and outputs a <see cref="DataTable"/>.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/framework/data/adonet/using-sqlclient">Using SqlClient</seealso>
+/// <seealso href="https://github.com/EvotecIT/DbaClientX">Project documentation</seealso>
 [Cmdlet(VerbsLifecycle.Invoke, "DbaXQuery", DefaultParameterSetName = "Query", SupportsShouldProcess = true)]
 [CmdletBinding()]
 public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
     internal static Func<DBAClientX.SqlServer> SqlServerFactory { get; set; } = () => new DBAClientX.SqlServer();
+
+    /// <summary>Specifies the SQL Server instance.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [Alias("DBServer", "SqlInstance", "Instance")]
     [ValidateNotNullOrEmpty]
     public string Server { get; set; }
 
+    /// <summary>Defines the database name.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [ValidateNotNullOrEmpty]
     public string Database { get; set; }
 
+    /// <summary>The SQL statement to execute.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
     [ValidateNotNullOrEmpty]
     public string Query { get; set; }
 
+    /// <summary>Name of the stored procedure to run.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [ValidateNotNullOrEmpty]
     public string StoredProcedure { get; set; }
 
+    /// <summary>Sets the command timeout in seconds.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public int QueryTimeout { get; set; }
 
+    /// <summary>Streams results instead of buffering them.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
     public SwitchParameter Stream { get; set; }
 
+    /// <summary>Selects the type of returned objects.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     [Alias("As")]
     public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
 
+    /// <summary>Provides additional parameters for the query or procedure.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public Hashtable Parameters { get; set; }
 
+    /// <summary>Optional user name for SQL authentication.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public string Username { get; set; }
 
+    /// <summary>Optional password for SQL authentication.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public string Password { get; set; }

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
@@ -2,41 +2,73 @@ using System.Runtime.CompilerServices;
 
 namespace DBAClientX.PowerShell;
 
+/// <summary>Invokes commands against a MySQL database.</summary>
+/// <para>Connects to a MySQL server using provided credentials and executes a SQL query.</para>
+/// <para>Results can be streamed or returned in different formats based on the <see cref="ReturnType"/>.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Network operations may incur latency; consider using <c>-Stream</c> for large result sets.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Query MySQL with credentials.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Invoke-DbaXMySql -Server 'mysqlsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'SELECT * FROM Users'</code>
+/// <para>Returns each row as a <see cref="DataRow"/>.</para>
+/// </example>
+/// <example>
+/// <summary>Stream results as they arrive.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Invoke-DbaXMySql -Server 'mysqlsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'SELECT * FROM Logs' -Stream</code>
+/// <para>Streams rows without buffering the entire result.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/ef/core/providers/?tabs=dotnet-core-cli#mysql">MySQL provider on MS Learn</seealso>
+/// <seealso href="https://github.com/EvotecIT/DbaClientX">Project documentation</seealso>
 [Cmdlet(VerbsLifecycle.Invoke, "DbaXMySql", DefaultParameterSetName = "Query", SupportsShouldProcess = true)]
 [CmdletBinding()]
 public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
     internal static Func<DBAClientX.MySql> MySqlFactory { get; set; } = () => new DBAClientX.MySql();
 
+    /// <summary>Specifies the MySQL server to connect to.</summary>
     [Parameter(Mandatory = true)]
     [Alias("DBServer", "SqlInstance", "Instance")]
     [ValidateNotNullOrEmpty]
     public string Server { get; set; }
 
+    /// <summary>Defines the name of the database.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string Database { get; set; }
 
+    /// <summary>The SQL statement to execute.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string Query { get; set; }
 
+    /// <summary>Sets the timeout for the command in seconds.</summary>
     [Parameter]
     public int QueryTimeout { get; set; }
 
+    /// <summary>Streams results without buffering.</summary>
     [Parameter]
     public SwitchParameter Stream { get; set; }
 
+    /// <summary>Selects the format of the returned data.</summary>
     [Parameter]
     [Alias("As")]
     public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
 
+    /// <summary>Provides additional parameters for the query.</summary>
     [Parameter]
     public Hashtable Parameters { get; set; }
 
+    /// <summary>User name for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string Username { get; set; }
 
+    /// <summary>Password for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string Password { get; set; }

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSql.cs
@@ -4,51 +4,84 @@ using Npgsql;
 
 namespace DBAClientX.PowerShell;
 
+/// <summary>Invokes commands against a PostgreSQL database.</summary>
+/// <para>Connects to a PostgreSQL server and executes a query or stored procedure with optional parameters.</para>
+/// <para>Results can be streamed or returned in DataRow, DataTable, DataSet or PSObject formats.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>Credentials are transmitted to the server; ensure secure channels when running over a network.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Run a query using explicit credentials.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Invoke-DbaXPostgreSql -Server 'pgsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'SELECT * FROM data'</code>
+/// <para>Executes the query and returns each row as a <see cref="DataRow"/>.</para>
+/// </example>
+/// <example>
+/// <summary>Execute a stored procedure and get a DataTable.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Invoke-DbaXPostgreSql -Server 'pgsrv' -Database 'app' -Username 'user' -Password 'p@ss' -StoredProcedure 'refresh_stats' -ReturnType DataTable</code>
+/// <para>Runs the stored procedure and outputs a <see cref="DataTable"/>.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/ef/core/providers/npgsql/">Npgsql provider on MS Learn</seealso>
+/// <seealso href="https://github.com/EvotecIT/DbaClientX">Project documentation</seealso>
 [Cmdlet(VerbsLifecycle.Invoke, "DbaXPostgreSql", DefaultParameterSetName = "Query", SupportsShouldProcess = true)]
 [CmdletBinding()]
 public sealed class CmdletInvokeDbaXPostgreSql : AsyncPSCmdlet {
     internal static Func<DBAClientX.PostgreSql> PostgreSqlFactory { get; set; } = () => new DBAClientX.PostgreSql();
 
+    /// <summary>Specifies the PostgreSQL server to connect to.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [Alias("DBServer", "SqlInstance", "Instance")]
     [ValidateNotNullOrEmpty]
     public string Server { get; set; }
 
+    /// <summary>Defines the database name on the server.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [ValidateNotNullOrEmpty]
     public string Database { get; set; }
 
+    /// <summary>Provides the SQL query text to execute.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
     [ValidateNotNullOrEmpty]
     public string Query { get; set; }
 
+    /// <summary>Names the stored procedure to invoke.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [ValidateNotNullOrEmpty]
     public string StoredProcedure { get; set; }
 
+    /// <summary>Sets the command timeout in seconds.</summary>
     [Parameter(ParameterSetName = "Query")]
     [Parameter(ParameterSetName = "StoredProcedure")]
     public int QueryTimeout { get; set; }
 
+    /// <summary>Streams results instead of buffering them.</summary>
     [Parameter(ParameterSetName = "Query")]
     public SwitchParameter Stream { get; set; }
 
+    /// <summary>Selects the format of returned data.</summary>
     [Parameter(ParameterSetName = "Query")]
     [Parameter(ParameterSetName = "StoredProcedure")]
     [Alias("As")]
     public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
 
+    /// <summary>Supplies parameters for the query or stored procedure.</summary>
     [Parameter(ParameterSetName = "Query")]
     [Parameter(ParameterSetName = "StoredProcedure")]
     public Hashtable Parameters { get; set; }
 
+    /// <summary>The user name for authentication.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [ValidateNotNullOrEmpty]
     public string Username { get; set; }
 
+    /// <summary>The password for authentication.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [ValidateNotNullOrEmpty]

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
@@ -2,29 +2,58 @@ using System.Runtime.CompilerServices;
 
 namespace DBAClientX.PowerShell;
 
+/// <summary>Invokes a query against a SQLite database.</summary>
+/// <para>Executes SQL statements on a specified SQLite database and returns data in the format you choose.</para>
+/// <para>Supports streaming results for large data sets when the platform allows asynchronous enumeration.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>When <c>-Stream</c> is used on platforms without streaming support, a <see cref="NotSupportedException"/> is thrown.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Run a query and return rows.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Invoke-DbaXSQLite -Database 'app.db' -Query 'SELECT * FROM Users'</code>
+/// <para>Executes the query and outputs each row as a <see cref="DataRow"/>.</para>
+/// </example>
+/// <example>
+/// <summary>Stream results from a large query.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Invoke-DbaXSQLite -Database 'app.db' -Query 'SELECT * FROM Logs' -Stream -ReturnType DataRow</code>
+/// <para>Streams each row as it is received, which is useful for large result sets.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/dotnet/standard/data/sqlite/">SQLite in .NET</seealso>
+/// <seealso href="https://github.com/EvotecIT/DbaClientX">Project documentation</seealso>
 [Cmdlet(VerbsLifecycle.Invoke, "DbaXSQLite", DefaultParameterSetName = "Query", SupportsShouldProcess = true)]
 [CmdletBinding()]
 public sealed class CmdletInvokeDbaXSQLite : AsyncPSCmdlet {
     internal static Func<DBAClientX.SQLite> SQLiteFactory { get; set; } = () => new DBAClientX.SQLite();
 
+    /// <summary>Specifies the path to the SQLite database file.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string Database { get; set; }
 
+    /// <summary>Defines the SQL query to execute.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
     public string Query { get; set; }
 
+    /// <summary>Sets the command timeout in seconds.</summary>
     [Parameter]
     public int QueryTimeout { get; set; }
 
+    /// <summary>Streams results instead of buffering them.</summary>
     [Parameter]
     public SwitchParameter Stream { get; set; }
 
+    /// <summary>Selects the format of returned data.</summary>
     [Parameter]
     [Alias("As")]
     public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
 
+    /// <summary>Provides additional query parameters.</summary>
     [Parameter]
     public Hashtable Parameters { get; set; }
 

--- a/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
@@ -8,20 +8,46 @@ using System.Net;
 
 namespace DBAClientX.PowerShell;
 
+/// <summary>Creates a new SQL query using the DbaX query builder.</summary>
+/// <para>Constructs a basic SELECT statement against a specified table and optionally compiles it to SQL text.</para>
+/// <para>Supports limiting and offsetting rows for paging scenarios.</para>
+/// <list type="alertSet">
+/// <item>
+/// <term>Note</term>
+/// <description>The cmdlet does not validate table existence; ensure the target table is correct.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Create a query object.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>New-DbaXQuery -TableName 'Users'</code>
+/// <para>Returns a query builder object targeting the Users table.</para>
+/// </example>
+/// <example>
+/// <summary>Compile the query to SQL.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>New-DbaXQuery -TableName 'Users' -Limit 10 -Compile</code>
+/// <para>Outputs the generated SQL statement limited to ten rows.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/sql/t-sql/queries/select-transact-sql">SELECT statement (Transact-SQL)</seealso>
+/// <seealso href="https://github.com/EvotecIT/DbaClientX">Project documentation</seealso>
 [Cmdlet(VerbsCommon.New, "DbaXQuery", DefaultParameterSetName = "Compatibility", SupportsShouldProcess = true)]
 [CmdletBinding()]
 public sealed class CmdletNewDbaXQuery : PSCmdlet {
+    /// <summary>Name of the table to select from.</summary>
     [Parameter(Mandatory = true, Position = 0)]
     [ValidateNotNullOrEmpty]
     public string TableName { get; set; }
 
+    /// <summary>Compiles the query to a SQL string.</summary>
     [Parameter(Mandatory = false)]
     public SwitchParameter Compile { get; set; }
 
-
+    /// <summary>Limits the number of returned rows.</summary>
     [Parameter(Mandatory = false)]
     public int? Limit { get; set; }
 
+    /// <summary>Skips a number of rows before returning results.</summary>
     [Parameter(Mandatory = false)]
     public int? Offset { get; set; }
 

--- a/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
+++ b/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
@@ -61,7 +61,7 @@
 
 	<ItemGroup>
 		<!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
-		<PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.4.2">
+                <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
+++ b/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
@@ -55,8 +55,8 @@
         <PropertyGroup>
                 <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
                 <GenerateDocumentationFile>true</GenerateDocumentationFile>
-                <!-- Disable strict mode to avoid failing the build when documentation cannot be generated -->
-                <XmlDoc2CmdletDocStrict>false</XmlDoc2CmdletDocStrict>
+                <!-- Fail the build if documentation is missing. -->
+                <XmlDoc2CmdletDocArguments>-strict</XmlDoc2CmdletDocArguments>
         </PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary
- document SQLite invocation cmdlet with examples and notes
- add detailed help for SQL Server, MySQL, and PostgreSQL cmdlets
- enable strict XML documentation generation

## Testing
- `dotnet build DbaClientX.sln` *(fails: XmlDoc2CmdletDoc.Core.EngineException: Failed to load XML Doc comments)*
- `dotnet test DbaClientX.sln` *(fails: XmlDoc2CmdletDoc.Core.EngineException: Failed to load XML Doc comments)*

------
https://chatgpt.com/codex/tasks/task_e_68965a14b4f0832ea7b4d702dd8c10c9