### PR TITLE
Add isolation level overloads for SQLite

### DIFF
--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -354,6 +354,9 @@ public class SQLite : DatabaseClientBase
         }
     }
 
+    public virtual void BeginTransaction(string database, IsolationLevel isolationLevel)
+        => BeginTransaction(database);
+
     public virtual async Task BeginTransactionAsync(string database, CancellationToken cancellationToken = default)
     {
         lock (_syncRoot)
@@ -387,6 +390,9 @@ public class SQLite : DatabaseClientBase
             _transaction = transaction;
         }
     }
+
+    public virtual Task BeginTransactionAsync(string database, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+        => BeginTransactionAsync(database, cancellationToken);
 
     public virtual void Commit()
     {

--- a/DbaClientX.Tests/SQLiteTransactionForwardingTests.cs
+++ b/DbaClientX.Tests/SQLiteTransactionForwardingTests.cs
@@ -1,0 +1,42 @@
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class SQLiteTransactionForwardingTests
+{
+    private class TestSQLite : DBAClientX.SQLite
+    {
+        public bool SyncCalled { get; private set; }
+        public bool AsyncCalled { get; private set; }
+
+        public override void BeginTransaction(string database)
+        {
+            SyncCalled = true;
+        }
+
+        public override Task BeginTransactionAsync(string database, CancellationToken cancellationToken = default)
+        {
+            AsyncCalled = true;
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public void BeginTransaction_WithIsolationLevel_ForwardsToBeginTransaction()
+    {
+        using var sqlite = new TestSQLite();
+        sqlite.BeginTransaction(":memory:", IsolationLevel.Serializable);
+        Assert.True(sqlite.SyncCalled);
+    }
+
+    [Fact]
+    public async Task BeginTransactionAsync_WithIsolationLevel_ForwardsToBeginTransaction()
+    {
+        using var sqlite = new TestSQLite();
+        await sqlite.BeginTransactionAsync(":memory:", IsolationLevel.Serializable);
+        Assert.True(sqlite.AsyncCalled);
+    }
+}


### PR DESCRIPTION
## Summary
- expose transaction overloads accepting `IsolationLevel` in SQLite client
- test that overloads forward to existing methods

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d0ea55e0832e924a6557f2c4fa95