### PR TITLE
Add XML documentation for MySql client

### DIFF
--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -38,12 +38,13 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="port">Optional TCP port; when omitted the provider default is used.</param>
     /// <param name="ssl">Optional SSL requirement flag; <see langword="true"/> enforces TLS.</param>
     /// <returns>The generated connection string.</returns>
     /// <remarks>
-    /// The builder enables connection pooling by default so repeated operations reuse the same socket where possible.
+    /// The builder enables connection pooling by default so repeated operations reuse the same socket where possible, lowering latency and resource consumption
+    /// for high-frequency workloads. Adjust pooling-related properties on the returned string when connection storm scenarios require tighter control.
     /// </remarks>
     public static string BuildConnectionString(string host, string database, string username, string password, uint? port = null, bool? ssl = null)
     {
@@ -72,11 +73,11 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <returns><see langword="true"/> when executing <c>SELECT 1</c> succeeds; otherwise <see langword="false"/>.</returns>
     /// <remarks>
     /// Exceptions are swallowed to keep the call lightweight; call
-    /// <see cref="ExecuteScalar(string, string, string, string, string, IDictionary{string, object}, bool, IDictionary{string, MySqlDbType}, IDictionary{string, ParameterDirection})" /> for detailed error information.
+    /// <see cref="ExecuteScalar(string, string, string, string, string, IDictionary{string, object?>?, bool, IDictionary{string, MySqlDbType}?, IDictionary{string, ParameterDirection}?)" /> for detailed error information.
     /// </remarks>
     public virtual bool Ping(string host, string database, string username, string password)
     {
@@ -97,7 +98,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="cancellationToken">Token used to cancel the underlying query.</param>
     /// <returns><see langword="true"/> when executing <c>SELECT 1</c> succeeds; otherwise <see langword="false"/>.</returns>
     /// <remarks>
@@ -122,13 +123,17 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="query">SQL text to execute.</param>
     /// <param name="parameters">Optional set of parameter name/value pairs.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
     /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
     /// <param name="parameterDirections">Optional map of parameter directions.</param>
-    /// <returns>The materialized query result; the concrete shape matches the <c>DatabaseClientBase</c> contract.</returns>
+    /// <returns>The materialized query result as defined by the <see cref="DatabaseClientBase"/> implementation.</returns>
+    /// <remarks>
+    /// Always prefer parameterized SQL by supplying <paramref name="parameters"/> (and optionally <paramref name="parameterTypes"/>) to guard against SQL injection attacks.
+    /// Avoid concatenating user input into <paramref name="query"/> directly.
+    /// </remarks>
     /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
     /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual object? Query(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
@@ -176,13 +181,16 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="query">SQL text to execute.</param>
     /// <param name="parameters">Optional set of parameter name/value pairs.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
     /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
     /// <param name="parameterDirections">Optional map of parameter directions.</param>
     /// <returns>The scalar value produced by the query, or <see langword="null"/> when no rows are returned.</returns>
+    /// <remarks>
+    /// Provide <paramref name="parameters"/> whenever user-supplied values are involved to ensure MySQL can compose safe parameterized commands and reduce SQL injection risk.
+    /// </remarks>
     /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
     /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual object? ExecuteScalar(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
@@ -233,7 +241,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="query">SQL text to execute.</param>
     /// <param name="parameters">Optional set of parameter name/value pairs.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -242,6 +250,10 @@ public class MySql : DatabaseClientBase
     /// <returns>The number of affected rows.</returns>
     /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
     /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
+    /// <remarks>
+    /// Use <paramref name="parameters"/> to supply user input safely and lean on <paramref name="parameterTypes"/> when explicit MySQL data types prevent implicit conversion overhead.
+    /// This combination mitigates SQL injection risk while ensuring the server can reuse execution plans efficiently.
+    /// </remarks>
     public virtual int ExecuteNonQuery(
         string host,
         string database,
@@ -296,7 +308,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="query">SQL text to execute.</param>
     /// <param name="parameters">Optional set of parameter name/value pairs.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -306,6 +318,9 @@ public class MySql : DatabaseClientBase
     /// <returns>The number of affected rows.</returns>
     /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
     /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
+    /// <remarks>
+    /// Provide <paramref name="parameters"/> (and optionally <paramref name="parameterTypes"/>) to avoid SQL injection vulnerabilities and to help MySQL reuse cached execution plans, especially in long-running async workloads.
+    /// </remarks>
     public virtual async Task<int> ExecuteNonQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -351,7 +366,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="query">SQL text to execute.</param>
     /// <param name="parameters">Optional set of parameter name/value pairs.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -361,6 +376,9 @@ public class MySql : DatabaseClientBase
     /// <returns>The materialized query result.</returns>
     /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
     /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
+    /// <remarks>
+    /// Always supply <paramref name="parameters"/> for user input to avoid SQL injection and consider populating <paramref name="parameterTypes"/> when deterministic MySQL types improve plan caching.
+    /// </remarks>
     public virtual async Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -406,7 +424,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="query">SQL text to execute.</param>
     /// <param name="parameters">Optional set of parameter name/value pairs.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -416,6 +434,9 @@ public class MySql : DatabaseClientBase
     /// <returns>The scalar value produced by the query, or <see langword="null"/> when no rows are returned.</returns>
     /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
     /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
+    /// <remarks>
+    /// Provide <paramref name="parameters"/> whenever user-supplied values are involved to ensure the MySQL provider composes parameterized commands and to protect against SQL injection attacks.
+    /// </remarks>
     public virtual async Task<object?> ExecuteScalarAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -461,7 +482,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="procedure">Stored procedure name.</param>
     /// <param name="parameters">Optional set of parameter name/value pairs.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -539,7 +560,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="procedure">Stored procedure name.</param>
     /// <param name="parameters">Optional set of parameter name/value pairs.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -618,7 +639,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="procedure">Stored procedure name.</param>
     /// <param name="parameters">Sequence of parameters to add directly to the command.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -691,7 +712,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="procedure">Stored procedure name.</param>
     /// <param name="parameters">Sequence of parameters to add directly to the command.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -766,7 +787,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="query">SQL text to execute.</param>
     /// <param name="parameters">Optional set of parameter name/value pairs.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -824,7 +845,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="procedure">Stored procedure name.</param>
     /// <param name="parameters">Optional set of parameter name/value pairs.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -882,7 +903,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="procedure">Stored procedure name.</param>
     /// <param name="parameters">Sequence of preconfigured parameters to add to the command.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -938,7 +959,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="table">Table containing rows to be inserted.</param>
     /// <param name="destinationTable">Target table name in the database.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -947,6 +968,10 @@ public class MySql : DatabaseClientBase
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="table"/> is <see langword="null"/>.</exception>
     /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
     /// <exception cref="DbaQueryExecutionException">Thrown when <see cref="MySqlBulkCopy"/> reports an error.</exception>
+    /// <remarks>
+    /// Enable <paramref name="useTransaction"/> for atomic ingestion or when staging tables must remain internally consistent.
+    /// For very large payloads choose a <paramref name="batchSize"/> that fits in memory comfortably to avoid temporary table inflation while still benefiting from network streaming.
+    /// </remarks>
     public virtual void BulkInsert(string host, string database, string username, string password, DataTable table, string destinationTable, bool useTransaction = false, int? batchSize = null, int? bulkCopyTimeout = null)
     {
         if (table == null) throw new ArgumentNullException(nameof(table));
@@ -1020,7 +1045,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="table">Table containing rows to be inserted.</param>
     /// <param name="destinationTable">Target table name in the database.</param>
     /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
@@ -1030,6 +1055,31 @@ public class MySql : DatabaseClientBase
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="table"/> is <see langword="null"/>.</exception>
     /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
     /// <exception cref="DbaQueryExecutionException">Thrown when <see cref="MySqlBulkCopy"/> reports an error.</exception>
+    /// <remarks>
+    /// Batch writes with <paramref name="batchSize"/> to balance throughput and memory pressure, and recycle the same <see cref="MySql"/> instance when streaming multiple batches so connection pooling can deliver consistent performance.
+    /// </remarks>
+    /// <example>
+    /// <code><![CDATA[
+    /// var client = new MySql();
+    /// CancellationToken cancellationToken = CancellationToken.None;
+    /// await client.BeginTransactionAsync(host, database, username, password, cancellationToken);
+    /// try
+    /// {
+    ///     using var table = new DataTable();
+    ///     table.Columns.Add("Id", typeof(int));
+    ///     table.Columns.Add("Name", typeof(string));
+    ///     table.Rows.Add(1, "Widget");
+    ///
+    ///     await client.BulkInsertAsync(host, database, username, password, table, "inventory", useTransaction: true, batchSize: 5_000, cancellationToken: cancellationToken);
+    ///     await client.CommitAsync(cancellationToken);
+    /// }
+    /// catch
+    /// {
+    ///     await client.RollbackAsync(cancellationToken);
+    ///     throw;
+    /// }
+    /// ]]></code>
+    /// </example>
     public virtual async Task BulkInsertAsync(string host, string database, string username, string password, DataTable table, string destinationTable, bool useTransaction = false, int? batchSize = null, int? bulkCopyTimeout = null, CancellationToken cancellationToken = default)
     {
         if (table == null) throw new ArgumentNullException(nameof(table));
@@ -1135,8 +1185,11 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <exception cref="DbaTransactionException">Thrown when a transaction is already in progress.</exception>
+    /// <remarks>
+    /// Uses <see cref="IsolationLevel.ReadCommitted"/> to avoid dirty reads while preserving concurrency. Increase the isolation level via the overload when phantom reads must be prevented.
+    /// </remarks>
     public virtual void BeginTransaction(string host, string database, string username, string password)
         => BeginTransaction(host, database, username, password, IsolationLevel.ReadCommitted);
 
@@ -1146,9 +1199,13 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="isolationLevel">Desired transaction isolation level.</param>
     /// <exception cref="DbaTransactionException">Thrown when a transaction is already in progress.</exception>
+    /// <remarks>
+    /// Higher isolation levels such as <see cref="IsolationLevel.Serializable"/> reduce write skew and phantom reads at the expense of increased locking and potential deadlocks.
+    /// Choose the loosest level that still satisfies business invariants to keep throughput high.
+    /// </remarks>
     public virtual void BeginTransaction(string host, string database, string username, string password, IsolationLevel isolationLevel)
     {
         lock (_syncRoot)
@@ -1172,10 +1229,34 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="cancellationToken">Token used to cancel connection establishment.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     /// <exception cref="DbaTransactionException">Thrown when a transaction is already in progress.</exception>
+    /// <remarks>
+    /// Uses <see cref="IsolationLevel.ReadCommitted"/> which balances data integrity with concurrency for most OLTP scenarios.
+    /// </remarks>
+    /// <example>
+    /// <code><![CDATA[
+    /// var client = new MySql();
+    /// await client.BeginTransactionAsync(host, database, username, password, cancellationToken);
+    /// try
+    /// {
+    ///     await client.ExecuteNonQueryAsync(host, database, username, password, "UPDATE accounts SET balance = balance - @amount WHERE id = @id", new Dictionary<string, object?>
+    ///     {
+    ///         ["@amount"] = 100m,
+    ///         ["@id"] = 42
+    ///     }, useTransaction: true, cancellationToken: cancellationToken);
+    ///
+    ///     await client.CommitAsync(cancellationToken);
+    /// }
+    /// catch
+    /// {
+    ///     await client.RollbackAsync(cancellationToken);
+    ///     throw;
+    /// }
+    /// ]]></code>
+    /// </example>
     public virtual Task BeginTransactionAsync(string host, string database, string username, string password, CancellationToken cancellationToken = default)
         => BeginTransactionAsync(host, database, username, password, IsolationLevel.ReadCommitted, cancellationToken);
 
@@ -1185,11 +1266,14 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="isolationLevel">Desired transaction isolation level.</param>
     /// <param name="cancellationToken">Token used to cancel connection establishment.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     /// <exception cref="DbaTransactionException">Thrown when a transaction is already in progress.</exception>
+    /// <remarks>
+    /// Stronger isolation levels increase lock contention and may require implementing retry logic to handle deadlocks gracefully.
+    /// </remarks>
     public virtual async Task BeginTransactionAsync(string host, string database, string username, string password, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
     {
         lock (_syncRoot)
@@ -1334,7 +1418,7 @@ public class MySql : DatabaseClientBase
     /// <param name="host">Host name or IP address of the MySQL server.</param>
     /// <param name="database">Database (schema) to connect to.</param>
     /// <param name="username">User identifier.</param>
-    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="password">User password.</param>
     /// <param name="cancellationToken">Token used to cancel the overall batch.</param>
     /// <param name="maxDegreeOfParallelism">Optional concurrency limiter; <see langword="null"/> uses as many tasks as queries.</param>
     /// <returns>Results returned by each query in submission order.</returns>

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -14,7 +14,7 @@ using System.Runtime.CompilerServices;
 namespace DBAClientX;
 
 /// <summary>
-/// This class is used to connect to MySQL
+/// Provides high-level convenience operations for interacting with a MySQL database using the shared <see cref="DatabaseClientBase"/> abstractions.
 /// </summary>
 public class MySql : DatabaseClientBase
 {
@@ -22,8 +22,29 @@ public class MySql : DatabaseClientBase
     private MySqlConnection? _transactionConnection;
     private MySqlTransaction? _transaction;
 
+    /// <summary>
+    /// Gets a value indicating whether the client currently has an active transaction scope.
+    /// </summary>
+    /// <remarks>
+    /// The flag is toggled when <see cref="BeginTransaction(string, string, string, string)"/> or
+    /// <see cref="BeginTransactionAsync(string, string, string, string, System.Threading.CancellationToken)"/> is invoked and
+    /// returns to <see langword="false"/> after <see cref="Commit"/>, <see cref="Rollback"/>, or the async counterparts dispose the transaction.
+    /// </remarks>
     public bool IsInTransaction => _transaction != null;
 
+    /// <summary>
+    /// Builds a <see cref="MySqlConnectionStringBuilder"/> connection string from individual connection components.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="port">Optional TCP port; when omitted the provider default is used.</param>
+    /// <param name="ssl">Optional SSL requirement flag; <see langword="true"/> enforces TLS.</param>
+    /// <returns>The generated connection string.</returns>
+    /// <remarks>
+    /// The builder enables connection pooling by default so repeated operations reuse the same socket where possible.
+    /// </remarks>
     public static string BuildConnectionString(string host, string database, string username, string password, uint? port = null, bool? ssl = null)
     {
         var builder = new MySqlConnectionStringBuilder
@@ -45,6 +66,18 @@ public class MySql : DatabaseClientBase
         return builder.ConnectionString;
     }
 
+    /// <summary>
+    /// Performs a synchronous connectivity test against the specified MySQL instance.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <returns><see langword="true"/> when executing <c>SELECT 1</c> succeeds; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Exceptions are swallowed to keep the call lightweight; call
+    /// <see cref="ExecuteScalar(string, string, string, string, string, IDictionary{string, object}, bool, IDictionary{string, MySqlDbType}, IDictionary{string, ParameterDirection})" /> for detailed error information.
+    /// </remarks>
     public virtual bool Ping(string host, string database, string username, string password)
     {
         try
@@ -58,6 +91,18 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Performs an asynchronous connectivity test against the specified MySQL instance.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="cancellationToken">Token used to cancel the underlying query.</param>
+    /// <returns><see langword="true"/> when executing <c>SELECT 1</c> succeeds; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// The method mirrors <see cref="Ping"/> but uses async I/O primitives to avoid blocking threads.
+    /// </remarks>
     public virtual async Task<bool> PingAsync(string host, string database, string username, string password, CancellationToken cancellationToken = default)
     {
         try
@@ -71,6 +116,21 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Executes a SQL query and materializes the result using the shared <see cref="DatabaseClientBase"/> pipeline.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="query">SQL text to execute.</param>
+    /// <param name="parameters">Optional set of parameter name/value pairs.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
+    /// <param name="parameterDirections">Optional map of parameter directions.</param>
+    /// <returns>The materialized query result; the concrete shape matches the <c>DatabaseClientBase</c> contract.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual object? Query(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -110,6 +170,21 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Executes a SQL query and returns the first column of the first row in the result set.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="query">SQL text to execute.</param>
+    /// <param name="parameters">Optional set of parameter name/value pairs.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
+    /// <param name="parameterDirections">Optional map of parameter directions.</param>
+    /// <returns>The scalar value produced by the query, or <see langword="null"/> when no rows are returned.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual object? ExecuteScalar(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -152,6 +227,21 @@ public class MySql : DatabaseClientBase
     private static IDictionary<string, DbType>? ConvertParameterTypes(IDictionary<string, MySqlDbType>? types) =>
         DbTypeConverter.ConvertParameterTypes(types, static () => new MySqlParameter(), static (p, t) => p.MySqlDbType = t);
 
+    /// <summary>
+    /// Executes a SQL statement that does not produce a result set.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="query">SQL text to execute.</param>
+    /// <param name="parameters">Optional set of parameter name/value pairs.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
+    /// <param name="parameterDirections">Optional map of parameter directions.</param>
+    /// <returns>The number of affected rows.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual int ExecuteNonQuery(
         string host,
         string database,
@@ -200,6 +290,22 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Executes a non-query SQL statement asynchronously.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="query">SQL text to execute.</param>
+    /// <param name="parameters">Optional set of parameter name/value pairs.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the underlying command.</param>
+    /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
+    /// <param name="parameterDirections">Optional map of parameter directions.</param>
+    /// <returns>The number of affected rows.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual async Task<int> ExecuteNonQueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -239,6 +345,22 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Executes a SQL query asynchronously and materializes the result using the shared <see cref="DatabaseClientBase"/> pipeline.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="query">SQL text to execute.</param>
+    /// <param name="parameters">Optional set of parameter name/value pairs.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the underlying command.</param>
+    /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
+    /// <param name="parameterDirections">Optional map of parameter directions.</param>
+    /// <returns>The materialized query result.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual async Task<object?> QueryAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -278,6 +400,22 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Executes a SQL query asynchronously and returns the first column of the first row in the result set.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="query">SQL text to execute.</param>
+    /// <param name="parameters">Optional set of parameter name/value pairs.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the underlying command.</param>
+    /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
+    /// <param name="parameterDirections">Optional map of parameter directions.</param>
+    /// <returns>The scalar value produced by the query, or <see langword="null"/> when no rows are returned.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual async Task<object?> ExecuteScalarAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -317,6 +455,21 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Executes a stored procedure and returns the aggregated results.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="procedure">Stored procedure name.</param>
+    /// <param name="parameters">Optional set of parameter name/value pairs.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
+    /// <param name="parameterDirections">Optional map of parameter directions.</param>
+    /// <returns>The materialized result as defined by the base client.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual object? ExecuteStoredProcedure(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -380,6 +533,22 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Executes a stored procedure asynchronously and returns the aggregated results.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="procedure">Stored procedure name.</param>
+    /// <param name="parameters">Optional set of parameter name/value pairs.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the underlying command.</param>
+    /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
+    /// <param name="parameterDirections">Optional map of parameter directions.</param>
+    /// <returns>The materialized result as defined by the base client.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual async Task<object?> ExecuteStoredProcedureAsync(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -443,6 +612,19 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Executes a stored procedure using explicitly configured <see cref="DbParameter"/> instances.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="procedure">Stored procedure name.</param>
+    /// <param name="parameters">Sequence of parameters to add directly to the command.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <returns>The materialized result as defined by the base client.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual object? ExecuteStoredProcedure(string host, string database, string username, string password, string procedure, IEnumerable<DbParameter>? parameters = null, bool useTransaction = false)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -503,6 +685,20 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Executes a stored procedure asynchronously using explicitly configured <see cref="DbParameter"/> instances.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="procedure">Stored procedure name.</param>
+    /// <param name="parameters">Sequence of parameters to add directly to the command.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The materialized result as defined by the base client.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when the underlying command fails.</exception>
     public virtual async Task<object?> ExecuteStoredProcedureAsync(string host, string database, string username, string password, string procedure, IEnumerable<DbParameter>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default)
     {
         var connectionString = BuildConnectionString(host, database, username, password);
@@ -564,6 +760,21 @@ public class MySql : DatabaseClientBase
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    /// <summary>
+    /// Streams rows produced by a query asynchronously without buffering the entire result set.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="query">SQL text to execute.</param>
+    /// <param name="parameters">Optional set of parameter name/value pairs.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the streaming operation.</param>
+    /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
+    /// <param name="parameterDirections">Optional map of parameter directions.</param>
+    /// <returns>An <see cref="IAsyncEnumerable{DataRow}"/> that yields <see cref="DataRow"/> instances as they arrive from the server.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
     public virtual IAsyncEnumerable<DataRow> QueryStreamAsync(string host, string database, string username, string password, string query, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         return Stream();
@@ -607,6 +818,21 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Streams rows produced by a stored procedure asynchronously without buffering the entire result set.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="procedure">Stored procedure name.</param>
+    /// <param name="parameters">Optional set of parameter name/value pairs.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the streaming operation.</param>
+    /// <param name="parameterTypes">Optional map of parameter types expressed as <see cref="MySqlDbType"/> values.</param>
+    /// <param name="parameterDirections">Optional map of parameter directions.</param>
+    /// <returns>An <see cref="IAsyncEnumerable{DataRow}"/> that yields <see cref="DataRow"/> instances as they arrive from the server.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
     public virtual IAsyncEnumerable<DataRow> ExecuteStoredProcedureStreamAsync(string host, string database, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default, IDictionary<string, MySqlDbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         return Stream();
@@ -650,6 +876,19 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Streams rows produced by a stored procedure using explicitly constructed <see cref="DbParameter"/> instances.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="procedure">Stored procedure name.</param>
+    /// <param name="parameters">Sequence of preconfigured parameters to add to the command.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the streaming operation.</param>
+    /// <returns>An <see cref="IAsyncEnumerable{DataRow}"/> that yields <see cref="DataRow"/> instances as they arrive from the server.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
     public virtual IAsyncEnumerable<DataRow> ExecuteStoredProcedureStreamAsync(string host, string database, string username, string password, string procedure, IEnumerable<DbParameter>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         return Stream();
@@ -693,6 +932,21 @@ public class MySql : DatabaseClientBase
     }
 #endif
 
+    /// <summary>
+    /// Performs a bulk insert using <see cref="MySqlBulkCopy"/> and the provided <see cref="DataTable"/> payload.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="table">Table containing rows to be inserted.</param>
+    /// <param name="destinationTable">Target table name in the database.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="batchSize">Optional batch size; enables chunked ingestion for large payloads.</param>
+    /// <param name="bulkCopyTimeout">Optional timeout applied to the bulk copy operation.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="table"/> is <see langword="null"/>.</exception>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when <see cref="MySqlBulkCopy"/> reports an error.</exception>
     public virtual void BulkInsert(string host, string database, string username, string password, DataTable table, string destinationTable, bool useTransaction = false, int? batchSize = null, int? bulkCopyTimeout = null)
     {
         if (table == null) throw new ArgumentNullException(nameof(table));
@@ -760,6 +1014,22 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Performs a bulk insert asynchronously using <see cref="MySqlBulkCopy"/> and the provided <see cref="DataTable"/> payload.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="table">Table containing rows to be inserted.</param>
+    /// <param name="destinationTable">Target table name in the database.</param>
+    /// <param name="useTransaction">When <see langword="true"/> the call uses the currently open transaction.</param>
+    /// <param name="batchSize">Optional batch size; enables chunked ingestion for large payloads.</param>
+    /// <param name="bulkCopyTimeout">Optional timeout applied to the bulk copy operation.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="table"/> is <see langword="null"/>.</exception>
+    /// <exception cref="DbaTransactionException">Thrown when <paramref name="useTransaction"/> is <see langword="true"/> but no transaction has been started.</exception>
+    /// <exception cref="DbaQueryExecutionException">Thrown when <see cref="MySqlBulkCopy"/> reports an error.</exception>
     public virtual async Task BulkInsertAsync(string host, string database, string username, string password, DataTable table, string destinationTable, bool useTransaction = false, int? batchSize = null, int? bulkCopyTimeout = null, CancellationToken cancellationToken = default)
     {
         if (table == null) throw new ArgumentNullException(nameof(table));
@@ -827,20 +1097,58 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Creates a configured <see cref="MySqlBulkCopy"/> instance for bulk operations.
+    /// </summary>
+    /// <param name="connection">Open MySQL connection.</param>
+    /// <param name="transaction">Optional ambient transaction.</param>
+    /// <returns>A <see cref="MySqlBulkCopy"/> bound to the provided connection.</returns>
     protected virtual MySqlBulkCopy CreateBulkCopy(MySqlConnection connection, MySqlTransaction? transaction) => new(connection, transaction);
 
+    /// <summary>
+    /// Writes the contents of <paramref name="table"/> to the server using the provided bulk copy instance.
+    /// </summary>
     protected virtual void WriteToServer(MySqlBulkCopy bulkCopy, DataTable table) => bulkCopy.WriteToServer(table);
 
+    /// <summary>
+    /// Asynchronously writes the contents of <paramref name="table"/> to the server using the provided bulk copy instance.
+    /// </summary>
     protected virtual Task WriteToServerAsync(MySqlBulkCopy bulkCopy, DataTable table, CancellationToken cancellationToken) => bulkCopy.WriteToServerAsync(table, cancellationToken).AsTask();
 
+    /// <summary>
+    /// Creates a new <see cref="MySqlConnection"/> for the supplied connection string.
+    /// </summary>
     protected virtual MySqlConnection CreateConnection(string connectionString) => new(connectionString);
 
+    /// <summary>
+    /// Opens a MySQL connection using synchronous APIs.
+    /// </summary>
     protected virtual void OpenConnection(MySqlConnection connection) => connection.Open();
 
+    /// <summary>
+    /// Opens a MySQL connection asynchronously.
+    /// </summary>
     protected virtual Task OpenConnectionAsync(MySqlConnection connection, CancellationToken cancellationToken) => connection.OpenAsync(cancellationToken);
+    /// <summary>
+    /// Starts a transaction using the default isolation level (<see cref="IsolationLevel.ReadCommitted"/>).
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already in progress.</exception>
     public virtual void BeginTransaction(string host, string database, string username, string password)
         => BeginTransaction(host, database, username, password, IsolationLevel.ReadCommitted);
 
+    /// <summary>
+    /// Starts a transaction with the specified <paramref name="isolationLevel"/>.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="isolationLevel">Desired transaction isolation level.</param>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already in progress.</exception>
     public virtual void BeginTransaction(string host, string database, string username, string password, IsolationLevel isolationLevel)
     {
         lock (_syncRoot)
@@ -858,9 +1166,30 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Asynchronously starts a transaction using the default isolation level (<see cref="IsolationLevel.ReadCommitted"/>).
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="cancellationToken">Token used to cancel connection establishment.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already in progress.</exception>
     public virtual Task BeginTransactionAsync(string host, string database, string username, string password, CancellationToken cancellationToken = default)
         => BeginTransactionAsync(host, database, username, password, IsolationLevel.ReadCommitted, cancellationToken);
 
+    /// <summary>
+    /// Asynchronously starts a transaction with the specified <paramref name="isolationLevel"/>.
+    /// </summary>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="isolationLevel">Desired transaction isolation level.</param>
+    /// <param name="cancellationToken">Token used to cancel connection establishment.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already in progress.</exception>
     public virtual async Task BeginTransactionAsync(string host, string database, string username, string password, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
     {
         lock (_syncRoot)
@@ -895,6 +1224,10 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Commits the active transaction.
+    /// </summary>
+    /// <exception cref="DbaTransactionException">Thrown when no active transaction exists.</exception>
     public virtual void Commit()
     {
         lock (_syncRoot)
@@ -908,6 +1241,12 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Asynchronously commits the active transaction.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel the commit operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when no active transaction exists.</exception>
     public virtual async Task CommitAsync(CancellationToken cancellationToken = default)
     {
         if (_transaction == null)
@@ -919,6 +1258,10 @@ public class MySql : DatabaseClientBase
         DisposeTransaction();
     }
 
+    /// <summary>
+    /// Rolls back the active transaction.
+    /// </summary>
+    /// <exception cref="DbaTransactionException">Thrown when no active transaction exists.</exception>
     public virtual void Rollback()
     {
         lock (_syncRoot)
@@ -932,6 +1275,12 @@ public class MySql : DatabaseClientBase
         }
     }
 
+    /// <summary>
+    /// Asynchronously rolls back the active transaction.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel the rollback operation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    /// <exception cref="DbaTransactionException">Thrown when no active transaction exists.</exception>
     public virtual async Task RollbackAsync(CancellationToken cancellationToken = default)
     {
         if (_transaction == null)
@@ -959,6 +1308,7 @@ public class MySql : DatabaseClientBase
         _transactionConnection = null;
     }
 
+    /// <inheritdoc />
     protected override bool IsTransient(Exception ex) =>
         ex is MySqlException mysqlEx &&
         mysqlEx.ErrorCode is MySqlErrorCode.ConnectionCountError
@@ -967,6 +1317,7 @@ public class MySql : DatabaseClientBase
             or MySqlErrorCode.UnableToConnectToHost
             or MySqlErrorCode.XARBDeadlock;
 
+    /// <inheritdoc />
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -976,6 +1327,18 @@ public class MySql : DatabaseClientBase
         base.Dispose(disposing);
     }
 
+    /// <summary>
+    /// Executes multiple queries concurrently against the same connection information.
+    /// </summary>
+    /// <param name="queries">Collection of SQL statements to execute.</param>
+    /// <param name="host">Host name or IP address of the MySQL server.</param>
+    /// <param name="database">Database (schema) to connect to.</param>
+    /// <param name="username">User identifier.</param>
+    /// <param name="password">Password for the provided <paramref name="username"/>.</param>
+    /// <param name="cancellationToken">Token used to cancel the overall batch.</param>
+    /// <param name="maxDegreeOfParallelism">Optional concurrency limiter; <see langword="null"/> uses as many tasks as queries.</param>
+    /// <returns>Results returned by each query in submission order.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="queries"/> is <see langword="null"/>.</exception>
     public async Task<IReadOnlyList<object?>> RunQueriesInParallel(IEnumerable<string> queries, string host, string database, string username, string password, CancellationToken cancellationToken = default, int? maxDegreeOfParallelism = null)
     {
         if (queries == null)


### PR DESCRIPTION
## Summary
- expand the `DbaClientX.MySql` class XML documentation to describe connection helpers, transaction state, and ping operations
- document stored procedure, streaming, bulk insert, and transaction APIs including parameter guidance and exceptions
- add XML remarks for helper extensibility points and the parallel query runner

## Testing
- `dotnet build DbaClientX.MySql/DbaClientX.MySql.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68dd6acb5818832eaa07aa1cafac2d12