### PR TITLE
Support output parameters in synchronous ExecuteNonQuery

### DIFF
--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -152,7 +152,16 @@ public class MySql : DatabaseClientBase
     private static IDictionary<string, DbType>? ConvertParameterTypes(IDictionary<string, MySqlDbType>? types) =>
         DbTypeConverter.ConvertParameterTypes(types, static () => new MySqlParameter(), static (p, t) => p.MySqlDbType = t);
 
-    public virtual int ExecuteNonQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null)
+    public virtual int ExecuteNonQuery(
+        string host,
+        string database,
+        string username,
+        string password,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
 
@@ -176,7 +185,7 @@ public class MySql : DatabaseClientBase
             }
 
             var dbTypes = ConvertParameterTypes(parameterTypes);
-            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
+            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes, parameterDirections);
         }
         catch (Exception ex)
         {

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -153,7 +153,16 @@ public class PostgreSql : DatabaseClientBase
     private static IDictionary<string, DbType>? ConvertParameterTypes(IDictionary<string, NpgsqlDbType>? types) =>
         DbTypeConverter.ConvertParameterTypes(types, static () => new NpgsqlParameter(), static (p, t) => p.NpgsqlDbType = t);
 
-    public virtual int ExecuteNonQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null)
+    public virtual int ExecuteNonQuery(
+        string host,
+        string database,
+        string username,
+        string password,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
 
@@ -177,7 +186,7 @@ public class PostgreSql : DatabaseClientBase
             }
 
             var dbTypes = ConvertParameterTypes(parameterTypes);
-            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
+            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes, parameterDirections);
         }
         catch (Exception ex)
         {

--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -141,7 +141,13 @@ public class SQLite : DatabaseClientBase
     private static IDictionary<string, DbType>? ConvertParameterTypes(IDictionary<string, SqliteType>? types) =>
         DbTypeConverter.ConvertParameterTypes(types, static () => new SqliteParameter(), static (p, t) => p.SqliteType = t);
 
-    public virtual int ExecuteNonQuery(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null)
+    public virtual int ExecuteNonQuery(
+        string database,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, SqliteType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(database);
 
@@ -165,7 +171,7 @@ public class SQLite : DatabaseClientBase
             }
 
             var dbTypes = ConvertParameterTypes(parameterTypes);
-            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
+            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes, parameterDirections);
         }
         catch (Exception ex)
         {

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -152,7 +152,17 @@ public class SqlServer : DatabaseClientBase
     private static IDictionary<string, DbType>? ConvertParameterTypes(IDictionary<string, SqlDbType>? types) =>
         DbTypeConverter.ConvertParameterTypes(types, static () => new SqlParameter(), static (p, t) => p.SqlDbType = t);
 
-    public virtual int ExecuteNonQuery(string serverOrInstance, string database, bool integratedSecurity, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqlDbType>? parameterTypes = null, string? username = null, string? password = null)
+    public virtual int ExecuteNonQuery(
+        string serverOrInstance,
+        string database,
+        bool integratedSecurity,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        string? username = null,
+        string? password = null)
     {
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
@@ -176,7 +186,7 @@ public class SqlServer : DatabaseClientBase
             }
 
             var dbTypes = ConvertParameterTypes(parameterTypes);
-            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes);
+            return ExecuteNonQuery(connection, useTransaction ? _transaction : null, query, parameters, dbTypes, parameterDirections);
         }
         catch (Exception ex)
         {

--- a/DbaClientX.Tests/PostgreSqlNonQueryTests.cs
+++ b/DbaClientX.Tests/PostgreSqlNonQueryTests.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using Npgsql;
+using NpgsqlTypes;
+using DBAClientX;
+
+namespace DbaClientX.Tests;
+
+public class PostgreSqlNonQueryTests
+{
+    private class OutputDictionaryPostgreSql : DBAClientX.PostgreSql
+    {
+        protected override int ExecuteNonQuery(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, IDictionary<string, DbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            using var command = new NpgsqlCommand(query);
+            AddParameters(command, parameters, parameterTypes, parameterDirections);
+            foreach (NpgsqlParameter p in command.Parameters)
+            {
+                if (p.Direction != ParameterDirection.Input)
+                {
+                    p.Value = 7;
+                }
+            }
+            UpdateOutputParameters(command, parameters);
+            return 1;
+        }
+
+        public override int ExecuteNonQuery(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, NpgsqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            var dbTypes = DbTypeConverter.ConvertParameterTypes(parameterTypes, static () => new NpgsqlParameter(), static (p, t) => p.NpgsqlDbType = t);
+            return ExecuteNonQuery(null!, null, query, parameters, dbTypes, parameterDirections);
+        }
+    }
+
+    [Fact]
+    public void ExecuteNonQuery_UpdatesOutputParameters()
+    {
+        using var postgre = new OutputDictionaryPostgreSql();
+        var parameters = new Dictionary<string, object?> { ["@out"] = null };
+        var directions = new Dictionary<string, ParameterDirection> { ["@out"] = ParameterDirection.Output };
+        postgre.ExecuteNonQuery("h", "d", "u", "p", "q", parameters, parameterDirections: directions);
+        Assert.Equal(7, parameters["@out"]);
+    }
+}

--- a/DbaClientX.Tests/SqliteNonQueryTests.cs
+++ b/DbaClientX.Tests/SqliteNonQueryTests.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using DBAClientX;
+
+namespace DbaClientX.Tests;
+
+public class SqliteNonQueryTests
+{
+    private class OutputDictionarySqlite : DBAClientX.SQLite
+    {
+        protected override int ExecuteNonQuery(DbConnection connection, DbTransaction? transaction, string query, IDictionary<string, object?>? parameters = null, IDictionary<string, DbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            using var command = new SqliteCommand(query);
+            AddParameters(command, parameters, parameterTypes, parameterDirections);
+            return 1; // will not reach here if AddParameters throws
+        }
+
+        public override int ExecuteNonQuery(string database, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, SqliteType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            var dbTypes = DbTypeConverter.ConvertParameterTypes(parameterTypes, static () => new SqliteParameter(), static (p, t) => p.SqliteType = t);
+            return ExecuteNonQuery(null!, null, query, parameters, dbTypes, parameterDirections);
+        }
+    }
+
+    [Fact]
+    public void ExecuteNonQuery_WithOutputParameter_Throws()
+    {
+        using var sqlite = new OutputDictionarySqlite();
+        var parameters = new Dictionary<string, object?> { ["@out"] = null };
+        var directions = new Dictionary<string, ParameterDirection> { ["@out"] = ParameterDirection.Output };
+        Assert.Throws<ArgumentException>(() => sqlite.ExecuteNonQuery("db", "q", parameters, parameterDirections: directions));
+    }
+}


### PR DESCRIPTION
## Summary
- add optional `parameterDirections` to synchronous `ExecuteNonQuery` in SQL Server, PostgreSQL, MySQL and SQLite providers
- forward directions when building commands so output values propagate
- cover providers with synchronous output parameter tests (SQLite asserts unsupported output parameters)

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b33f4862a4832e812d6e9bb9bd6477