### PR TITLE
Add SqlBulkCopy-based bulk insert for SQL Server

### DIFF
--- a/DbaClientX.Examples/BulkInsertExample.cs
+++ b/DbaClientX.Examples/BulkInsertExample.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Data;
+
+public static class BulkInsertExample
+{
+    public static void Run()
+    {
+        using var sqlServer = new DBAClientX.SqlServer();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "Example");
+
+        sqlServer.BulkInsert("SQL1", "master", true, table, "dbo.ExampleTable", batchSize: 1000, bulkCopyTimeout: 60);
+        Console.WriteLine("Bulk insert executed.");
+    }
+}

--- a/DbaClientX.Tests/SqlServerBulkInsertTests.cs
+++ b/DbaClientX.Tests/SqlServerBulkInsertTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class SqlServerBulkInsertTests
+{
+    private class CaptureBulkCopySqlServer : DBAClientX.SqlServer
+    {
+        public int? BatchSize { get; private set; }
+        public int? Timeout { get; private set; }
+        public string? Destination { get; private set; }
+        public List<(string Source, string Destination)> Mappings { get; } = new();
+
+        protected override SqlConnection CreateConnection(string connectionString) => new();
+
+        protected override void OpenConnection(SqlConnection connection)
+        {
+            // no-op to avoid real connection
+        }
+
+        protected override Task OpenConnectionAsync(SqlConnection connection, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        protected override void WriteToServer(SqlBulkCopy bulkCopy, DataTable table)
+        {
+            BatchSize = bulkCopy.BatchSize;
+            Timeout = bulkCopy.BulkCopyTimeout;
+            Destination = bulkCopy.DestinationTableName;
+            foreach (SqlBulkCopyColumnMapping mapping in bulkCopy.ColumnMappings)
+            {
+                Mappings.Add((mapping.SourceColumn, mapping.DestinationColumn));
+            }
+        }
+
+        protected override Task WriteToServerAsync(SqlBulkCopy bulkCopy, DataTable table, CancellationToken cancellationToken)
+        {
+            WriteToServer(bulkCopy, table);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public void BulkInsert_SetsOptionsAndMappings()
+    {
+        using var sqlServer = new CaptureBulkCopySqlServer();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "test");
+
+        sqlServer.BulkInsert("s", "db", true, table, "dbo.Dest", batchSize: 100, bulkCopyTimeout: 60);
+
+        Assert.Equal(100, sqlServer.BatchSize);
+        Assert.Equal(60, sqlServer.Timeout);
+        Assert.Equal("dbo.Dest", sqlServer.Destination);
+        Assert.Contains(sqlServer.Mappings, m => m.Source == "Id" && m.Destination == "Id");
+        Assert.Contains(sqlServer.Mappings, m => m.Source == "Name" && m.Destination == "Name");
+    }
+
+    [Fact]
+    public async Task BulkInsertAsync_SetsOptionsAndMappings()
+    {
+        using var sqlServer = new CaptureBulkCopySqlServer();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "test");
+
+        await sqlServer.BulkInsertAsync("s", "db", true, table, "dbo.Dest", batchSize: 50, bulkCopyTimeout: 30);
+
+        Assert.Equal(50, sqlServer.BatchSize);
+        Assert.Equal(30, sqlServer.Timeout);
+        Assert.Equal("dbo.Dest", sqlServer.Destination);
+        Assert.Contains(sqlServer.Mappings, m => m.Source == "Id" && m.Destination == "Id");
+        Assert.Contains(sqlServer.Mappings, m => m.Source == "Name" && m.Destination == "Name");
+    }
+
+    [Fact]
+    public void BulkInsert_WithTransactionNotStarted_Throws()
+    {
+        using var sqlServer = new DBAClientX.SqlServer();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => sqlServer.BulkInsert("s", "db", true, table, "dbo.Dest", useTransaction: true));
+    }
+}


### PR DESCRIPTION
## Summary
- support bulk insert operations via `SqlBulkCopy`
- allow specifying batch size and timeout
- add example and tests for bulk insert

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cde130fdc832e9fffdec715f6dc38