### PR TITLE
Ensure insert value counts match column definitions

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -501,6 +501,16 @@ public class Query
 
     public Query Values(params object[] values)
     {
+        if (_insertColumns.Count == 0)
+        {
+            throw new InvalidOperationException("InsertInto must be called before Values.");
+        }
+
+        if (values == null || values.Length != _insertColumns.Count)
+        {
+            throw new InvalidOperationException($"Expected {_insertColumns.Count} values, but got {values?.Length ?? 0}.");
+        }
+
         _values.Add(new List<object>(values));
         return this;
     }

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -53,6 +53,24 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void ValuesCountMismatchThrows()
+    {
+        var query = new Query().InsertInto("users", "name", "age");
+
+        Assert.Throws<InvalidOperationException>(() => query.Values("Bob"));
+    }
+
+    [Fact]
+    public void SecondValuesCountMismatchThrows()
+    {
+        var query = new Query()
+            .InsertInto("users", "name", "age")
+            .Values("Alice", 30);
+
+        Assert.Throws<InvalidOperationException>(() => query.Values("Bob"));
+    }
+
+    [Fact]
     public void InsertOrUpdate_PostgreSql_UsesOnConflict()
     {
         var query = new Query()


### PR DESCRIPTION
## Summary
- guard Query.Values to match the number of InsertInto columns
- test mismatched value counts

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test DbaClientX.sln`


------
https://chatgpt.com/codex/tasks/task_e_689c9807f5dc832eb13cce11da21f128