### PR TITLE
Add stored procedure streaming support

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -327,7 +327,15 @@ public abstract class DatabaseClientBase : IDisposable
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
-    protected virtual async IAsyncEnumerable<DataRow> ExecuteQueryStreamAsync(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, DbType>? parameterTypes = null)
+    protected virtual async IAsyncEnumerable<DataRow> ExecuteQueryStreamAsync(
+        DbConnection connection,
+        DbTransaction? transaction,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        IDictionary<string, DbType>? parameterTypes = null,
+        IEnumerable<DbParameter>? dbParameters = null,
+        CommandType commandType = CommandType.Text)
     {
         var maxAttempts = MaxRetryAttempts < 1 ? 1 : MaxRetryAttempts;
         var attempt = 0;
@@ -335,7 +343,9 @@ public abstract class DatabaseClientBase : IDisposable
         using var command = connection.CreateCommand();
         command.CommandText = query;
         command.Transaction = transaction;
+        command.CommandType = commandType;
         AddParameters(command, parameters, parameterTypes);
+        AddParameters(command, dbParameters);
         var commandTimeout = CommandTimeout;
         if (commandTimeout > 0)
         {

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -424,6 +424,48 @@ public class PostgreSql : DatabaseClientBase
             }
         }
     }
+
+    public virtual IAsyncEnumerable<DataRow> ExecuteStoredProcedureStreamAsync(string host, string database, string username, string password, string procedure, IEnumerable<DbParameter>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        return Stream();
+
+        async IAsyncEnumerable<DataRow> Stream()
+        {
+            var connectionString = BuildConnectionString(host, database, username, password);
+
+            NpgsqlConnection? connection = null;
+            bool dispose = false;
+            if (useTransaction)
+            {
+                if (_transaction == null || _transactionConnection == null)
+                {
+                    throw new DbaTransactionException("Transaction has not been started.");
+                }
+                connection = _transactionConnection;
+            }
+            else
+            {
+                connection = new NpgsqlConnection(connectionString);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+                dispose = true;
+            }
+
+            try
+            {
+                await foreach (var row in ExecuteQueryStreamAsync(connection, useTransaction ? _transaction : null, procedure, cancellationToken: cancellationToken, dbParameters: parameters, commandType: CommandType.StoredProcedure).ConfigureAwait(false))
+                {
+                    yield return row;
+                }
+            }
+            finally
+            {
+                if (dispose)
+                {
+                    connection?.Dispose();
+                }
+            }
+        }
+    }
 #endif
 
     public virtual void BeginTransaction(string host, string database, string username, string password)

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -61,6 +61,7 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
 
     /// <summary>Streams results instead of buffering them.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public SwitchParameter Stream { get; set; }
 
     /// <summary>Selects the type of returned objects.</summary>
@@ -127,7 +128,15 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
             if (Stream.IsPresent)
             {
-                var enumerable = sqlServer.QueryStreamAsync(Server, Database, integratedSecurity, Query, parameters, cancellationToken: CancelToken, username: Username, password: Password);
+                IAsyncEnumerable<DataRow> enumerable;
+                if (!string.IsNullOrEmpty(StoredProcedure))
+                {
+                    enumerable = sqlServer.ExecuteStoredProcedureStreamAsync(Server, Database, integratedSecurity, StoredProcedure, dbParameters, cancellationToken: CancelToken, username: Username, password: Password);
+                }
+                else
+                {
+                    enumerable = sqlServer.QueryStreamAsync(Server, Database, integratedSecurity, Query, parameters, cancellationToken: CancelToken, username: Username, password: Password);
+                }
                 switch (ReturnType)
                 {
                     case ReturnType.DataRow:

--- a/Module/Examples/Example.QueryStoredProcedureStream.ps1
+++ b/Module/Examples/Example.QueryStoredProcedureStream.ps1
@@ -1,0 +1,5 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+
+Invoke-DbaXQuery -StoredProcedure "dbo.MyProcedure" -Server "SQL1" -Database "master" -Stream |
+    Format-Table


### PR DESCRIPTION
## Summary
- allow ExecuteQueryStreamAsync to accept DbParameters and stored procedure command type
- stream stored procedure results across SQL Server, MySql and PostgreSql providers
- enable Invoke-DbaXQuery to stream stored procedures and document example

## Testing
- `dotnet test`
- `pwsh -NoLogo -Command "Install-Module Pester -Scope CurrentUser -Force; Import-Module ./Module/DbaClientX.psd1 -Force; Invoke-Pester -Path Module/Tests"`

------
https://chatgpt.com/codex/tasks/task_e_689cde2094c0832ea786dc9d43ebc5c7