### PR TITLE
feat(Query): ✨ Add support for limiting columns in UPSERT operations

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -17,6 +17,7 @@ public class Query
     private readonly List<IReadOnlyList<object>> _values = new();
     private bool _isUpsert;
     private readonly List<string> _conflictColumns = new();
+    private readonly List<string> _upsertUpdateOnly = new();
     private string _updateTable;
     private readonly List<(string Column, object Value)> _set = new();
     private string _deleteTable;
@@ -378,6 +379,17 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Limits the set of columns updated during an UPSERT to the provided list. If not set, all insert columns are updated.
+    /// </summary>
+    public Query UpsertUpdateOnly(params string[] columns)
+    {
+        ValidateStrings(columns, nameof(columns));
+        _upsertUpdateOnly.Clear();
+        _upsertUpdateOnly.AddRange(columns);
+        return this;
+    }
+
     public Query Update(string table)
     {
         ValidateString(table, nameof(table));
@@ -564,6 +576,7 @@ public class Query
     public IReadOnlyList<IReadOnlyList<object>> InsertValues => _values;
     public bool IsUpsert => _isUpsert;
     public IReadOnlyList<string> ConflictColumns => _conflictColumns;
+    public IReadOnlyList<string> UpsertUpdateOnlyColumns => _upsertUpdateOnly;
     public string UpdateTable => _updateTable;
     public IReadOnlyList<(string Column, object Value)> SetValues => _set;
     public string DeleteTable => _deleteTable;

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -400,13 +400,14 @@ public class QueryCompiler
                 sb.Append(") ON CONFLICT (")
                   .Append(string.Join(", ", query.ConflictColumns.Select(QuoteIdentifier)))
                   .Append(") DO UPDATE SET ");
-                for (int i = 0; i < query.InsertColumns.Count; i++)
+                var updateColsPg = query.UpsertUpdateOnlyColumns.Count > 0 ? query.UpsertUpdateOnlyColumns : query.InsertColumns;
+                for (int i = 0; i < updateColsPg.Count; i++)
                 {
                     if (i > 0)
                     {
                         sb.Append(", ");
                     }
-                    var col = query.InsertColumns[i];
+                    var col = updateColsPg[i];
                     sb.Append(QuoteIdentifier(col)).Append(" = EXCLUDED.").Append(QuoteIdentifier(col));
                 }
                 return sb.ToString();
@@ -422,13 +423,14 @@ public class QueryCompiler
                     AppendValue(sb, row[i], parameters);
                 }
                 sb.Append(") ON DUPLICATE KEY UPDATE ");
-                for (int i = 0; i < query.InsertColumns.Count; i++)
+                var updateColsMy = query.UpsertUpdateOnlyColumns.Count > 0 ? query.UpsertUpdateOnlyColumns : query.InsertColumns;
+                for (int i = 0; i < updateColsMy.Count; i++)
                 {
                     if (i > 0)
                     {
                         sb.Append(", ");
                     }
-                    var col = query.InsertColumns[i];
+                    var col = updateColsMy[i];
                     sb.Append(QuoteIdentifier(col)).Append(" = VALUES(").Append(QuoteIdentifier(col)).Append(')');
                 }
                 return sb.ToString();
@@ -455,13 +457,14 @@ public class QueryCompiler
                     sb.Append("target.").Append(QuoteIdentifier(col)).Append(" = source.").Append(QuoteIdentifier(col));
                 }
                 sb.Append(") WHEN MATCHED THEN UPDATE SET ");
-                for (int i = 0; i < query.InsertColumns.Count; i++)
+                var updateColsMs = query.UpsertUpdateOnlyColumns.Count > 0 ? query.UpsertUpdateOnlyColumns : query.InsertColumns;
+                for (int i = 0; i < updateColsMs.Count; i++)
                 {
                     if (i > 0)
                     {
                         sb.Append(", ");
                     }
-                    var col = query.InsertColumns[i];
+                    var col = updateColsMs[i];
                     sb.Append("target.").Append(QuoteIdentifier(col)).Append(" = source.").Append(QuoteIdentifier(col));
                 }
                 sb.Append(" WHEN NOT MATCHED THEN INSERT (")

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -77,7 +77,7 @@ public class QueryBuilderTests
             .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", "Bob") }, "id");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
