### PR TITLE
Add dictionary-style stored procedure APIs to SQL Server and PostgreSQL providers

### DIFF
--- a/DbaClientX.Examples/StoredProcedureExample.cs
+++ b/DbaClientX.Examples/StoredProcedureExample.cs
@@ -1,7 +1,6 @@
 using DBAClientX;
 using System.Data;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 
 public static class StoredProcedureExample
 {
@@ -12,9 +11,9 @@ public static class StoredProcedureExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var parameters = new List<SqlParameter>
+        var parameters = new Dictionary<string, object?>
         {
-            new("@dbname", "master")
+            ["@dbname"] = "master"
         };
 
         var result = sqlServer.ExecuteStoredProcedure("SQL1", "master", true, "sp_helpdb", parameters);

--- a/DbaClientX.Examples/StoredProcedurePostgreSqlExample.cs
+++ b/DbaClientX.Examples/StoredProcedurePostgreSqlExample.cs
@@ -1,7 +1,6 @@
 using DBAClientX;
 using System.Collections.Generic;
 using System.Data;
-using Npgsql;
 
 public static class StoredProcedurePostgreSqlExample
 {
@@ -12,9 +11,9 @@ public static class StoredProcedurePostgreSqlExample
             ReturnType = ReturnType.DataTable,
         };
 
-        var parameters = new List<NpgsqlParameter>
+        var parameters = new Dictionary<string, object?>
         {
-            new("@id", 1)
+            ["@id"] = 1
         };
 
         var result = pg.ExecuteStoredProcedure("localhost", "postgres", "user", "password", "sp_test", parameters);


### PR DESCRIPTION
## Summary
- Add dictionary-based ExecuteStoredProcedure APIs for SQL Server and PostgreSQL with optional type and direction metadata and output parameter propagation
- Support streaming stored procedures with dictionaries
- Update examples and add unit tests for new stored procedure overloads

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b2d3f0b248832e8f339d3d5b243db7