### PR TITLE
Add query compiler caching with benchmark

### DIFF
--- a/DbaClientX.Benchmarks/DbaClientX.Benchmarks.csproj
+++ b/DbaClientX.Benchmarks/DbaClientX.Benchmarks.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/DbaClientX.Benchmarks/Program.cs
+++ b/DbaClientX.Benchmarks/Program.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Diagnostics;
+using DBAClientX.QueryBuilder;
+
+namespace DbaClientX.Benchmarks;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var query = new Query().Select("*").From("users").Where("id", 1);
+        var compiler = new QueryCompiler(SqlDialect.SqlServer);
+
+        QueryCompiler.ClearCache();
+        var sw = Stopwatch.StartNew();
+        for (int i = 0; i < 10000; i++)
+        {
+            QueryCompiler.ClearCache();
+            compiler.Compile(query);
+        }
+        sw.Stop();
+        Console.WriteLine($"Uncached: {sw.ElapsedMilliseconds} ms");
+
+        QueryCompiler.ClearCache();
+        compiler.Compile(query); // populate cache
+        sw.Restart();
+        for (int i = 0; i < 10000; i++)
+        {
+            compiler.Compile(query);
+        }
+        sw.Stop();
+        Console.WriteLine($"Cached: {sw.ElapsedMilliseconds} ms");
+    }
+}

--- a/DbaClientX.Tests/QueryCompilerCacheTests.cs
+++ b/DbaClientX.Tests/QueryCompilerCacheTests.cs
@@ -1,0 +1,36 @@
+using DBAClientX.QueryBuilder;
+
+namespace DbaClientX.Tests;
+
+public class QueryCompilerCacheTests
+{
+    [Fact]
+    public void CompileUsesCache()
+    {
+        QueryCompiler.ClearCache();
+        var compiler = new QueryCompiler(SqlDialect.SqlServer);
+        var query = new Query().Select("*").From("users").Where("id", 1);
+
+        var sql1 = compiler.Compile(query);
+        var countAfterFirst = QueryCompiler.CacheCount;
+
+        var sql2 = compiler.Compile(query);
+        var countAfterSecond = QueryCompiler.CacheCount;
+
+        Assert.Equal(sql1, sql2);
+        Assert.Equal(countAfterFirst, countAfterSecond);
+    }
+
+    [Fact]
+    public void CacheIsLimited()
+    {
+        QueryCompiler.ClearCache();
+        var compiler = new QueryCompiler(SqlDialect.SqlServer);
+        for (int i = 0; i < QueryCompiler.CacheSizeLimit + 10; i++)
+        {
+            var q = new Query().Select("*").From($"t{i}");
+            compiler.Compile(q);
+        }
+        Assert.True(QueryCompiler.CacheCount <= QueryCompiler.CacheSizeLimit);
+    }
+}


### PR DESCRIPTION
## Summary
- add concurrent cache with size-based eviction to QueryCompiler
- verify cache behavior and limit in new tests
- add console benchmark project showing cached compilation speedups

## Testing
- `dotnet test`
- `dotnet run -c Release --project DbaClientX.Benchmarks`


------
https://chatgpt.com/codex/tasks/task_e_689dcff05fec832e97654ccfe79559cd