### PR TITLE
Add isolation level overloads for PostgreSql transactions

### DIFF
--- a/DbaClientX.Examples/Program.cs
+++ b/DbaClientX.Examples/Program.cs
@@ -25,6 +25,9 @@ public class Program
             case "transaction":
                 await TransactionExample.RunAsync().ConfigureAwait(false);
                 break;
+            case "pgtransaction":
+                await TransactionPostgreSqlExample.RunAsync().ConfigureAwait(false);
+                break;
             case "cancellation":
                 await CancellationExample.RunAsync().ConfigureAwait(false);
                 break;
@@ -53,7 +56,7 @@ public class Program
                 InsertOrUpdateExample.Run();
                 break;
             default:
-                Console.WriteLine("Available examples: asyncquery, pgasyncquery, mysqlasyncquery, parallelqueries, transaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized, inferdbtype, joins, upsert");
+                Console.WriteLine("Available examples: asyncquery, pgasyncquery, mysqlasyncquery, parallelqueries, transaction, pgtransaction, cancellation, nestedquery, streamquery, nonquery, orderby, nullconditions, parameterized, inferdbtype, joins, upsert");
                 break;
         }
     }

--- a/DbaClientX.Examples/TransactionPostgreSqlExample.cs
+++ b/DbaClientX.Examples/TransactionPostgreSqlExample.cs
@@ -1,0 +1,26 @@
+using DBAClientX;
+using System;
+using System.Data;
+using System.Threading.Tasks;
+
+public static class TransactionPostgreSqlExample
+{
+    public static Task RunAsync()
+    {
+        using var pg = new PostgreSql();
+        pg.BeginTransaction("localhost", "postgres", "user", "password", IsolationLevel.Serializable);
+        try
+        {
+            pg.Query("localhost", "postgres", "user", "password", "CREATE TABLE temp(id int)", null, true);
+            pg.Commit();
+            Console.WriteLine("Committed");
+        }
+        catch
+        {
+            pg.Rollback();
+            Console.WriteLine("Rolled back");
+        }
+        return Task.CompletedTask;
+    }
+}
+

--- a/DbaClientX.Tests/PostgreSqlTransactionTests.cs
+++ b/DbaClientX.Tests/PostgreSqlTransactionTests.cs
@@ -1,0 +1,127 @@
+using System.Data;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class PostgreSqlTransactionTests
+{
+    private class FakeNpgsqlConnection
+    {
+        public bool BeginCalled { get; private set; }
+        public IsolationLevel? Level { get; private set; }
+
+        public FakeNpgsqlTransaction BeginTransaction()
+            => BeginTransaction(IsolationLevel.ReadCommitted);
+
+        public FakeNpgsqlTransaction BeginTransaction(IsolationLevel isolationLevel)
+        {
+            BeginCalled = true;
+            Level = isolationLevel;
+            return new FakeNpgsqlTransaction(this);
+        }
+    }
+
+    private class FakeNpgsqlTransaction
+    {
+        private readonly FakeNpgsqlConnection _connection;
+        public bool CommitCalled { get; private set; }
+        public bool RollbackCalled { get; private set; }
+
+        public FakeNpgsqlTransaction(FakeNpgsqlConnection connection)
+        {
+            _connection = connection;
+        }
+
+        public void Commit() => CommitCalled = true;
+        public void Rollback() => RollbackCalled = true;
+    }
+
+    private class TestPostgreSql : DBAClientX.PostgreSql
+    {
+        public FakeNpgsqlConnection? Connection { get; private set; }
+        public FakeNpgsqlTransaction? Transaction { get; private set; }
+
+        public override void BeginTransaction(string host, string database, string username, string password)
+        {
+            Connection = new FakeNpgsqlConnection();
+            Transaction = Connection.BeginTransaction();
+        }
+
+        public override void BeginTransaction(string host, string database, string username, string password, IsolationLevel isolationLevel)
+        {
+            Connection = new FakeNpgsqlConnection();
+            Transaction = Connection.BeginTransaction(isolationLevel);
+        }
+
+        public override void Commit()
+        {
+            if (Transaction == null)
+            {
+                throw new DBAClientX.DbaTransactionException("No active transaction.");
+            }
+            Transaction.Commit();
+            Transaction = null;
+        }
+
+        public override void Rollback()
+        {
+            if (Transaction == null)
+            {
+                throw new DBAClientX.DbaTransactionException("No active transaction.");
+            }
+            Transaction.Rollback();
+            Transaction = null;
+        }
+
+        public override object? Query(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlTypes.NpgsqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            if (useTransaction && Transaction == null)
+            {
+                throw new DBAClientX.DbaTransactionException("Transaction has not been started.");
+            }
+            return null;
+        }
+    }
+
+    [Fact]
+    public void BeginTransaction_UsesConnection()
+    {
+        using var pg = new TestPostgreSql();
+        pg.BeginTransaction("h", "d", "u", "p");
+        Assert.NotNull(pg.Connection);
+        Assert.True(pg.Connection!.BeginCalled);
+        Assert.NotNull(pg.Transaction);
+    }
+
+    [Fact]
+    public void Commit_CallsCommitOnTransaction()
+    {
+        using var pg = new TestPostgreSql();
+        pg.BeginTransaction("h", "d", "u", "p");
+        var txn = pg.Transaction!;
+        pg.Commit();
+        Assert.True(txn.CommitCalled);
+        Assert.Null(pg.Transaction);
+    }
+
+    [Fact]
+    public void Rollback_CallsRollbackOnTransaction()
+    {
+        using var pg = new TestPostgreSql();
+        pg.BeginTransaction("h", "d", "u", "p");
+        var txn = pg.Transaction!;
+        pg.Rollback();
+        Assert.True(txn.RollbackCalled);
+        Assert.Null(pg.Transaction);
+    }
+
+    [Fact]
+    public void BeginTransaction_WithIsolationLevel_PassesIsolationLevel()
+    {
+        using var pg = new TestPostgreSql();
+        pg.BeginTransaction("h", "d", "u", "p", IsolationLevel.Serializable);
+        Assert.NotNull(pg.Connection);
+        Assert.Equal(IsolationLevel.Serializable, pg.Connection!.Level);
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow specifying isolation level when starting PostgreSql transactions synchronously or asynchronously
- cover isolation level transactions with new unit tests
- demonstrate PostgreSql transaction isolation level usage in examples

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a4d0e68fa8832e85859e33bcf1a7e7