### PR TITLE
Support additional primitive types in DbType inference

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -172,17 +172,24 @@ public abstract class DatabaseClientBase : IDisposable
         if (value == null || value == DBNull.Value) return DbType.Object;
         if (value is Guid) return DbType.Guid;
         if (value is byte[]) return DbType.Binary;
+        if (value is TimeSpan) return DbType.Time;
+        if (value is DateTimeOffset) return DbType.DateTimeOffset;
         return Type.GetTypeCode(value.GetType()) switch
         {
             TypeCode.Byte => DbType.Byte,
+            TypeCode.SByte => DbType.SByte,
             TypeCode.Int16 => DbType.Int16,
             TypeCode.Int32 => DbType.Int32,
             TypeCode.Int64 => DbType.Int64,
+            TypeCode.UInt16 => DbType.UInt16,
+            TypeCode.UInt32 => DbType.UInt32,
+            TypeCode.UInt64 => DbType.UInt64,
             TypeCode.Decimal => DbType.Decimal,
             TypeCode.Double => DbType.Double,
             TypeCode.Single => DbType.Single,
             TypeCode.Boolean => DbType.Boolean,
             TypeCode.String => DbType.String,
+            TypeCode.Char => DbType.StringFixedLength,
             TypeCode.DateTime => DbType.DateTime,
             _ => DbType.Object
         };

--- a/DbaClientX.Examples/InferDbTypeExample.cs
+++ b/DbaClientX.Examples/InferDbTypeExample.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using DBAClientX;
+
+public static class InferDbTypeExample
+{
+    public static void Run()
+    {
+        using var sqlServer = new SqlServer();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@offset"] = DateTimeOffset.UtcNow,
+            ["@duration"] = TimeSpan.FromMinutes(1),
+            ["@letter"] = 'A'
+        };
+        sqlServer.Query("SQL1", "master", true, "SELECT @offset, @duration, @letter", parameters);
+    }
+}

--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -43,6 +43,9 @@ public class Program
             case "parameterized":
                 ParameterizedQueryExample.Run();
                 break;
+            case "inferdbtype":
+                InferDbTypeExample.Run();
+                break;
             case "joins":
                 JoinExample.Run();
                 break;
@@ -50,7 +53,7 @@ public class Program
                 InsertOrUpdateExample.Run();
                 break;
             default:
-                Console.WriteLine("Available examples: asyncquery, pgasyncquery, mysqlasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized, joins, upsert");
+                Console.WriteLine("Available examples: asyncquery, pgasyncquery, mysqlasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized, inferdbtype, joins, upsert");
                 break;
         }
     }

--- a/DbaClientX.Tests/InferDbTypeTests.cs
+++ b/DbaClientX.Tests/InferDbTypeTests.cs
@@ -38,4 +38,24 @@ public class InferDbTypeTests
         Assert.Equal(DbType.Binary, parameter.DbType);
         Assert.Equal(bytes, parameter.Value);
     }
+
+    public static IEnumerable<object[]> InferDbTypeData => new[]
+    {
+        new object[] { TimeSpan.FromMinutes(1), DbType.Time },
+        new object[] { DateTimeOffset.UtcNow, DbType.DateTimeOffset },
+        new object[] { (sbyte)1, DbType.SByte },
+        new object[] { (ushort)1, DbType.UInt16 },
+        new object[] { (uint)1, DbType.UInt32 },
+        new object[] { (ulong)1, DbType.UInt64 },
+        new object[] { 'a', DbType.StringFixedLength }
+    };
+
+    [Theory]
+    [MemberData(nameof(InferDbTypeData))]
+    public void InferDbType_ReturnsExpected(object value, DbType expected)
+    {
+        var method = typeof(DBAClientX.DatabaseClientBase).GetMethod("InferDbType", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+        var result = (DbType)method.Invoke(null, new[] { value })!;
+        Assert.Equal(expected, result);
+    }
 }


### PR DESCRIPTION
## Summary
- infer DbType for TimeSpan, DateTimeOffset, signed/unsigned integer types, and char
- add tests for new type mappings
- include example demonstrating inferred parameter types

## Testing
- `dotnet build --no-restore`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a490091a08832ea334818326802daa