### PR TITLE
Add tests for default bulk insert options and mappings

### DIFF
--- a/DbaClientX.Tests/MySqlBulkInsertTests.cs
+++ b/DbaClientX.Tests/MySqlBulkInsertTests.cs
@@ -82,6 +82,24 @@ public class MySqlBulkInsertTests
     }
 
     [Fact]
+    public void BulkInsert_DefaultOptions_AddsAllMappings()
+    {
+        using var mySql = new CaptureBulkCopyMySql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "a");
+        table.Rows.Add(2, "b");
+
+        mySql.BulkInsert("h", "db", "u", "p", table, "Dest");
+
+        Assert.Equal(0, mySql.Timeout);
+        Assert.Equal("Dest", mySql.Destination);
+        Assert.Equal(table.Columns.Count, mySql.Mappings.Count);
+        Assert.Equal(new[] { 2 }, mySql.BatchRowCounts);
+    }
+
+    [Fact]
     public void BulkInsert_WithTransactionNotStarted_Throws()
     {
         using var mySql = new DBAClientX.MySql();

--- a/DbaClientX.Tests/SqlServerBulkInsertTests.cs
+++ b/DbaClientX.Tests/SqlServerBulkInsertTests.cs
@@ -80,6 +80,23 @@ public class SqlServerBulkInsertTests
     }
 
     [Fact]
+    public void BulkInsert_DefaultOptions_AddsAllMappings()
+    {
+        using var sqlServer = new CaptureBulkCopySqlServer();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "test");
+
+        sqlServer.BulkInsert("s", "db", true, table, "dbo.Dest");
+
+        Assert.Equal(0, sqlServer.BatchSize);
+        Assert.Equal(30, sqlServer.Timeout);
+        Assert.Equal("dbo.Dest", sqlServer.Destination);
+        Assert.Equal(table.Columns.Count, sqlServer.Mappings.Count);
+    }
+
+    [Fact]
     public void BulkInsert_WithTransactionNotStarted_Throws()
     {
         using var sqlServer = new DBAClientX.SqlServer();


### PR DESCRIPTION
## Summary
- add SQL Server bulk insert test verifying default options and mapping count
- add MySQL bulk insert test verifying default options and mapping count

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a7a1a734832ebc5b2f922c7e4c87