### PR TITLE
feat(mysql): add async non-query implementation

### DIFF
--- a/DbaClientX.Examples/NonQueryMySqlAsyncExample.cs
+++ b/DbaClientX.Examples/NonQueryMySqlAsyncExample.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DBAClientX;
+
+public static class NonQueryMySqlAsyncExample
+{
+    public static async Task RunAsync()
+    {
+        using var mySql = new MySql();
+        var affected = await mySql.ExecuteNonQueryAsync("MYSQL1", "mysql", "user", "password", "CREATE TABLE Example (Id INT)", cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        Console.WriteLine($"Rows affected: {affected}");
+    }
+}

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -215,7 +215,7 @@ public class MySql : DatabaseClientBase
             }
 
             var dbTypes = ConvertParameterTypes(parameterTypes);
-            return await base.ExecuteNonQueryAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes).ConfigureAwait(false);
+            return await ExecuteNonQueryAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/DbaClientX.Tests/MySqlNonQueryTests.cs
+++ b/DbaClientX.Tests/MySqlNonQueryTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using DBAClientX;
+using MySqlConnector;
+
+namespace DbaClientX.Tests;
+
+public class MySqlNonQueryTests
+{
+    private class CaptureParametersMySql : DBAClientX.MySql
+    {
+        public List<(string Name, object? Value, DbType Type)> Captured { get; } = new();
+
+        protected override Task<int> ExecuteNonQueryAsync(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, CancellationToken cancellationToken = default, IDictionary<string, DbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            var command = new MySqlCommand(query);
+            AddParameters(command, parameters, parameterTypes, parameterDirections);
+            foreach (DbParameter p in command.Parameters)
+            {
+                Captured.Add((p.ParameterName, p.Value, p.DbType));
+            }
+            return Task.FromResult(1);
+        }
+
+        public override Task<int> ExecuteNonQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null)
+        {
+            var dbTypes = DbTypeConverter.ConvertParameterTypes(parameterTypes, static () => new MySqlParameter(), static (p, t) => p.MySqlDbType = t);
+            return ExecuteNonQueryAsync(null!, null, query, parameters, cancellationToken, dbTypes);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteNonQueryAsync_BindsParameters()
+    {
+        using var mySql = new CaptureParametersMySql();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 5,
+            ["@name"] = "test"
+        };
+
+        await mySql.ExecuteNonQueryAsync("h", "d", "u", "p", "UPDATE t SET c=1 WHERE id=@id", parameters);
+
+        Assert.Contains(mySql.Captured, p => p.Name == "@id" && (int)p.Value == 5);
+        Assert.Contains(mySql.Captured, p => p.Name == "@name" && (string)p.Value == "test");
+    }
+
+    [Fact]
+    public async Task ExecuteNonQueryAsync_PreservesParameterTypes()
+    {
+        using var mySql = new CaptureParametersMySql();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["@id"] = 5,
+            ["@name"] = "test"
+        };
+        var types = new Dictionary<string, MySqlDbType>
+        {
+            ["@id"] = MySqlDbType.Int32,
+            ["@name"] = MySqlDbType.VarChar
+        };
+
+        await mySql.ExecuteNonQueryAsync("h", "d", "u", "p", "UPDATE t SET name=@name WHERE id=@id", parameters, parameterTypes: types);
+
+        Assert.Contains(mySql.Captured, p => p.Name == "@id" && p.Type == DbType.Int32);
+        Assert.Contains(mySql.Captured, p => p.Name == "@name" && p.Type == DbType.String);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure MySql ExecuteNonQueryAsync mirrors sync version and leverages retries
- add example showing asynchronous non-query usage
- test async non-query parameter binding and type preservation

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a4a6deb324832eab617a0cd15cbdc6