### PR TITLE
Refactor DataRow to PSObject conversion

### DIFF
--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 
 namespace DBAClientX.PowerShell;
 
@@ -130,7 +129,7 @@ public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
                         break;
                     default:
                         await foreach (var row in enumerable.ConfigureAwait(false)) {
-                            WriteObject(DataRowToPSObject(row));
+                            WriteObject(PSObjectConverter.DataRowToPSObject(row));
                         }
                         break;
                 }
@@ -145,7 +144,7 @@ public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
             if (result != null) {
                 if (ReturnType == ReturnType.PSObject) {
                     foreach (DataRow row in ((DataTable)result).Rows) {
-                        WriteObject(DataRowToPSObject(row));
+                        WriteObject(PSObjectConverter.DataRowToPSObject(row));
                     }
                 } else {
                     WriteObject(result, true);
@@ -159,30 +158,4 @@ public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
         }
     }
 
-    private static readonly ConditionalWeakTable<DataTable, PSNoteProperty[]> _psNotePropertyCache = new();
-
-    private static PSObject DataRowToPSObject(DataRow row) {
-        PSObject psObject = new PSObject();
-
-        if (row != null && (row.RowState & DataRowState.Detached) != DataRowState.Detached) {
-            var table = row.Table;
-            if (!_psNotePropertyCache.TryGetValue(table, out var propertyTemplates)) {
-                propertyTemplates = new PSNoteProperty[table.Columns.Count];
-                for (int i = 0; i < table.Columns.Count; i++) {
-                    propertyTemplates[i] = new PSNoteProperty(table.Columns[i].ColumnName, null);
-                }
-                _psNotePropertyCache.Add(table, propertyTemplates);
-            }
-
-            for (int i = 0; i < propertyTemplates.Length; i++) {
-                var prop = (PSNoteProperty)propertyTemplates[i].Copy();
-                if (!row.IsNull(i)) {
-                    prop.Value = row[i];
-                }
-                psObject.Properties.Add(prop);
-            }
-        }
-
-        return psObject;
-    }
 }

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 
 namespace DBAClientX.PowerShell;
 
@@ -114,7 +113,7 @@ public sealed class CmdletInvokeDbaXSQLite : AsyncPSCmdlet {
                         break;
                     default:
                         await foreach (var row in enumerable.ConfigureAwait(false)) {
-                            WriteObject(DataRowToPSObject(row));
+                            WriteObject(PSObjectConverter.DataRowToPSObject(row));
                         }
                         break;
                 }
