### PR TITLE
Add transient error detection and tests across providers

### DIFF
--- a/DbaClientX.Examples/RetryExample.cs
+++ b/DbaClientX.Examples/RetryExample.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+using DBAClientX;
+
+public static class RetryExample
+{
+    public static async Task RunAsync()
+    {
+        using var sqlite = new SQLite { MaxRetryAttempts = 3, RetryDelay = TimeSpan.FromSeconds(1) };
+        try
+        {
+            var result = await sqlite.ExecuteScalarAsync("test.db", "SELECT 1").ConfigureAwait(false);
+            Console.WriteLine($"Result: {result}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Operation failed after retries: {ex.Message}");
+        }
+    }
+}

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -594,6 +594,14 @@ public class MySql : DatabaseClientBase
         _transactionConnection = null;
     }
 
+    protected override bool IsTransient(Exception ex) =>
+        ex is MySqlException mysqlEx &&
+        mysqlEx.ErrorCode is MySqlErrorCode.ConnectionCountError
+            or MySqlErrorCode.LockDeadlock
+            or MySqlErrorCode.LockWaitTimeout
+            or MySqlErrorCode.UnableToConnectToHost
+            or MySqlErrorCode.XARBDeadlock;
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -600,6 +600,10 @@ public class PostgreSql : DatabaseClientBase
         _transactionConnection = null;
     }
 
+    protected override bool IsTransient(Exception ex) =>
+        ex is PostgresException pgEx &&
+        pgEx.SqlState is "40001" or "40P01" or "55P03" or "53300" or "55006";
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -421,6 +421,10 @@ public class SQLite : DatabaseClientBase
         _transactionConnection = null;
     }
 
+    protected override bool IsTransient(Exception ex) =>
+        ex is SqliteException sqliteEx &&
+        sqliteEx.SqliteErrorCode is 5 or 6;
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -721,6 +721,10 @@ public class SqlServer : DatabaseClientBase
         _transactionConnection = null;
     }
 
+    protected override bool IsTransient(Exception ex) =>
+        ex is SqlException sqlEx &&
+        sqlEx.Number is 4060 or 10928 or 10929 or 1205 or 40197 or 40501 or 40613 or 49918 or 49919 or 49920;
+
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/DbaClientX.Tests/ProviderRetryTests.cs
+++ b/DbaClientX.Tests/ProviderRetryTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Data.SqlClient;
+using MySqlConnector;
+using Npgsql;
+using Microsoft.Data.Sqlite;
+
+namespace DbaClientX.Tests;
+
+public class ProviderRetryTests
+{
+    private class MySqlRetryClient : DBAClientX.MySql
+    {
+        public T Run<T>(Func<T> operation) => ExecuteWithRetry(operation);
+    }
+
+    private static MySqlException CreateMySqlException(MySqlErrorCode code)
+    {
+        var ctor = typeof(MySqlException).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance,
+            null, new[] { typeof(MySqlErrorCode), typeof(string), typeof(string), typeof(Exception) }, null)!;
+        return (MySqlException)ctor.Invoke(new object?[] { code, null, string.Empty, null });
+    }
+
+    [Fact]
+    public void MySql_RetriesTransientErrors()
+    {
+        using var client = new MySqlRetryClient { MaxRetryAttempts = 3, RetryDelay = TimeSpan.Zero };
+        var exception = CreateMySqlException(MySqlErrorCode.LockDeadlock);
+        var attempts = 0;
+        var result = client.Run(() =>
+        {
+            if (++attempts < 3)
+            {
+                throw exception;
+            }
+            return 1;
+        });
+        Assert.Equal(1, result);
+        Assert.Equal(3, attempts);
+    }
+
+    private class PostgreSqlRetryClient : DBAClientX.PostgreSql
+    {
+        public T Run<T>(Func<T> operation) => ExecuteWithRetry(operation);
+    }
+
+    [Fact]
+    public void PostgreSql_RetriesTransientErrors()
+    {
+        using var client = new PostgreSqlRetryClient { MaxRetryAttempts = 3, RetryDelay = TimeSpan.Zero };
+        var exception = new PostgresException("msg", "S", "S", "40001");
+        var attempts = 0;
+        var result = client.Run(() =>
+        {
+            if (++attempts < 3)
+            {
+                throw exception;
+            }
+            return 1;
+        });
+        Assert.Equal(1, result);
+        Assert.Equal(3, attempts);
+    }
+
+    private class SqlServerRetryClient : DBAClientX.SqlServer
+    {
+        public T Run<T>(Func<T> operation) => ExecuteWithRetry(operation);
+    }
+
+    private static SqlException CreateSqlException(int number)
+    {
+        var errorCtor = typeof(SqlError).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)
+            .First(c => c.GetParameters().Length == 8);
+        var error = errorCtor.Invoke(new object?[]
+        {
+            number, (byte)0, (byte)0, string.Empty, string.Empty, string.Empty, 1, null
+        });
+        var collection = (SqlErrorCollection)typeof(SqlErrorCollection).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0]
+            .Invoke(null);
+        typeof(SqlErrorCollection).GetMethod("Add", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .Invoke(collection, new[] { error });
+        var ctor = typeof(SqlException).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)
+            .First(c => c.GetParameters().Length == 4);
+        return (SqlException)ctor.Invoke(new object?[] { "msg", collection, null, Guid.NewGuid() });
+    }
+
+    [Fact]
+    public void SqlServer_RetriesTransientErrors()
+    {
+        using var client = new SqlServerRetryClient { MaxRetryAttempts = 3, RetryDelay = TimeSpan.Zero };
+        var exception = CreateSqlException(1205);
+        var attempts = 0;
+        var result = client.Run(() =>
+        {
+            if (++attempts < 3)
+            {
+                throw exception;
+            }
+            return 1;
+        });
+        Assert.Equal(1, result);
+        Assert.Equal(3, attempts);
+    }
+
+    private class SqliteRetryClient : DBAClientX.SQLite
+    {
+        public T Run<T>(Func<T> operation) => ExecuteWithRetry(operation);
+    }
+
+    [Fact]
+    public void Sqlite_RetriesTransientErrors()
+    {
+        using var client = new SqliteRetryClient { MaxRetryAttempts = 3, RetryDelay = TimeSpan.Zero };
+        var exception = new SqliteException("msg", 5);
+        var attempts = 0;
+        var result = client.Run(() =>
+        {
+            if (++attempts < 3)
+            {
+                throw exception;
+            }
+            return 1;
+        });
+        Assert.Equal(1, result);
+        Assert.Equal(3, attempts);
+    }
+}


### PR DESCRIPTION
## Summary
- detect provider-specific transient errors in MySql, PostgreSql, SqlServer, and SQLite
- add example of configuring retries
- test retry logic against transient provider exceptions

## Testing
- `dotnet test DbaClientX.Tests/DbaClientX.Tests.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_689dcff3c1cc832ea92b56e63e3a8a55