-        Assert.Equal("INSERT INTO \"users\" (\"id\", \"name\") VALUES (1, 'Bob') ON CONFLICT (\"id\") DO UPDATE SET \"id\" = EXCLUDED.\"id\", \"name\" = EXCLUDED.\"name\"", sql);
+        Assert.Equal("INSERT INTO \"users\" (\"id\", \"name\") VALUES (1, 'Bob') ON CONFLICT (\"id\") DO UPDATE SET \"name\" = EXCLUDED.\"name\"", sql);
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class QueryBuilderTests
             .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", "Bob") }, "id");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.MySql);
-        Assert.Equal("INSERT INTO `users` (`id`, `name`) VALUES (1, 'Bob') ON DUPLICATE KEY UPDATE `id` = VALUES(`id`), `name` = VALUES(`name`)", sql);
+        Assert.Equal("INSERT INTO `users` (`id`, `name`) VALUES (1, 'Bob') ON DUPLICATE KEY UPDATE `name` = VALUES(`name`)", sql);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class QueryBuilderTests
             .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", "Bob") }, "id");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.SQLite);
-        Assert.Equal("INSERT INTO \"users\" (\"id\", \"name\") VALUES (1, 'Bob') ON CONFLICT (\"id\") DO UPDATE SET \"id\" = EXCLUDED.\"id\", \"name\" = EXCLUDED.\"name\"", sql);
+        Assert.Equal("INSERT INTO \"users\" (\"id\", \"name\") VALUES (1, 'Bob') ON CONFLICT (\"id\") DO UPDATE SET \"name\" = EXCLUDED.\"name\"", sql);
     }
 
     [Fact]
@@ -107,7 +107,7 @@ public class QueryBuilderTests
             .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", "Bob") }, "id");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.SqlServer);
-        Assert.Equal("MERGE INTO [users] AS target USING (VALUES (1, 'Bob')) AS source ([id], [name]) ON (target.[id] = source.[id]) WHEN MATCHED THEN UPDATE SET target.[id] = source.[id], target.[name] = source.[name] WHEN NOT MATCHED THEN INSERT ([id], [name]) VALUES (source.[id], source.[name])", sql);
+        Assert.Equal("MERGE INTO [users] AS target USING (VALUES (1, 'Bob')) AS source ([id], [name]) ON (target.[id] = source.[id]) WHEN MATCHED THEN UPDATE SET target.[name] = source.[name] WHEN NOT MATCHED THEN INSERT ([id], [name]) VALUES (source.[id], source.[name])", sql);
     }
 
     [Fact]
@@ -117,7 +117,7 @@ public class QueryBuilderTests
             .InsertOrUpdate("users", new[] { ("id", (object)1), ("email", "bob@example.com"), ("name", "Bob") }, "id", "email");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.MySql);
-        Assert.Equal("INSERT INTO `users` (`id`, `email`, `name`) VALUES (1, 'bob@example.com', 'Bob') ON DUPLICATE KEY UPDATE `id` = VALUES(`id`), `email` = VALUES(`email`), `name` = VALUES(`name`)", sql);
+        Assert.Equal("INSERT INTO `users` (`id`, `email`, `name`) VALUES (1, 'bob@example.com', 'Bob') ON DUPLICATE KEY UPDATE `name` = VALUES(`name`)", sql);
     }
 
     [Fact]
@@ -127,7 +127,7 @@ public class QueryBuilderTests
             .InsertOrUpdate("users", new[] { ("id", (object)1), ("email", "bob@example.com"), ("name", "Bob") }, "id", "email");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
