### PR TITLE
Add PostgreSQL COPY streaming test

### DIFF
--- a/DbaClientX.Tests/DbaClientX.Tests.csproj
+++ b/DbaClientX.Tests/DbaClientX.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Lib.Harmony" Version="2.4.0" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/DbaClientX.Tests/PostgreSqlCopyStreamTests.cs
+++ b/DbaClientX.Tests/PostgreSqlCopyStreamTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Data;
+using System.Runtime.Serialization;
+using HarmonyLib;
+using Npgsql;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class PostgreSqlCopyStreamTests
+{
+    private class FakePostgreSql : DBAClientX.PostgreSql
+    {
+        protected override NpgsqlConnection CreateConnection(string connectionString) => new();
+        protected override void OpenConnection(NpgsqlConnection connection) { }
+    }
+    private static string? _command;
+    private static TimeSpan? _timeout;
+
+    private static bool BeginBinaryImportPrefix(string copyFromCommand, ref NpgsqlBinaryImporter __result)
+    {
+        _command = copyFromCommand;
+        __result = (NpgsqlBinaryImporter)FormatterServices.GetUninitializedObject(typeof(NpgsqlBinaryImporter));
+        return false;
+    }
+
+    private static bool TimeoutSetterPrefix(TimeSpan value)
+    {
+        _timeout = value;
+        return false;
+    }
+
+    private static bool Skip() => false;
+
+    [Fact]
+    public void BulkInsert_InvokesCopyWithTimeout()
+    {
+        var harmony = new Harmony(nameof(BulkInsert_InvokesCopyWithTimeout));
+        harmony.Patch(
+            AccessTools.Method(typeof(NpgsqlConnection), nameof(NpgsqlConnection.BeginBinaryImport), new[] { typeof(string) }),
+            prefix: new HarmonyMethod(typeof(PostgreSqlCopyStreamTests), nameof(BeginBinaryImportPrefix)));
+        harmony.Patch(
+            AccessTools.PropertySetter(typeof(NpgsqlBinaryImporter), nameof(NpgsqlBinaryImporter.Timeout)),
+            prefix: new HarmonyMethod(typeof(PostgreSqlCopyStreamTests), nameof(TimeoutSetterPrefix)));
+        harmony.Patch(
+            AccessTools.Method(typeof(NpgsqlBinaryImporter), nameof(NpgsqlBinaryImporter.Complete)),
+            prefix: new HarmonyMethod(typeof(PostgreSqlCopyStreamTests), nameof(Skip)));
+        harmony.Patch(
+            AccessTools.Method(typeof(NpgsqlBinaryImporter), "Dispose"),
+            prefix: new HarmonyMethod(typeof(PostgreSqlCopyStreamTests), nameof(Skip)));
+
+        using var pg = new FakePostgreSql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        pg.BulkInsert("h", "d", "u", "p", table, "dest", bulkCopyTimeout: 5);
+
+        harmony.UnpatchAll(harmony.Id);
+
+        Assert.Equal("COPY dest (\"Id\") FROM STDIN (FORMAT BINARY)", _command);
+        Assert.Equal(TimeSpan.FromSeconds(5), _timeout);
+    }
+}


### PR DESCRIPTION
## Summary
- add Harmony to test project for patch-based mocking
- verify PostgreSQL bulk insert uses COPY and honors timeout

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a4d0d52920832e91905656903012d7