### PR TITLE
Add PostgreSQL bulk insert with batching

### DIFF
--- a/DbaClientX.Examples/BulkInsertPostgreSqlExample.cs
+++ b/DbaClientX.Examples/BulkInsertPostgreSqlExample.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Data;
+
+public static class BulkInsertPostgreSqlExample
+{
+    public static void Run()
+    {
+        using var postgre = new DBAClientX.PostgreSql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "Example");
+
+        postgre.BulkInsert("localhost", "database", "user", "password", table, "ExampleTable", batchSize: 1000, bulkCopyTimeout: 60);
+        Console.WriteLine("Bulk insert executed.");
+    }
+}

--- a/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
+++ b/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
     <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Collections" />

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -516,6 +516,178 @@ public class PostgreSql : DatabaseClientBase
     }
 #endif
 
+    public virtual void BulkInsert(string host, string database, string username, string password, DataTable table, string destinationTable, bool useTransaction = false, int? batchSize = null, int? bulkCopyTimeout = null)
+    {
+        if (table == null) throw new ArgumentNullException(nameof(table));
+
+        var connectionString = BuildConnectionString(host, database, username, password);
+
+        NpgsqlConnection? connection = null;
+        bool dispose = false;
+        if (useTransaction)
+        {
+            if (_transaction == null || _transactionConnection == null)
+            {
+                throw new DbaTransactionException("Transaction has not been started.");
+            }
+            connection = _transactionConnection;
+        }
+        else
+        {
+            connection = CreateConnection(connectionString);
+            OpenConnection(connection);
+            dispose = true;
+        }
+        try
+        {
+            if (batchSize.HasValue && batchSize.Value > 0)
+            {
+                var totalRows = table.Rows.Count;
+                for (int offset = 0; offset < totalRows; offset += batchSize.Value)
+                {
+                    var batchTable = table.Clone();
+                    for (int i = offset; i < Math.Min(offset + batchSize.Value, totalRows); i++)
+                    {
+                        batchTable.ImportRow(table.Rows[i]);
+                    }
+                    WriteTable(connection, batchTable, destinationTable, bulkCopyTimeout, useTransaction ? _transaction : null);
+                }
+            }
+            else
+            {
+                WriteTable(connection, table, destinationTable, bulkCopyTimeout, useTransaction ? _transaction : null);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    public virtual async Task BulkInsertAsync(string host, string database, string username, string password, DataTable table, string destinationTable, bool useTransaction = false, int? batchSize = null, int? bulkCopyTimeout = null, CancellationToken cancellationToken = default)
+    {
+        if (table == null) throw new ArgumentNullException(nameof(table));
+
+        var connectionString = BuildConnectionString(host, database, username, password);
+
+        NpgsqlConnection? connection = null;
+        bool dispose = false;
+        if (useTransaction)
+        {
+            if (_transaction == null || _transactionConnection == null)
+            {
+                throw new DbaTransactionException("Transaction has not been started.");
+            }
+            connection = _transactionConnection;
+        }
+        else
+        {
+            connection = CreateConnection(connectionString);
+            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+            dispose = true;
+        }
+        try
+        {
+            if (batchSize.HasValue && batchSize.Value > 0)
+            {
+                var totalRows = table.Rows.Count;
+                for (int offset = 0; offset < totalRows; offset += batchSize.Value)
+                {
+                    var batchTable = table.Clone();
+                    for (int i = offset; i < Math.Min(offset + batchSize.Value, totalRows); i++)
+                    {
+                        batchTable.ImportRow(table.Rows[i]);
+                    }
+                    await WriteTableAsync(connection, batchTable, destinationTable, bulkCopyTimeout, useTransaction ? _transaction : null, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            else
+            {
+                await WriteTableAsync(connection, table, destinationTable, bulkCopyTimeout, useTransaction ? _transaction : null, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                connection?.Dispose();
+            }
+        }
+    }
+
+    protected virtual void WriteTable(NpgsqlConnection connection, DataTable table, string destinationTable, int? bulkCopyTimeout, NpgsqlTransaction? transaction)
+    {
+        var columns = string.Join(", ", table.Columns.Cast<DataColumn>().Select(c => $"\"{c.ColumnName}\""));
+        var copyCommand = $"COPY {destinationTable} ({columns}) FROM STDIN (FORMAT BINARY)";
+        using var importer = connection.BeginBinaryImport(copyCommand);
+        if (bulkCopyTimeout.HasValue)
+        {
+            importer.Timeout = TimeSpan.FromSeconds(bulkCopyTimeout.Value);
+        }
+        foreach (DataRow row in table.Rows)
+        {
+            importer.StartRow();
+            foreach (DataColumn column in table.Columns)
+            {
+                var value = row[column];
+                if (value == null || value == DBNull.Value)
+                {
+                    importer.WriteNull();
+                }
+                else
+                {
+                    importer.Write((dynamic)value);
+                }
+            }
+        }
+        importer.Complete();
+    }
+
+    protected virtual async Task WriteTableAsync(NpgsqlConnection connection, DataTable table, string destinationTable, int? bulkCopyTimeout, NpgsqlTransaction? transaction, CancellationToken cancellationToken)
+    {
+        var columns = string.Join(", ", table.Columns.Cast<DataColumn>().Select(c => $"\"{c.ColumnName}\""));
+        var copyCommand = $"COPY {destinationTable} ({columns}) FROM STDIN (FORMAT BINARY)";
+        await using var importer = await connection.BeginBinaryImportAsync(copyCommand, cancellationToken).ConfigureAwait(false);
+        if (bulkCopyTimeout.HasValue)
+        {
+            importer.Timeout = TimeSpan.FromSeconds(bulkCopyTimeout.Value);
+        }
+        foreach (DataRow row in table.Rows)
+        {
+            await importer.StartRowAsync(cancellationToken).ConfigureAwait(false);
+            foreach (DataColumn column in table.Columns)
+            {
+                var value = row[column];
+                if (value == null || value == DBNull.Value)
+                {
+                    await importer.WriteNullAsync(cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    await importer.WriteAsync((dynamic)value, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+        await importer.CompleteAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    protected virtual NpgsqlConnection CreateConnection(string connectionString) => new(connectionString);
+
+    protected virtual void OpenConnection(NpgsqlConnection connection) => connection.Open();
+
+    protected virtual Task OpenConnectionAsync(NpgsqlConnection connection, CancellationToken cancellationToken) => connection.OpenAsync(cancellationToken);
+
     public virtual void BeginTransaction(string host, string database, string username, string password)
     {
         lock (_syncRoot)

--- a/DbaClientX.Tests/PostgreSqlBulkInsertTests.cs
+++ b/DbaClientX.Tests/PostgreSqlBulkInsertTests.cs
@@ -1,0 +1,92 @@
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Npgsql;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class PostgreSqlBulkInsertTests
+{
+    private class CapturePostgreSql : DBAClientX.PostgreSql
+    {
+        public int? Timeout { get; private set; }
+        public string? Destination { get; private set; }
+        public List<(int Ordinal, string Destination)> Mappings { get; } = new();
+        public List<int> BatchRowCounts { get; } = new();
+
+        protected override NpgsqlConnection CreateConnection(string connectionString) => new();
+
+        protected override void OpenConnection(NpgsqlConnection connection)
+        {
+            // no-op
+        }
+
+        protected override Task OpenConnectionAsync(NpgsqlConnection connection, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        protected override void WriteTable(NpgsqlConnection connection, DataTable table, string destinationTable, int? bulkCopyTimeout, NpgsqlTransaction? transaction)
+        {
+            Timeout = bulkCopyTimeout;
+            Destination = destinationTable;
+            foreach (DataColumn column in table.Columns)
+            {
+                Mappings.Add((column.Ordinal, column.ColumnName));
+            }
+            BatchRowCounts.Add(table.Rows.Count);
+        }
+
+        protected override Task WriteTableAsync(NpgsqlConnection connection, DataTable table, string destinationTable, int? bulkCopyTimeout, NpgsqlTransaction? transaction, CancellationToken cancellationToken)
+        {
+            WriteTable(connection, table, destinationTable, bulkCopyTimeout, transaction);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public void BulkInsert_SetsOptionsAndMappings()
+    {
+        using var pg = new CapturePostgreSql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "a");
+        table.Rows.Add(2, "b");
+
+        pg.BulkInsert("h", "db", "u", "p", table, "Dest", batchSize: 1, bulkCopyTimeout: 60);
+
+        Assert.Equal(60, pg.Timeout);
+        Assert.Equal("Dest", pg.Destination);
+        Assert.Contains(pg.Mappings, m => m.Ordinal == 0 && m.Destination == "Id");
+        Assert.Contains(pg.Mappings, m => m.Ordinal == 1 && m.Destination == "Name");
+        Assert.Equal(new[] { 1, 1 }, pg.BatchRowCounts);
+    }
+
+    [Fact]
+    public async Task BulkInsertAsync_SetsOptionsAndMappings()
+    {
+        using var pg = new CapturePostgreSql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "a");
+        table.Rows.Add(2, "b");
+
+        await pg.BulkInsertAsync("h", "db", "u", "p", table, "Dest", batchSize: 1, bulkCopyTimeout: 30);
+
+        Assert.Equal(30, pg.Timeout);
+        Assert.Equal("Dest", pg.Destination);
+        Assert.Contains(pg.Mappings, m => m.Ordinal == 0 && m.Destination == "Id");
+        Assert.Contains(pg.Mappings, m => m.Ordinal == 1 && m.Destination == "Name");
+        Assert.Equal(new[] { 1, 1 }, pg.BatchRowCounts);
+    }
+
+    [Fact]
+    public void BulkInsert_WithTransactionNotStarted_Throws()
+    {
+        using var pg = new DBAClientX.PostgreSql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => pg.BulkInsert("h", "db", "u", "p", table, "Dest", useTransaction: true));
+    }
+}


### PR DESCRIPTION
## Summary
- add bulk insert and async variants for PostgreSQL using `NpgsqlBinaryImporter`
- support optional batch size and timeout parameters
- add examples and unit tests for PostgreSQL bulk insert

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a7a79544832e86d358b609e5cf90