@@ -129,7 +128,7 @@ public sealed class CmdletInvokeDbaXSQLite : AsyncPSCmdlet {
             if (result != null) {
                 if (ReturnType == ReturnType.PSObject) {
                     foreach (DataRow row in ((DataTable)result).Rows) {
-                        WriteObject(DataRowToPSObject(row));
+                        WriteObject(PSObjectConverter.DataRowToPSObject(row));
                     }
                 } else {
                     WriteObject(result, true);
@@ -143,30 +142,4 @@ public sealed class CmdletInvokeDbaXSQLite : AsyncPSCmdlet {
         }
     }
 
-    private static readonly ConditionalWeakTable<DataTable, PSNoteProperty[]> _psNotePropertyCache = new();
-
-    private static PSObject DataRowToPSObject(DataRow row) {
-        PSObject psObject = new PSObject();
-
-        if (row != null && (row.RowState & DataRowState.Detached) != DataRowState.Detached) {
-            var table = row.Table;
-            if (!_psNotePropertyCache.TryGetValue(table, out var propertyTemplates)) {
-                propertyTemplates = new PSNoteProperty[table.Columns.Count];
-                for (int i = 0; i < table.Columns.Count; i++) {
-                    propertyTemplates[i] = new PSNoteProperty(table.Columns[i].ColumnName, null);
-                }
-                _psNotePropertyCache.Add(table, propertyTemplates);
-            }
-
-            for (int i = 0; i < propertyTemplates.Length; i++) {
-                var prop = (PSNoteProperty)propertyTemplates[i].Copy();
-                if (!row.IsNull(i)) {
-                    prop.Value = row[i];
-                }
-                psObject.Properties.Add(prop);
-            }
-        }
-
-        return psObject;
-    }
 }

--- a/DbaClientX.PowerShell/PSObjectConverter.cs
+++ b/DbaClientX.PowerShell/PSObjectConverter.cs
@@ -1,0 +1,48 @@
+using System.Runtime.CompilerServices;
+
+namespace DBAClientX.PowerShell;
+
+/// <summary>
+/// Provides helpers for converting common data structures to <see cref="PSObject"/> instances.
+/// </summary>
+public static class PSObjectConverter
+{
+    private static readonly ConditionalWeakTable<DataTable, PSNoteProperty[]> _psNotePropertyCache = new();
+
+    /// <summary>
+    /// Converts a <see cref="DataRow"/> into a PowerShell <see cref="PSObject"/> with note properties matching the row's columns.
+    /// </summary>
+    /// <param name="row">The data row to convert.</param>
+    /// <returns>A <see cref="PSObject"/> representing the provided data row.</returns>
+    public static PSObject DataRowToPSObject(DataRow row)
+    {
+        PSObject psObject = new PSObject();
+
+        if (row != null && (row.RowState & DataRowState.Detached) != DataRowState.Detached)
+        {
+            var table = row.Table;
+            if (!_psNotePropertyCache.TryGetValue(table, out var propertyTemplates))
+            {
+                propertyTemplates = new PSNoteProperty[table.Columns.Count];
+                for (int i = 0; i < table.Columns.Count; i++)
+                {
+                    propertyTemplates[i] = new PSNoteProperty(table.Columns[i].ColumnName, null);
+                }
+                _psNotePropertyCache.Add(table, propertyTemplates);
+            }
+
+            for (int i = 0; i < propertyTemplates.Length; i++)
+            {
+                var prop = (PSNoteProperty)propertyTemplates[i].Copy();
+                if (!row.IsNull(i))
+                {
+                    prop.Value = row[i];
+                }
+                psObject.Properties.Add(prop);
+            }
+        }
+
+        return psObject;
+    }
+}
+

--- a/DbaClientX.Tests/PSObjectConverterTests.cs
+++ b/DbaClientX.Tests/PSObjectConverterTests.cs
@@ -1,10 +1,9 @@
 using System.Data;
 using System.Management.Automation;
-using System.Reflection;
 using DBAClientX.PowerShell;
 using Xunit;
 
-public class CmdletIInvokeDbaXQueryTests
+public class PSObjectConverterTests
 {
     [Fact]
     public void DataRowToPSObjectCreatesProperties()
@@ -21,14 +20,11 @@ public class CmdletIInvokeDbaXQueryTests
         row2["Name"] = "Bob";
         table.Rows.Add(row2);
 
-        var method = typeof(CmdletIInvokeDbaXQuery).GetMethod("DataRowToPSObject", BindingFlags.NonPublic | BindingFlags.Static);
-        Assert.NotNull(method);
-
-        var ps1 = (PSObject)method!.Invoke(null, new object[] { row1 })!;
+        var ps1 = PSObjectConverter.DataRowToPSObject(row1);
         Assert.Equal(1, ps1.Properties["Id"].Value);
         Assert.Equal("Alice", ps1.Properties["Name"].Value);
 
-        var ps2 = (PSObject)method.Invoke(null, new object[] { row2 })!;
+        var ps2 = PSObjectConverter.DataRowToPSObject(row2);
         Assert.Equal(2, ps2.Properties["Id"].Value);
         Assert.Equal("Bob", ps2.Properties["Name"].Value);
     }


### PR DESCRIPTION
## Summary
- add PSObjectConverter helper for converting DataRow to PSObject
- reuse shared converter across database cmdlets
- update unit tests for new converter class

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cbba86adc832e9f491d7b08b7fd6c