### PR TITLE
Add Oracle provider examples

### DIFF
--- a/DbaClientX.Examples/BulkInsertOracleExample.cs
+++ b/DbaClientX.Examples/BulkInsertOracleExample.cs
@@ -1,0 +1,37 @@
+using DBAClientX;
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+public static class BulkInsertOracleExample
+{
+    public static void Run()
+    {
+        using var oracle = new DBAClientX.Oracle();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "Example");
+
+        oracle.BeginTransaction("OracleServer", "ORCL", "user", "pass");
+        try
+        {
+            foreach (DataRow row in table.Rows)
+            {
+                var parameters = new Dictionary<string, object?>
+                {
+                    ["Id"] = row["Id"],
+                    ["Name"] = row["Name"]
+                };
+                oracle.ExecuteNonQuery("OracleServer", "ORCL", "user", "pass", "INSERT INTO ExampleTable (Id, Name) VALUES (:Id, :Name)", parameters, useTransaction: true);
+            }
+            oracle.Commit();
+            Console.WriteLine("Bulk insert executed.");
+        }
+        catch
+        {
+            oracle.Rollback();
+            Console.WriteLine("Bulk insert failed.");
+        }
+    }
+}

--- a/DbaClientX.Examples/QueryOracleExample.cs
+++ b/DbaClientX.Examples/QueryOracleExample.cs
@@ -1,0 +1,30 @@
+using DBAClientX;
+using System;
+using System.Data;
+
+public static class QueryOracleExample
+{
+    public static void Run()
+    {
+        var connectionString = DBAClientX.Oracle.BuildConnectionString("OracleServer", "ORCL", "user", "pass");
+        Console.WriteLine(connectionString);
+
+        using var oracle = new DBAClientX.Oracle
+        {
+            ReturnType = ReturnType.DataTable,
+        };
+
+        var result = oracle.Query("OracleServer", "ORCL", "user", "pass", "SELECT 1 FROM dual");
+        if (result is DataTable table)
+        {
+            foreach (DataRow row in table.Rows)
+            {
+                foreach (DataColumn col in table.Columns)
+                {
+                    Console.Write($"{row[col]}\t");
+                }
+                Console.WriteLine();
+            }
+        }
+    }
+}

--- a/DbaClientX.Examples/TransactionOracleExample.cs
+++ b/DbaClientX.Examples/TransactionOracleExample.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Data;
+using DBAClientX;
+
+public static class TransactionOracleExample
+{
+    public static void Run()
+    {
+        using var oracle = new DBAClientX.Oracle();
+        oracle.BeginTransaction("OracleServer", "ORCL", "user", "pass", IsolationLevel.Serializable);
+        try
+        {
+            oracle.ExecuteNonQuery("OracleServer", "ORCL", "user", "pass", "CREATE TABLE Example (Id NUMBER)", useTransaction: true);
+            oracle.Commit();
+            Console.WriteLine("Committed");
+        }
+        catch
+        {
+            oracle.Rollback();
+            Console.WriteLine("Rolled back");
+        }
+    }
+}

--- a/Module/Examples/Example.OracleNonQuery.ps1
+++ b/Module/Examples/Example.OracleNonQuery.ps1
@@ -1,5 +1,8 @@
 Clear-Host
 Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
 
+$connectionString = [DBAClientX.Oracle]::BuildConnectionString("OracleServer", "ORCL", "user", "pass")
+Write-Host $connectionString
+
 $Rows = Invoke-DbaXOracleNonQuery -Query "UPDATE Users SET Disabled = 1 WHERE 1=0" -Server "OracleServer" -Database "ORCL" -Username "user" -Password "pass"
 $Rows

--- a/Module/Examples/Example.QueryOracle.ps1
+++ b/Module/Examples/Example.QueryOracle.ps1
@@ -1,5 +1,8 @@
 Clear-Host
 Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
 
+$connectionString = [DBAClientX.Oracle]::BuildConnectionString("OracleServer", "ORCL", "user", "pass")
+Write-Host $connectionString
+
 $T = Invoke-DbaXOracle -Query "SELECT 1 FROM dual" -Server "OracleServer" -Database "ORCL" -Username "user" -Password "pass"
 $T | Format-Table


### PR DESCRIPTION
## Summary
- add Oracle query example showing connection string usage
- add Oracle bulk insert and transaction examples
- update PowerShell examples for Oracle with connection string builder

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test --no-build DbaClientX.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b73bcce120832e814262198d02866d