### PR TITLE
Only reference Microsoft.Bcl.AsyncInterfaces on legacy frameworks

### DIFF
--- a/DbaClientX.Core/DbaClientX.Core.csproj
+++ b/DbaClientX.Core/DbaClientX.Core.csproj
@@ -26,7 +26,7 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- only include Microsoft.Bcl.AsyncInterfaces package when targeting netstandard2.0 or net472

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test DbaClientX.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b7333ba660832e8a561cd7ba890947