### PR TITLE
Add Oracle bulk insert support

### DIFF
--- a/DbaClientX.Examples/BulkInsertOracleExample.cs
+++ b/DbaClientX.Examples/BulkInsertOracleExample.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Data;
+
+public static class BulkInsertOracleExample
+{
+    public static void Run()
+    {
+        using var oracle = new DBAClientX.Oracle();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "Example");
+
+        oracle.BulkInsert("localhost", "ORCL", "user", "password", table, "ExampleTable", batchSize: 1000, bulkCopyTimeout: 60);
+        Console.WriteLine("Bulk insert executed.");
+    }
+}

--- a/DbaClientX.Tests/OracleBulkInsertTests.cs
+++ b/DbaClientX.Tests/OracleBulkInsertTests.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Oracle.ManagedDataAccess.Client;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class OracleBulkInsertTests
+{
+    private class CaptureBulkCopyOracle : DBAClientX.Oracle
+    {
+        public int? Timeout { get; private set; }
+        public string? Destination { get; private set; }
+        public List<(string Source, string Destination)> Mappings { get; } = new();
+        public List<int> BatchRowCounts { get; } = new();
+
+        protected override OracleConnection CreateConnection(string connectionString) => new();
+
+        protected override void OpenConnection(OracleConnection connection)
+        {
+            // no-op
+        }
+
+        protected override Task OpenConnectionAsync(OracleConnection connection, CancellationToken cancellationToken) => Task.CompletedTask;
+
+        protected override OracleBulkCopy CreateBulkCopy(OracleConnection connection, OracleTransaction? transaction) => new("User Id=a;Password=b;Data Source=localhost/XE");
+
+        protected override void WriteToServer(OracleBulkCopy bulkCopy, DataTable table)
+        {
+            Timeout = bulkCopy.BulkCopyTimeout;
+            Destination = bulkCopy.DestinationTableName;
+            foreach (OracleBulkCopyColumnMapping mapping in bulkCopy.ColumnMappings)
+            {
+                Mappings.Add((mapping.SourceColumn, mapping.DestinationColumn));
+            }
+            BatchRowCounts.Add(table.Rows.Count);
+        }
+
+        protected override Task WriteToServerAsync(OracleBulkCopy bulkCopy, DataTable table, CancellationToken cancellationToken)
+        {
+            WriteToServer(bulkCopy, table);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public void BulkInsert_SetsOptionsAndMappings()
+    {
+        using var oracle = new CaptureBulkCopyOracle();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "a");
+        table.Rows.Add(2, "b");
+
+        oracle.BulkInsert("h", "svc", "u", "p", table, "Dest", batchSize: 1, bulkCopyTimeout: 60);
+
+        Assert.Equal(60, oracle.Timeout);
+        Assert.Equal("Dest", oracle.Destination);
+        Assert.Contains(oracle.Mappings, m => m.Source == "Id" && m.Destination == "Id");
+        Assert.Contains(oracle.Mappings, m => m.Source == "Name" && m.Destination == "Name");
+        Assert.Equal(new[] { 1, 1 }, oracle.BatchRowCounts);
+    }
+
+    [Fact]
+    public async Task BulkInsertAsync_SetsOptionsAndMappings()
+    {
+        using var oracle = new CaptureBulkCopyOracle();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "a");
+        table.Rows.Add(2, "b");
+
+        await oracle.BulkInsertAsync("h", "svc", "u", "p", table, "Dest", batchSize: 1, bulkCopyTimeout: 30);
+
+        Assert.Equal(30, oracle.Timeout);
+        Assert.Equal("Dest", oracle.Destination);
+        Assert.Contains(oracle.Mappings, m => m.Source == "Id" && m.Destination == "Id");
+        Assert.Contains(oracle.Mappings, m => m.Source == "Name" && m.Destination == "Name");
+        Assert.Equal(new[] { 1, 1 }, oracle.BatchRowCounts);
+    }
+
+    [Fact]
+    public void BulkInsert_DefaultOptions_AddsAllMappings()
+    {
+        using var oracle = new CaptureBulkCopyOracle();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(1, "a");
+        table.Rows.Add(2, "b");
+
+        oracle.BulkInsert("h", "svc", "u", "p", table, "Dest");
+
+        Assert.Equal(30, oracle.Timeout);
+        Assert.Equal("Dest", oracle.Destination);
+        Assert.Equal(table.Columns.Count, oracle.Mappings.Count);
+        Assert.Equal(new[] { 2 }, oracle.BatchRowCounts);
+    }
+
+    [Fact]
+    public void BulkInsert_WithTransactionNotStarted_Throws()
+    {
+        using var oracle = new DBAClientX.Oracle();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        Assert.Throws<DBAClientX.DbaTransactionException>(() => oracle.BulkInsert("h", "svc", "u", "p", table, "Dest", useTransaction: true));
+    }
+}

--- a/Module/Examples/Example.OracleBulkInsert.ps1
+++ b/Module/Examples/Example.OracleBulkInsert.ps1
@@ -1,0 +1,11 @@
+Clear-Host
+Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+
+$Table = New-Object System.Data.DataTable
+$Table.Columns.Add("Id", [int]) | Out-Null
+$Table.Columns.Add("Name", [string]) | Out-Null
+$Table.Rows.Add(1, "Example") | Out-Null
+
+$Oracle = [DBAClientX.Oracle]::new()
+$Oracle.BulkInsert("OracleServer", "ORCL", "user", "pass", $Table, "ExampleTable", $false, 1000, 60)
+$Oracle.Dispose()


### PR DESCRIPTION
## Summary
- implement Oracle bulk insert with batching and async helpers
- add Oracle bulk insert unit tests
- include Oracle bulk insert examples in C# and PowerShell

## Testing
- `dotnet build DbaClientX.sln`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b743d7484c832eb2b518944f6db9be