### PR TITLE
Add Oracle dialect handling in query compiler

### DIFF
--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -346,7 +346,7 @@ public class QueryCompiler
             sb.Append(" ORDER BY ").Append(string.Join(", ", query.OrderByColumns.Select(QuoteIdentifier)));
         }
 
-        if (_dialect == SqlDialect.SqlServer)
+        if (_dialect == SqlDialect.SqlServer || _dialect == SqlDialect.Oracle)
         {
             if (query.OffsetValue.HasValue)
             {
@@ -576,6 +576,9 @@ public class QueryCompiler
         {
             SqlDialect.SqlServer => ('[', ']'),
             SqlDialect.MySql => ('`', '`'),
+            SqlDialect.PostgreSql => ('"', '"'),
+            SqlDialect.SQLite => ('"', '"'),
+            SqlDialect.Oracle => ('"', '"'),
             _ => ('"', '"')
         };
 

--- a/DbaClientX.Core/QueryBuilder/SqlDialect.cs
+++ b/DbaClientX.Core/QueryBuilder/SqlDialect.cs
@@ -8,5 +8,6 @@ public enum SqlDialect
     SqlServer,
     PostgreSql,
     MySql,
-    SQLite
+    SQLite,
+    Oracle
 }

--- a/DbaClientX.Examples/DialectExample.cs
+++ b/DbaClientX.Examples/DialectExample.cs
@@ -15,5 +15,6 @@ public static class DialectExample
         Console.WriteLine("MySql:      " + QueryBuilder.Compile(query, SqlDialect.MySql));
         Console.WriteLine("SQLite:     " + QueryBuilder.Compile(query, SqlDialect.SQLite));
         Console.WriteLine("SqlServer:  " + QueryBuilder.Compile(query, SqlDialect.SqlServer));
+        Console.WriteLine("Oracle:     " + QueryBuilder.Compile(query, SqlDialect.Oracle));
     }
 }

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -241,6 +241,20 @@ public class QueryBuilderTests
     }
 
     [Fact]
+    public void SelectLimitOffset_OracleUsesOffsetFetch()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .OrderBy("name")
+            .Limit(5)
+            .Offset(10);
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.Oracle);
+        Assert.Equal("SELECT * FROM \"users\" ORDER BY \"name\" OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY", sql);
+    }
+
+    [Fact]
     public void SelectOrderByTop()
     {
         var query = new Query()
@@ -845,6 +859,7 @@ public class QueryBuilderTests
     [InlineData(SqlDialect.SqlServer, "SELECT [123] FROM [t]")]
     [InlineData(SqlDialect.PostgreSql, "SELECT \"123\" FROM \"t\"")]
     [InlineData(SqlDialect.MySql, "SELECT `123` FROM `t`")]
+    [InlineData(SqlDialect.Oracle, "SELECT \"123\" FROM \"t\"")]
     public void NumericColumnNames_AreQuoted(SqlDialect dialect, string expected)
     {
         var query = new Query().Select("123").From("t");


### PR DESCRIPTION
## Summary
- support Oracle in `SqlDialect`
- treat Oracle like SQL Server for OFFSET/FETCH while quoting identifiers with double quotes
- add Oracle dialect examples and tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b7181ec8f8832ebc73129463b3d31b