### PR TITLE
feat: add port and ssl options to connection string builders

### DIFF
--- a/DbaClientX.Examples/BuildConnectionStringExample.cs
+++ b/DbaClientX.Examples/BuildConnectionStringExample.cs
@@ -4,10 +4,10 @@ public static class BuildConnectionStringExample
 {
     public static void Run()
     {
-        var mysql = DBAClientX.MySql.BuildConnectionString("localhost", "mydb", "user", "password");
-        var postgres = DBAClientX.PostgreSql.BuildConnectionString("localhost", "mydb", "user", "password");
+        var mysql = DBAClientX.MySql.BuildConnectionString("localhost", "mydb", "user", "password", port: 3307, ssl: true);
+        var postgres = DBAClientX.PostgreSql.BuildConnectionString("localhost", "mydb", "user", "password", port: 5433, ssl: true);
         var sqlite = DBAClientX.SQLite.BuildConnectionString("data.db");
-        var sqlServer = DBAClientX.SqlServer.BuildConnectionString("SQL1", "master", true);
+        var sqlServer = DBAClientX.SqlServer.BuildConnectionString("SQL1", "master", true, port: 1444, ssl: true);
         Console.WriteLine(mysql);
         Console.WriteLine(postgres);
         Console.WriteLine(sqlite);

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -24,16 +24,25 @@ public class MySql : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public static string BuildConnectionString(string host, string database, string username, string password)
+    public static string BuildConnectionString(string host, string database, string username, string password, uint? port = null, bool? ssl = null)
     {
-        return new MySqlConnectionStringBuilder
+        var builder = new MySqlConnectionStringBuilder
         {
             Server = host,
             Database = database,
             UserID = username,
             Password = password,
             Pooling = true
-        }.ConnectionString;
+        };
+        if (port.HasValue)
+        {
+            builder.Port = port.Value;
+        }
+        if (ssl.HasValue)
+        {
+            builder.SslMode = ssl.Value ? MySqlSslMode.Required : MySqlSslMode.None;
+        }
+        return builder.ConnectionString;
     }
 
     public virtual bool Ping(string host, string database, string username, string password)

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -25,16 +25,25 @@ public class PostgreSql : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public static string BuildConnectionString(string host, string database, string username, string password)
+    public static string BuildConnectionString(string host, string database, string username, string password, int? port = null, bool? ssl = null)
     {
-        return new NpgsqlConnectionStringBuilder
+        var builder = new NpgsqlConnectionStringBuilder
         {
             Host = host,
             Database = database,
             Username = username,
             Password = password,
             Pooling = true
-        }.ConnectionString;
+        };
+        if (port.HasValue)
+        {
+            builder.Port = port.Value;
+        }
+        if (ssl.HasValue)
+        {
+            builder.SslMode = ssl.Value ? SslMode.Require : SslMode.Disable;
+        }
+        return builder.ConnectionString;
     }
 
     public virtual bool Ping(string host, string database, string username, string password)

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -23,11 +23,12 @@ public class SqlServer : DatabaseClientBase
 
     public bool IsInTransaction => _transaction != null;
 
-    public static string BuildConnectionString(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null)
+    public static string BuildConnectionString(string serverOrInstance, string database, bool integratedSecurity, string? username = null, string? password = null, int? port = null, bool? ssl = null)
     {
+        var dataSource = port.HasValue ? $"{serverOrInstance},{port.Value}" : serverOrInstance;
         var connectionStringBuilder = new SqlConnectionStringBuilder
         {
-            DataSource = serverOrInstance,
+            DataSource = dataSource,
             InitialCatalog = database,
             IntegratedSecurity = integratedSecurity,
             Pooling = true
@@ -36,6 +37,10 @@ public class SqlServer : DatabaseClientBase
         {
             connectionStringBuilder.UserID = username;
             connectionStringBuilder.Password = password;
+        }
+        if (ssl.HasValue)
+        {
+            connectionStringBuilder.Encrypt = ssl.Value;
         }
         return connectionStringBuilder.ConnectionString;
     }

--- a/DbaClientX.Tests/ConnectionStringBuilderTests.cs
+++ b/DbaClientX.Tests/ConnectionStringBuilderTests.cs
@@ -20,6 +20,15 @@ public class ConnectionStringBuilderTests
     }
 
     [Fact]
+    public void MySql_BuildConnectionString_SetsPortAndSsl()
+    {
+        var cs = DBAClientX.MySql.BuildConnectionString("host", "db", "user", "pass", port: 3307, ssl: true);
+        var builder = new MySqlConnectionStringBuilder(cs);
+        Assert.Equal((uint)3307, builder.Port);
+        Assert.Equal(MySqlSslMode.Required, builder.SslMode);
+    }
+
+    [Fact]
     public void PostgreSql_BuildConnectionString_CreatesExpectedValues()
     {
         var cs = DBAClientX.PostgreSql.BuildConnectionString("host", "db", "user", "pass");
@@ -28,6 +37,15 @@ public class ConnectionStringBuilderTests
         Assert.Equal("db", builder.Database);
         Assert.Equal("user", builder.Username);
         Assert.Equal("pass", builder.Password);
+    }
+
+    [Fact]
+    public void PostgreSql_BuildConnectionString_SetsPortAndSsl()
+    {
+        var cs = DBAClientX.PostgreSql.BuildConnectionString("host", "db", "user", "pass", port: 5433, ssl: true);
+        var builder = new NpgsqlConnectionStringBuilder(cs);
+        Assert.Equal(5433, builder.Port);
+        Assert.Equal(SslMode.Require, builder.SslMode);
     }
 
     [Fact]
@@ -58,5 +76,14 @@ public class ConnectionStringBuilderTests
         Assert.False(builder.IntegratedSecurity);
         Assert.Equal("user", builder.UserID);
         Assert.Equal("pass", builder.Password);
+    }
+
+    [Fact]
+    public void SqlServer_BuildConnectionString_SetsPortAndSsl()
+    {
+        var cs = DBAClientX.SqlServer.BuildConnectionString("srv", "db", true, port: 1444, ssl: true);
+        var builder = new SqlConnectionStringBuilder(cs);
+        Assert.Equal("srv,1444", builder.DataSource);
+        Assert.True(builder.Encrypt);
     }
 }


### PR DESCRIPTION
## Summary
- allow specifying optional port and SSL in MySql, PostgreSql, and SqlServer `BuildConnectionString`
- document usage in example
- test that custom port and SSL settings persist in builders

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cddeebb64832eb9ad476379d36ffc