### PR TITLE
Add MySQL bulk insert with batching support

### DIFF
--- a/DbaClientX.Examples/BulkInsertMySqlExample.cs
+++ b/DbaClientX.Examples/BulkInsertMySqlExample.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Data;
+
+public static class BulkInsertMySqlExample
+{
+    public static void Run()
+    {
+        using var mySql = new DBAClientX.MySql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "Example");
+
+        mySql.BulkInsert("localhost", "database", "user", "password", table, "ExampleTable", batchSize: 1000, bulkCopyTimeout: 60);
+        Console.WriteLine("Bulk insert executed.");
+    }
+}

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -483,6 +483,151 @@ public class MySql : DatabaseClientBase
     }
 #endif
 
+    public virtual void BulkInsert(string host, string database, string username, string password, DataTable table, string destinationTable, bool useTransaction = false, int? batchSize = null, int? bulkCopyTimeout = null)
+    {
+        if (table == null) throw new ArgumentNullException(nameof(table));
+
+        var connectionString = BuildConnectionString(host, database, username, password);
+
+        MySqlConnection? connection = null;
+        bool dispose = false;
+        if (useTransaction)
+        {
+            if (_transaction == null || _transactionConnection == null)
+            {
+                throw new DbaTransactionException("Transaction has not been started.");
+            }
+            connection = _transactionConnection;
+        }
+        else
+        {
+            connection = CreateConnection(connectionString);
+            OpenConnection(connection);
+            dispose = true;
+        }
+        try
+        {
+            var bulkCopy = CreateBulkCopy(connection, useTransaction ? _transaction : null);
+            bulkCopy.DestinationTableName = destinationTable;
+            if (bulkCopyTimeout.HasValue)
+            {
+                bulkCopy.BulkCopyTimeout = bulkCopyTimeout.Value;
+            }
+
+            foreach (DataColumn column in table.Columns)
+            {
+                bulkCopy.ColumnMappings.Add(new MySqlBulkCopyColumnMapping(column.Ordinal, column.ColumnName, null));
+            }
+
+            if (batchSize.HasValue && batchSize.Value > 0)
+            {
+                var totalRows = table.Rows.Count;
+                for (int offset = 0; offset < totalRows; offset += batchSize.Value)
+                {
+                    var batchTable = table.Clone();
+                    for (int i = offset; i < Math.Min(offset + batchSize.Value, totalRows); i++)
+                    {
+                        batchTable.ImportRow(table.Rows[i]);
+                    }
+                    WriteToServer(bulkCopy, batchTable);
+                }
+            }
+            else
+            {
+                WriteToServer(bulkCopy, table);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    public virtual async Task BulkInsertAsync(string host, string database, string username, string password, DataTable table, string destinationTable, bool useTransaction = false, int? batchSize = null, int? bulkCopyTimeout = null, CancellationToken cancellationToken = default)
+    {
+        if (table == null) throw new ArgumentNullException(nameof(table));
+
+        var connectionString = BuildConnectionString(host, database, username, password);
+
+        MySqlConnection? connection = null;
+        bool dispose = false;
+        if (useTransaction)
+        {
+            if (_transaction == null || _transactionConnection == null)
+            {
+                throw new DbaTransactionException("Transaction has not been started.");
+            }
+            connection = _transactionConnection;
+        }
+        else
+        {
+            connection = CreateConnection(connectionString);
+            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+            dispose = true;
+        }
+        try
+        {
+            var bulkCopy = CreateBulkCopy(connection, useTransaction ? _transaction : null);
+            bulkCopy.DestinationTableName = destinationTable;
+            if (bulkCopyTimeout.HasValue)
+            {
+                bulkCopy.BulkCopyTimeout = bulkCopyTimeout.Value;
+            }
+
+            foreach (DataColumn column in table.Columns)
+            {
+                bulkCopy.ColumnMappings.Add(new MySqlBulkCopyColumnMapping(column.Ordinal, column.ColumnName, null));
+            }
+
+            if (batchSize.HasValue && batchSize.Value > 0)
+            {
+                var totalRows = table.Rows.Count;
+                for (int offset = 0; offset < totalRows; offset += batchSize.Value)
+                {
+                    var batchTable = table.Clone();
+                    for (int i = offset; i < Math.Min(offset + batchSize.Value, totalRows); i++)
+                    {
+                        batchTable.ImportRow(table.Rows[i]);
+                    }
+                    await WriteToServerAsync(bulkCopy, batchTable, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                await WriteToServerAsync(bulkCopy, table, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    protected virtual MySqlBulkCopy CreateBulkCopy(MySqlConnection connection, MySqlTransaction? transaction) => new(connection, transaction);
+
+    protected virtual void WriteToServer(MySqlBulkCopy bulkCopy, DataTable table) => bulkCopy.WriteToServer(table);
+
+    protected virtual Task WriteToServerAsync(MySqlBulkCopy bulkCopy, DataTable table, CancellationToken cancellationToken) => bulkCopy.WriteToServerAsync(table, cancellationToken).AsTask();
+
+    protected virtual MySqlConnection CreateConnection(string connectionString) => new(connectionString);
+
+    protected virtual void OpenConnection(MySqlConnection connection) => connection.Open();
+
+    protected virtual Task OpenConnectionAsync(MySqlConnection connection, CancellationToken cancellationToken) => connection.OpenAsync(cancellationToken);
     public virtual void BeginTransaction(string host, string database, string username, string password)
     {
         lock (_syncRoot)

--- a/DbaClientX.Tests/MySqlBulkInsertTests.cs
+++ b/DbaClientX.Tests/MySqlBulkInsertTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using MySqlConnector;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class MySqlBulkInsertTests
+{
+    private class CaptureBulkCopyMySql : DBAClientX.MySql
+    {
+        public int? Timeout { get; private set; }
+        public string? Destination { get; private set; }
+        public List<(int Ordinal, string Destination)> Mappings { get; } = new();
+        public List<int> BatchRowCounts { get; } = new();
+
+        protected override MySqlConnection CreateConnection(string connectionString) => new();
+
+        protected override void OpenConnection(MySqlConnection connection)
+        {
+            // no-op
+        }
+
+        protected override Task OpenConnectionAsync(MySqlConnection connection, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        protected override void WriteToServer(MySqlBulkCopy bulkCopy, DataTable table)
+        {
+            Timeout = bulkCopy.BulkCopyTimeout;
+            Destination = bulkCopy.DestinationTableName;
+            foreach (MySqlBulkCopyColumnMapping mapping in bulkCopy.ColumnMappings)
+            {
+                Mappings.Add((mapping.SourceOrdinal, mapping.DestinationColumn));
+            }
+            BatchRowCounts.Add(table.Rows.Count);
+        }
+
+        protected override Task WriteToServerAsync(MySqlBulkCopy bulkCopy, DataTable table, CancellationToken cancellationToken)
+        {
+            WriteToServer(bulkCopy, table);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public void BulkInsert_SetsOptionsAndMappings()
+    {
+        using var mySql = new CaptureBulkCopyMySql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "a");
+        table.Rows.Add(2, "b");
+
+        mySql.BulkInsert("h", "db", "u", "p", table, "Dest", batchSize: 1, bulkCopyTimeout: 60);
+
+        Assert.Equal(60, mySql.Timeout);
+        Assert.Equal("Dest", mySql.Destination);
+        Assert.Contains(mySql.Mappings, m => m.Ordinal == 0 && m.Destination == "Id");
+        Assert.Contains(mySql.Mappings, m => m.Ordinal == 1 && m.Destination == "Name");
+        Assert.Equal(new[] { 1, 1 }, mySql.BatchRowCounts);
+    }
+
+    [Fact]
+    public async Task BulkInsertAsync_SetsOptionsAndMappings()
+    {
+        using var mySql = new CaptureBulkCopyMySql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "a");
+        table.Rows.Add(2, "b");
+
+        await mySql.BulkInsertAsync("h", "db", "u", "p", table, "Dest", batchSize: 1, bulkCopyTimeout: 30);
+
+        Assert.Equal(30, mySql.Timeout);
+        Assert.Equal("Dest", mySql.Destination);
+        Assert.Contains(mySql.Mappings, m => m.Ordinal == 0 && m.Destination == "Id");
+        Assert.Contains(mySql.Mappings, m => m.Ordinal == 1 && m.Destination == "Name");
+        Assert.Equal(new[] { 1, 1 }, mySql.BatchRowCounts);
+    }
+
+    [Fact]
+    public void BulkInsert_WithTransactionNotStarted_Throws()
+    {
+        using var mySql = new DBAClientX.MySql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => mySql.BulkInsert("h", "db", "u", "p", table, "Dest", useTransaction: true));
+    }
+}


### PR DESCRIPTION
## Summary
- add BulkInsert and BulkInsertAsync for MySQL with column mapping and batch options
- provide example and unit tests for MySQL bulk insert

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a48fed3150832e986693a7c10fe66f