### PR TITLE
feat(sqlserver): add isolation level overloads

### DIFF
--- a/DbaClientX.Examples/TransactionAsyncExample.cs
+++ b/DbaClientX.Examples/TransactionAsyncExample.cs
@@ -1,5 +1,6 @@
 using DBAClientX;
 using System;
+using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -8,7 +9,7 @@ public static class TransactionAsyncExample
     public static async Task RunAsync(CancellationToken cancellationToken = default)
     {
         using var sql = new SqlServer();
-        await sql.BeginTransactionAsync("SQL1", "master", true, cancellationToken).ConfigureAwait(false);
+        await sql.BeginTransactionAsync("SQL1", "master", true, IsolationLevel.Serializable, cancellationToken).ConfigureAwait(false);
         try
         {
             await sql.QueryAsync("SQL1", "master", true, "CREATE TABLE #temp(id int)", null, true, cancellationToken).ConfigureAwait(false);

--- a/DbaClientX.Examples/TransactionExample.cs
+++ b/DbaClientX.Examples/TransactionExample.cs
@@ -1,5 +1,6 @@
 using DBAClientX;
 using System;
+using System.Data;
 using System.Threading.Tasks;
 
 public static class TransactionExample
@@ -7,7 +8,7 @@ public static class TransactionExample
     public static Task RunAsync()
     {
         using var sql = new SqlServer();
-        sql.BeginTransaction("SQL1", "master", true);
+        sql.BeginTransaction("SQL1", "master", true, IsolationLevel.Serializable);
         try
         {
             sql.Query("SQL1", "master", true, "CREATE TABLE #temp(id int)", null, true);


### PR DESCRIPTION
## Summary
- allow specifying IsolationLevel when starting a SQL Server transaction
- cover IsolationLevel overloads with unit tests
- update transaction examples to demonstrate IsolationLevel usage

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a490139a94832ea9c2977c7e02614e