### PR TITLE
Add DISTINCT query support

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -7,6 +7,7 @@ namespace DBAClientX.QueryBuilder;
 public class Query
 {
     private readonly List<string> _select = new();
+    private bool _distinct;
     private string _from;
     private (Query Query, string Alias)? _fromSubquery;
     private readonly List<(string Type, string Table, string? Condition)> _joins = new();
@@ -32,6 +33,12 @@ public class Query
     {
         ValidateStrings(columns, nameof(columns));
         _select.AddRange(columns);
+        return this;
+    }
+
+    public Query Distinct()
+    {
+        _distinct = true;
         return this;
     }
 
@@ -565,6 +572,7 @@ public class Query
     public IReadOnlyList<(string Column, string Operator, object Value)> HavingClauses => _having;
     public IReadOnlyList<(string Type, string Table, string? Condition)> Joins => _joins;
     public IReadOnlyList<(string Type, Query Query)> CompoundQueries => _compoundQueries;
+    public bool IsDistinct => _distinct;
     public int? LimitValue => _limit;
     public int? OffsetValue => _offset;
     public bool UseTop => _useTop;

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -115,6 +115,10 @@ public class QueryCompiler
         }
 
         sb.Append("SELECT ");
+        if (query.IsDistinct)
+        {
+            sb.Append("DISTINCT ");
+        }
         if (_dialect == SqlDialect.SqlServer && query.LimitValue.HasValue && (query.UseTop || !query.OffsetValue.HasValue))
         {
             sb.Append("TOP ").Append(query.LimitValue.Value).Append(' ');

--- a/DbaClientX.Examples/DistinctExample.cs
+++ b/DbaClientX.Examples/DistinctExample.cs
@@ -1,0 +1,14 @@
+using DBAClientX.QueryBuilder;
+
+public static class DistinctExample
+{
+    public static void Run()
+    {
+        var query = new Query()
+            .Select("name")
+            .Distinct()
+            .From("users");
+
+        Console.WriteLine(QueryBuilder.Compile(query));
+    }
+}

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -330,6 +330,54 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void SelectDistinct_SqlServer()
+    {
+        var query = new Query()
+            .Select("name")
+            .Distinct()
+            .From("users");
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.SqlServer);
+        Assert.Equal("SELECT DISTINCT [name] FROM [users]", sql);
+    }
+
+    [Fact]
+    public void SelectDistinct_PostgreSql()
+    {
+        var query = new Query()
+            .Select("name")
+            .Distinct()
+            .From("users");
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
+        Assert.Equal("SELECT DISTINCT \"name\" FROM \"users\"", sql);
+    }
+
+    [Fact]
+    public void SelectDistinct_MySql()
+    {
+        var query = new Query()
+            .Select("name")
+            .Distinct()
+            .From("users");
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.MySql);
+        Assert.Equal("SELECT DISTINCT `name` FROM `users`", sql);
+    }
+
+    [Fact]
+    public void SelectDistinct_Sqlite()
+    {
+        var query = new Query()
+            .Select("name")
+            .Distinct()
+            .From("users");
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.SQLite);
+        Assert.Equal("SELECT DISTINCT \"name\" FROM \"users\"", sql);
+    }
+
+    [Fact]
     public void MultipleWhereClauses()
     {
         var query = new Query()


### PR DESCRIPTION
## Summary
- allow marking queries as DISTINCT via `Distinct()`
- emit `SELECT DISTINCT` for all dialects
- cover distinct queries in unit tests and examples

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689cf87db768832ea027c2fdb029b8d4