### PR TITLE
feat(sqlite): add async non-query wrapper

### DIFF
--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -179,7 +179,7 @@ public class SQLite : DatabaseClientBase
         }
     }
 
-    public virtual async Task<int> ExecuteNonQueryAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null)
+    public virtual async Task<int> ExecuteNonQueryAsync(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, SqliteType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(database);
 
@@ -203,7 +203,7 @@ public class SQLite : DatabaseClientBase
             }
 
             var dbTypes = ConvertParameterTypes(parameterTypes);
-            return await base.ExecuteNonQueryAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes).ConfigureAwait(false);
+            return await base.ExecuteNonQueryAsync(connection, useTransaction ? _transaction : null, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -32,6 +32,26 @@ public class SqliteTests
         }
     }
 
+    [Fact]
+    public async Task ExecuteNonQueryAsync_CreatesAndReadsData()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            using var sqlite = new DBAClientX.SQLite { ReturnType = ReturnType.DataTable };
+            await sqlite.ExecuteNonQueryAsync(path, "CREATE TABLE t(id INTEGER);");
+            await sqlite.ExecuteNonQueryAsync(path, "INSERT INTO t(id) VALUES (1);");
+            var result = await sqlite.QueryAsync(path, "SELECT id FROM t;");
+            var table = Assert.IsType<DataTable>(result);
+            Assert.Single(table.Rows);
+            Assert.Equal(1L, table.Rows[0]["id"]);
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
     private class OutputDictionarySqlite : DBAClientX.SQLite
     {
         public override object? Query(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)


### PR DESCRIPTION
## Summary
- support parameter direction in SQLite's async non-query execution
- test SQLite ExecuteNonQueryAsync

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a6ef3434832eb1c7b215ddf48817