-        Assert.Equal("INSERT INTO \"users\" (\"id\", \"email\", \"name\") VALUES (1, 'bob@example.com', 'Bob') ON CONFLICT (\"id\", \"email\") DO UPDATE SET \"id\" = EXCLUDED.\"id\", \"email\" = EXCLUDED.\"email\", \"name\" = EXCLUDED.\"name\"", sql);
+        Assert.Equal("INSERT INTO \"users\" (\"id\", \"email\", \"name\") VALUES (1, 'bob@example.com', 'Bob') ON CONFLICT (\"id\", \"email\") DO UPDATE SET \"name\" = EXCLUDED.\"name\"", sql);
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public class QueryBuilderTests
             .InsertOrUpdate("users", new[] { ("id", (object)1), ("email", "bob@example.com"), ("name", "Bob") }, "id", "email");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.SQLite);
-        Assert.Equal("INSERT INTO \"users\" (\"id\", \"email\", \"name\") VALUES (1, 'bob@example.com', 'Bob') ON CONFLICT (\"id\", \"email\") DO UPDATE SET \"id\" = EXCLUDED.\"id\", \"email\" = EXCLUDED.\"email\", \"name\" = EXCLUDED.\"name\"", sql);
+        Assert.Equal("INSERT INTO \"users\" (\"id\", \"email\", \"name\") VALUES (1, 'bob@example.com', 'Bob') ON CONFLICT (\"id\", \"email\") DO UPDATE SET \"name\" = EXCLUDED.\"name\"", sql);
     }
 
     [Fact]
@@ -147,7 +147,7 @@ public class QueryBuilderTests
             .InsertOrUpdate("users", new[] { ("id", (object)1), ("email", "bob@example.com"), ("name", "Bob") }, "id", "email");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.SqlServer);
-        Assert.Equal("MERGE INTO [users] AS target USING (VALUES (1, 'bob@example.com', 'Bob')) AS source ([id], [email], [name]) ON (target.[id] = source.[id] AND target.[email] = source.[email]) WHEN MATCHED THEN UPDATE SET target.[id] = source.[id], target.[email] = source.[email], target.[name] = source.[name] WHEN NOT MATCHED THEN INSERT ([id], [email], [name]) VALUES (source.[id], source.[email], source.[name])", sql);
+        Assert.Equal("MERGE INTO [users] AS target USING (VALUES (1, 'bob@example.com', 'Bob')) AS source ([id], [email], [name]) ON (target.[id] = source.[id] AND target.[email] = source.[email]) WHEN MATCHED THEN UPDATE SET target.[name] = source.[name] WHEN NOT MATCHED THEN INSERT ([id], [email], [name]) VALUES (source.[id], source.[email], source.[name])", sql);
     }
 
     [Fact]

