### PR TITLE
chore: update database client dependencies

### DIFF
--- a/DbaClientX.Core/DbaClientX.Core.csproj
+++ b/DbaClientX.Core/DbaClientX.Core.csproj
@@ -27,7 +27,7 @@
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Collections" />

--- a/DbaClientX.Oracle/DbaClientX.Oracle.csproj
+++ b/DbaClientX.Oracle/DbaClientX.Oracle.csproj
@@ -28,6 +28,11 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.9.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.110" />
   </ItemGroup>
   <ItemGroup>

--- a/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
+++ b/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
@@ -28,8 +28,13 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
-    <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Npgsql" Version="9.0.3" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+    <PackageReference Include="Npgsql" Version="8.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Collections" />

--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Collections" />

--- a/DbaClientX.SqlServer/DbaClientX.SqlServer.csproj
+++ b/DbaClientX.SqlServer/DbaClientX.SqlServer.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Collections" />

--- a/DbaClientX.Tests/DbaClientX.Tests.csproj
+++ b/DbaClientX.Tests/DbaClientX.Tests.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.3.7" />
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.110" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.11" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.9.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- update Oracle package to 23.9.1 for net8.0 and keep older version for legacy targets
- bump SqlClient, Sqlite, PowerShell and other test dependencies
- modernize Npgsql to 9.0.3 for net8.0

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test DbaClientX.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b72becbb8c832eb758774b5883601a