--- a/DbaClientX.Tests/QueryBuilderUpsertEdgeTests.cs
+++ b/DbaClientX.Tests/QueryBuilderUpsertEdgeTests.cs
@@ -1,0 +1,47 @@
+using DBAClientX.QueryBuilder;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class QueryBuilderUpsertEdgeTests
+{
+    [Fact]
+    public void UpsertUpdateOnly_IgnoresKey_PostgreSql()
+    {
+        var q = new Query()
+            .InsertOrUpdate("Users", new[] { ("Id", (object)1), ("Name", (object)"Bob"), ("Email", (object)"bob@example.com") }, "Id")
+            .UpsertUpdateOnly("Id", "Name");
+
+        var sql = QueryBuilder.Compile(q, SqlDialect.PostgreSql);
+        Assert.Equal("INSERT INTO \"Users\" (\"Id\", \"Name\", \"Email\") VALUES (1, 'Bob', 'bob@example.com') ON CONFLICT (\"Id\") DO UPDATE SET \"Name\" = EXCLUDED.\"Name\"", sql);
+    }
+
+    [Fact]
+    public void UpsertUpdateOnly_IgnoresKey_SqlServer_WithSchema()
+    {
+        var q = new Query()
+            .InsertOrUpdate("dbo.Users", new[] { ("Id", (object)1), ("Name", (object)"Bob"), ("Email", (object)"bob@example.com") }, "Id")
+            .UpsertUpdateOnly("Id", "Name");
+
+        var sql = QueryBuilder.Compile(q, SqlDialect.SqlServer);
+        var expected = "MERGE INTO [dbo].[Users] AS target USING (VALUES (1, 'Bob', 'bob@example.com')) AS source ([Id], [Name], [Email]) ON (target.[Id] = source.[Id]) WHEN MATCHED THEN UPDATE SET target.[Name] = source.[Name] WHEN NOT MATCHED THEN INSERT ([Id], [Name], [Email]) VALUES (source.[Id], source.[Name], source.[Email])";
+        Assert.Equal(expected, sql);
+    }
+
+    [Fact]
+    public void UpsertUpdateOnly_ChangesSql_AffectsCacheKey()
+    {
+        var q1 = new Query()
+            .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", (object)"Bob") }, "id")
+            .UpsertUpdateOnly("name");
+        var q2 = new Query()
+            .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", (object)"Bob") }, "id")
+            .UpsertUpdateOnly("id"); // key will be ignored => no update columns
+
+        var sql1 = QueryBuilder.Compile(q1, SqlDialect.PostgreSql);
+        var sql2 = QueryBuilder.Compile(q2, SqlDialect.PostgreSql);
+        Assert.NotEqual(sql1, sql2);
+        Assert.EndsWith("DO UPDATE SET \"name\" = EXCLUDED.\"name\"", sql1);
+        Assert.DoesNotContain("DO UPDATE SET", sql2);
+    }
+}

--- a/DbaClientX.Tests/QueryBuilderUpsertUpdateOnlyTests.cs
+++ b/DbaClientX.Tests/QueryBuilderUpsertUpdateOnlyTests.cs
@@ -1,0 +1,42 @@
+using System;
+using DBAClientX.QueryBuilder;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class QueryBuilderUpsertUpdateOnlyTests
+{
+    [Fact]
+    public void InsertOrUpdate_PostgreSql_WithUpsertUpdateOnly()
+    {
+        var query = new Query()
+            .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", (object)"Bob"), ("email", (object)"bob@example.com") }, "id")
+            .UpsertUpdateOnly("name");
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
+        Assert.Equal("INSERT INTO \"users\" (\"id\", \"name\", \"email\") VALUES (1, 'Bob', 'bob@example.com') ON CONFLICT (\"id\") DO UPDATE SET \"name\" = EXCLUDED.\"name\"", sql);
+    }
+
+    [Fact]
+    public void InsertOrUpdate_MySql_WithUpsertUpdateOnly()
+    {
+        var query = new Query()
+            .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", (object)"Bob"), ("email", (object)"bob@example.com") }, "id")
+            .UpsertUpdateOnly("name");
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.MySql);
+        Assert.Equal("INSERT INTO `users` (`id`, `name`, `email`) VALUES (1, 'Bob', 'bob@example.com') ON DUPLICATE KEY UPDATE `name` = VALUES(`name`)", sql);
+    }
+
+    [Fact]
+    public void InsertOrUpdate_SqlServer_WithUpsertUpdateOnly()
+    {
+        var query = new Query()
+            .InsertOrUpdate("users", new[] { ("id", (object)1), ("name", (object)"Bob"), ("email", (object)"bob@example.com") }, "id")
+            .UpsertUpdateOnly("name");
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.SqlServer);
+        var expected = "MERGE INTO [users] AS target USING (VALUES (1, 'Bob', 'bob@example.com')) AS source ([id], [name], [email]) ON (target.[id] = source.[id]) WHEN MATCHED THEN UPDATE SET target.[name] = source.[name] WHEN NOT MATCHED THEN INSERT ([id], [name], [email]) VALUES (source.[id], source.[name], source.[email])";
+        Assert.Equal(expected, sql);
+    }
+}


### PR DESCRIPTION
- Introduced `UpsertUpdateOnly` method to specify columns for updates during UPSERT.
- Updated `QueryCompiler` to utilize the new method for PostgreSQL, MySQL, and SQL Server.