### PR TITLE
Add XML documentation for core APIs

### DIFF
--- a/DbaClientX.Core/DbTypeConverter.cs
+++ b/DbaClientX.Core/DbTypeConverter.cs
@@ -5,13 +5,28 @@ using System.Data.Common;
 
 namespace DBAClientX;
 
+/// <summary>
+/// Provides helper methods for translating provider-specific parameter types to <see cref="DbType"/> values.
+/// </summary>
 public static class DbTypeConverter
 {
     private static class TypeCache<TDbType>
     {
+        /// <summary>
+        /// Cache of provider-specific types mapped to <see cref="DbType"/> values.
+        /// </summary>
         public static readonly ConcurrentDictionary<TDbType, DbType> Cache = new();
     }
 
+    /// <summary>
+    /// Converts provider-specific parameter type definitions to <see cref="DbType"/> values using a parameter factory.
+    /// </summary>
+    /// <typeparam name="TDbType">The provider-specific type enumeration.</typeparam>
+    /// <typeparam name="TParameter">The provider parameter type.</typeparam>
+    /// <param name="types">A dictionary of provider-specific types keyed by parameter name.</param>
+    /// <param name="parameterFactory">Factory that produces a new provider parameter instance.</param>
+    /// <param name="assignType">Delegate that assigns the provider-specific type to the parameter.</param>
+    /// <returns>A dictionary of <see cref="DbType"/> values keyed by parameter name, or <c>null</c> when <paramref name="types"/> is <c>null</c>.</returns>
     public static IDictionary<string, DbType>? ConvertParameterTypes<TDbType, TParameter>(
         IDictionary<string, TDbType>? types,
         Func<TParameter> parameterFactory,

--- a/DbaClientX.Core/DbaClientXException.cs
+++ b/DbaClientX.Core/DbaClientXException.cs
@@ -1,15 +1,30 @@
 namespace DBAClientX;
 
+/// <summary>
+/// Represents the base exception type for DbaClientX operations.
+/// </summary>
 public class DbaClientXException : Exception
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbaClientXException"/> class.
+    /// </summary>
     public DbaClientXException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbaClientXException"/> class with a message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
     public DbaClientXException(string? message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbaClientXException"/> class with a message and an inner exception.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The exception that caused the current exception.</param>
     public DbaClientXException(string? message, Exception? innerException) : base(message, innerException)
     {
     }

--- a/DbaClientX.Core/DbaQueryExecutionException.cs
+++ b/DbaClientX.Core/DbaQueryExecutionException.cs
@@ -1,18 +1,38 @@
 namespace DBAClientX;
 
+/// <summary>
+/// Represents an exception thrown when executing a query fails.
+/// </summary>
 public class DbaQueryExecutionException : DbaClientXException
 {
+    /// <summary>
+    /// Gets the query text that was being executed when the exception occurred.
+    /// </summary>
     public string? Query { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbaQueryExecutionException"/> class.
+    /// </summary>
     public DbaQueryExecutionException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbaQueryExecutionException"/> class with a message and optional query text.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="query">The query text that failed, if available.</param>
     public DbaQueryExecutionException(string? message, string? query = null) : base(BuildMessage(message, query))
     {
         Query = query;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbaQueryExecutionException"/> class with a message, query text, and inner exception.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="query">The query text that failed.</param>
+    /// <param name="innerException">The exception that caused the current exception.</param>
     public DbaQueryExecutionException(string? message, string? query, Exception? innerException) : base(BuildMessage(message, query), innerException)
     {
         Query = query;

--- a/DbaClientX.Core/DbaTransactionException.cs
+++ b/DbaClientX.Core/DbaTransactionException.cs
@@ -1,15 +1,30 @@
 namespace DBAClientX;
 
+/// <summary>
+/// Represents errors that occur while managing database transactions.
+/// </summary>
 public class DbaTransactionException : DbaClientXException
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbaTransactionException"/> class.
+    /// </summary>
     public DbaTransactionException()
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbaTransactionException"/> class with a message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
     public DbaTransactionException(string? message) : base(message)
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DbaTransactionException"/> class with a message and an inner exception.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <param name="innerException">The exception that caused the current exception.</param>
     public DbaTransactionException(string? message, Exception? innerException) : base(message, innerException)
     {
     }

--- a/DbaClientX.Core/Invoker/DbInvoker.cs
+++ b/DbaClientX.Core/Invoker/DbInvoker.cs
@@ -15,10 +15,6 @@ namespace DBAClientX.Invoker;
 public static class DbInvoker
 {
     /// <summary>
-    /// Executes the given SQL once per item, mapping properties to parameters using <paramref name="map"/>.
-    /// Returns the sum of affected rows.
-    /// </summary>
-    /// <summary>
     /// Executes a parameterized SQL statement once per item, mapping properties to parameters using <paramref name="map"/>.
     /// </summary>
     /// <param name="providerAlias">Provider alias: sqlite, sqlserver|mssql, postgresql|pgsql|postgres, mysql, oracle.</param>
@@ -64,9 +60,6 @@ public static class DbInvoker
         return affected;
     }
 
-    /// <summary>
-    /// Executes a stored procedure once per item, mapping properties to parameters.
-    /// </summary>
     /// <summary>
     /// Executes a stored procedure once per item, mapping properties to parameters using <paramref name="map"/>.
     /// </summary>

--- a/DbaClientX.Core/Mapping/DbParameterMapper.cs
+++ b/DbaClientX.Core/Mapping/DbParameterMapper.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 
 namespace DBAClientX.Mapping;
 
+/// <summary>
+/// Provides configuration for mapping object properties to provider parameters.
+/// </summary>
 public sealed class DbParameterMapperOptions
 {
     /// <summary>

--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -4,6 +4,9 @@ using System.Linq;
 
 namespace DBAClientX.QueryBuilder;
 
+/// <summary>
+/// Provides a fluent interface for constructing SQL queries in a provider-agnostic manner.
+/// </summary>
 public class Query
 {
     private readonly List<string> _select = new();
@@ -30,6 +33,11 @@ public class Query
     private readonly List<(string Type, Query Query)> _compoundQueries = new();
     private int _openGroups;
 
+    /// <summary>
+    /// Adds one or more columns to the <c>SELECT</c> clause.
+    /// </summary>
+    /// <param name="columns">Column expressions to include.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Select(params string[] columns)
     {
         ValidateStrings(columns, nameof(columns));
@@ -37,12 +45,21 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Marks the query as <c>SELECT DISTINCT</c>.
+    /// </summary>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Distinct()
     {
         _distinct = true;
         return this;
     }
 
+    /// <summary>
+    /// Specifies the table for the <c>FROM</c> clause.
+    /// </summary>
+    /// <param name="table">The table name or expression.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query From(string table)
     {
         ValidateString(table, nameof(table));
@@ -51,6 +68,12 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Specifies a subquery for the <c>FROM</c> clause using an alias.
+    /// </summary>
+    /// <param name="subQuery">The subquery to use as a data source.</param>
+    /// <param name="alias">The alias applied to the subquery.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query From(Query subQuery, string alias)
     {
         if (subQuery == null)
@@ -63,6 +86,12 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds an inner join to the query.
+    /// </summary>
+    /// <param name="table">The joined table.</param>
+    /// <param name="condition">The join condition.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Join(string table, string condition)
     {
         ValidateString(table, nameof(table));
@@ -71,6 +100,10 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds a left outer join to the query.
+    /// </summary>
+    /// <inheritdoc cref="Join(string, string)"/>
     public Query LeftJoin(string table, string condition)
     {
         ValidateString(table, nameof(table));
@@ -79,6 +112,10 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds a right outer join to the query.
+    /// </summary>
+    /// <inheritdoc cref="Join(string, string)"/>
     public Query RightJoin(string table, string condition)
     {
         ValidateString(table, nameof(table));
@@ -87,6 +124,11 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds a cross join to the query.
+    /// </summary>
+    /// <param name="table">The joined table.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query CrossJoin(string table)
     {
         ValidateString(table, nameof(table));
@@ -94,6 +136,10 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds a full outer join to the query.
+    /// </summary>
+    /// <inheritdoc cref="Join(string, string)"/>
     public Query FullOuterJoin(string table, string condition)
     {
         ValidateString(table, nameof(table));
@@ -102,116 +148,216 @@ public class Query
         return this;
     }
 
+    /// <inheritdoc cref="Where(string, string, object)"/>
     public Query Where(string column, object value)
     {
         return Where(column, "=", value);
     }
 
+    /// <summary>
+    /// Adds a predicate to the <c>WHERE</c> clause using the specified operator and value.
+    /// </summary>
+    /// <param name="column">The column or expression to evaluate.</param>
+    /// <param name="op">The comparison operator.</param>
+    /// <param name="value">The value to compare with.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Where(string column, string op, object value)
     {
         return AddCondition(column, op, value);
     }
 
+    /// <summary>
+    /// Adds a predicate to the <c>WHERE</c> clause comparing to a subquery.
+    /// </summary>
+    /// <param name="column">The column or expression to evaluate.</param>
+    /// <param name="op">The comparison operator.</param>
+    /// <param name="subQuery">The subquery that provides the comparison value.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Where(string column, string op, Query subQuery)
     {
         return AddCondition(column, op, subQuery);
     }
 
+    /// <inheritdoc cref="OrWhere(string, string, object)"/>
     public Query OrWhere(string column, object value)
     {
         return OrWhere(column, "=", value);
     }
 
+    /// <summary>
+    /// Adds an <c>OR</c> predicate to the <c>WHERE</c> clause using the specified operator and value.
+    /// </summary>
+    /// <inheritdoc cref="Where(string, string, object)"/>
     public Query OrWhere(string column, string op, object value)
     {
         return AddCondition(column, op, value, "OR");
     }
 
+    /// <summary>
+    /// Adds an <c>OR</c> predicate that compares to a subquery.
+    /// </summary>
+    /// <inheritdoc cref="Where(string, string, Query)"/>
     public Query OrWhere(string column, string op, Query subQuery)
     {
         return AddCondition(column, op, subQuery, "OR");
     }
 
+    /// <summary>
+    /// Adds an <c>IN</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <param name="column">The column or expression to evaluate.</param>
+    /// <param name="values">The values to test for membership.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query WhereIn(string column, params object[] values)
     {
         return AddInCondition(column, values);
     }
 
+    /// <summary>
+    /// Adds an <c>IN</c> predicate comparing to a subquery.
+    /// </summary>
+    /// <param name="column">The column or expression to evaluate.</param>
+    /// <param name="subQuery">The subquery producing the value set.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query WhereIn(string column, Query subQuery)
     {
         return AddCondition(column, "IN", subQuery);
     }
 
+    /// <summary>
+    /// Adds an <c>OR IN</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <inheritdoc cref="WhereIn(string, object[])"/>
     public Query OrWhereIn(string column, params object[] values)
     {
         return AddInCondition(column, values, "OR");
     }
 
+    /// <summary>
+    /// Adds an <c>OR IN</c> predicate comparing to a subquery.
+    /// </summary>
+    /// <inheritdoc cref="WhereIn(string, Query)"/>
     public Query OrWhereIn(string column, Query subQuery)
     {
         return AddCondition(column, "IN", subQuery, "OR");
     }
 
+    /// <summary>
+    /// Adds a <c>NOT IN</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <inheritdoc cref="WhereIn(string, object[])"/>
     public Query WhereNotIn(string column, params object[] values)
     {
         return AddInCondition(column, values, null, true);
     }
 
+    /// <summary>
+    /// Adds a <c>NOT IN</c> predicate comparing to a subquery.
+    /// </summary>
+    /// <inheritdoc cref="WhereIn(string, Query)"/>
     public Query WhereNotIn(string column, Query subQuery)
     {
         return AddCondition(column, "NOT IN", subQuery);
     }
 
+    /// <summary>
+    /// Adds an <c>OR NOT IN</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <inheritdoc cref="WhereIn(string, object[])"/>
     public Query OrWhereNotIn(string column, params object[] values)
     {
         return AddInCondition(column, values, "OR", true);
     }
 
+    /// <summary>
+    /// Adds an <c>OR NOT IN</c> predicate comparing to a subquery.
+    /// </summary>
+    /// <inheritdoc cref="WhereIn(string, Query)"/>
     public Query OrWhereNotIn(string column, Query subQuery)
     {
         return AddCondition(column, "NOT IN", subQuery, "OR");
     }
 
+    /// <summary>
+    /// Adds a <c>BETWEEN</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <param name="column">The column or expression to evaluate.</param>
+    /// <param name="start">The inclusive start value.</param>
+    /// <param name="end">The inclusive end value.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query WhereBetween(string column, object start, object end)
     {
         return AddBetweenCondition(column, start, end);
     }
 
+    /// <summary>
+    /// Adds an <c>OR BETWEEN</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <inheritdoc cref="WhereBetween(string, object, object)"/>
     public Query OrWhereBetween(string column, object start, object end)
     {
         return AddBetweenCondition(column, start, end, "OR");
     }
 
+    /// <summary>
+    /// Adds a <c>NOT BETWEEN</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <inheritdoc cref="WhereBetween(string, object, object)"/>
     public Query WhereNotBetween(string column, object start, object end)
     {
         return AddBetweenCondition(column, start, end, null, true);
     }
 
+    /// <summary>
+    /// Adds an <c>OR NOT BETWEEN</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <inheritdoc cref="WhereBetween(string, object, object)"/>
     public Query OrWhereNotBetween(string column, object start, object end)
     {
         return AddBetweenCondition(column, start, end, "OR", true);
     }
 
+    /// <summary>
+    /// Adds an <c>IS NULL</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <param name="column">The column or expression to evaluate.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query WhereNull(string column)
     {
         return AddNullCondition(column);
     }
 
+    /// <summary>
+    /// Adds an <c>OR IS NULL</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <inheritdoc cref="WhereNull(string)"/>
     public Query OrWhereNull(string column)
     {
         return AddNullCondition(column, "OR");
     }
 
+    /// <summary>
+    /// Adds an <c>IS NOT NULL</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <inheritdoc cref="WhereNull(string)"/>
     public Query WhereNotNull(string column)
     {
         return AddNotNullCondition(column);
     }
 
+    /// <summary>
+    /// Adds an <c>OR IS NOT NULL</c> predicate to the <c>WHERE</c> clause.
+    /// </summary>
+    /// <inheritdoc cref="WhereNull(string)"/>
     public Query OrWhereNotNull(string column)
     {
         return AddNotNullCondition(column, "OR");
     }
 
+    /// <summary>
+    /// Starts a grouped condition within the <c>WHERE</c> clause.
+    /// </summary>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query BeginGroup()
     {
         AddDefaultAndIfRequired();
@@ -220,6 +366,10 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Closes the most recent grouped condition within the <c>WHERE</c> clause.
+    /// </summary>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query EndGroup()
     {
         if (_openGroups == 0)
@@ -231,6 +381,10 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Inserts a literal <c>OR</c> operator into the <c>WHERE</c> clause.
+    /// </summary>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Or()
     {
         _where.Add(new OperatorToken("OR"));
@@ -335,6 +489,12 @@ public class Query
         }
     }
 
+    /// <summary>
+    /// Configures the query for an <c>INSERT</c> statement targeting the specified table and columns.
+    /// </summary>
+    /// <param name="table">The table to insert into.</param>
+    /// <param name="columns">The columns receiving values.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query InsertInto(string table, params string[] columns)
     {
         ValidateString(table, nameof(table));
@@ -344,6 +504,13 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Configures an upsert (<c>INSERT</c>/<c>UPDATE</c>) statement targeting the specified table.
+    /// </summary>
+    /// <param name="table">The table to insert into.</param>
+    /// <param name="values">Column/value pairs describing the insert payload.</param>
+    /// <param name="conflictColumns">Columns used to detect conflicts.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query InsertOrUpdate(string table, IEnumerable<(string Column, object Value)> values, params string[] conflictColumns)
     {
         ValidateString(table, nameof(table));
@@ -380,8 +547,10 @@ public class Query
     }
 
     /// <summary>
-    /// Limits the set of columns updated during an UPSERT to the provided list. If not set, all insert columns are updated.
+    /// Limits the set of columns updated during an upsert to the provided list. If not set, all insert columns are updated.
     /// </summary>
+    /// <param name="columns">The columns to update when a conflict occurs.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query UpsertUpdateOnly(params string[] columns)
     {
         ValidateStrings(columns, nameof(columns));
@@ -390,6 +559,11 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Configures the query for an <c>UPDATE</c> statement targeting the specified table.
+    /// </summary>
+    /// <param name="table">The table to update.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Update(string table)
     {
         ValidateString(table, nameof(table));
@@ -397,6 +571,12 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds a column/value pair to the <c>SET</c> clause of an <c>UPDATE</c> statement.
+    /// </summary>
+    /// <param name="column">The column to update.</param>
+    /// <param name="value">The new value.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Set(string column, object value)
     {
         ValidateString(column, nameof(column));
@@ -408,6 +588,11 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Configures the query for a <c>DELETE</c> statement targeting the specified table.
+    /// </summary>
+    /// <param name="table">The table from which rows will be deleted.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query DeleteFrom(string table)
     {
         ValidateString(table, nameof(table));
@@ -415,6 +600,11 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds columns to the <c>ORDER BY</c> clause in ascending order.
+    /// </summary>
+    /// <param name="columns">The columns or expressions to order by.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query OrderBy(params string[] columns)
     {
         ValidateStrings(columns, nameof(columns));
@@ -422,6 +612,10 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds columns to the <c>ORDER BY</c> clause in descending order.
+    /// </summary>
+    /// <inheritdoc cref="OrderBy(string[])"/>
     public Query OrderByDescending(params string[] columns)
     {
         ValidateStrings(columns, nameof(columns));
@@ -432,6 +626,11 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds raw expressions to the <c>ORDER BY</c> clause.
+    /// </summary>
+    /// <param name="expressions">Raw ordering expressions.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query OrderByRaw(params string[] expressions)
     {
         ValidateStrings(expressions, nameof(expressions));
@@ -439,6 +638,11 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds columns to the <c>GROUP BY</c> clause.
+    /// </summary>
+    /// <param name="columns">The columns or expressions used for grouping.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query GroupBy(params string[] columns)
     {
         ValidateStrings(columns, nameof(columns));
@@ -446,11 +650,19 @@ public class Query
         return this;
     }
 
+    /// <inheritdoc cref="Having(string, string, object)"/>
     public Query Having(string column, object value)
     {
         return Having(column, "=", value);
     }
 
+    /// <summary>
+    /// Adds a predicate to the <c>HAVING</c> clause.
+    /// </summary>
+    /// <param name="column">The aggregated column or expression.</param>
+    /// <param name="op">The comparison operator.</param>
+    /// <param name="value">The value to compare with.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Having(string column, string op, object value)
     {
         ValidateString(column, nameof(column));
@@ -463,6 +675,11 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Applies a <c>LIMIT</c> (or provider equivalent) clause to restrict result count.
+    /// </summary>
+    /// <param name="limit">The maximum number of rows to return.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Limit(int limit)
     {
         _limit = limit;
@@ -472,6 +689,11 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Applies an <c>OFFSET</c> clause to skip a number of rows.
+    /// </summary>
+    /// <param name="offset">The number of rows to skip.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Offset(int offset)
     {
         _offset = offset;
@@ -479,6 +701,11 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Applies a <c>TOP</c> clause (SQL Server style) to limit results.
+    /// </summary>
+    /// <param name="top">The number of rows to return.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Top(int top)
     {
         _limit = top;
@@ -488,6 +715,11 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds a <c>UNION</c> compound query.
+    /// </summary>
+    /// <param name="query">The query to union.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Union(Query query)
     {
         if (query == null)
@@ -498,6 +730,10 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds a <c>UNION ALL</c> compound query.
+    /// </summary>
+    /// <inheritdoc cref="Union(Query)"/>
     public Query UnionAll(Query query)
     {
         if (query == null)
@@ -508,6 +744,10 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds an <c>INTERSECT</c> compound query.
+    /// </summary>
+    /// <inheritdoc cref="Union(Query)"/>
     public Query Intersect(Query query)
     {
         if (query == null)
@@ -518,6 +758,11 @@ public class Query
         return this;
     }
 
+    /// <summary>
+    /// Adds a row of values to an <c>INSERT</c> statement.
+    /// </summary>
+    /// <param name="values">The values corresponding to the configured columns.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query Values(params object[] values)
     {
         if (_insertColumns.Count == 0)
@@ -555,62 +800,212 @@ public class Query
         }
     }
 
+    /// <summary>
+    /// Compiles the query into SQL text using the specified dialect.
+    /// </summary>
+    /// <param name="dialect">The target SQL dialect.</param>
+    /// <returns>The compiled SQL text.</returns>
     public string Compile(SqlDialect dialect = SqlDialect.SqlServer)
     {
         var compiler = new QueryCompiler(dialect);
         return compiler.Compile(this);
     }
 
+    /// <summary>
+    /// Compiles the query into SQL text and collects ordered parameter values for the specified dialect.
+    /// </summary>
+    /// <param name="dialect">The target SQL dialect.</param>
+    /// <returns>A tuple containing SQL text and parameter values.</returns>
     public (string Sql, IReadOnlyList<object> Parameters) CompileWithParameters(SqlDialect dialect = SqlDialect.SqlServer)
     {
         var compiler = new QueryCompiler(dialect);
         return compiler.CompileWithParameters(this);
     }
 
+    /// <summary>
+    /// Gets the selected columns for the query.
+    /// </summary>
     public IReadOnlyList<string> SelectColumns => _select;
+
+    /// <summary>
+    /// Gets the table used in the <c>FROM</c> clause, when not using a subquery.
+    /// </summary>
     public string Table => _from;
+
+    /// <summary>
+    /// Gets the subquery used in the <c>FROM</c> clause, if any.
+    /// </summary>
     public (Query Query, string Alias)? FromSubquery => _fromSubquery;
+
+    /// <summary>
+    /// Gets the sequence of tokens representing the <c>WHERE</c> clause.
+    /// </summary>
     public IReadOnlyList<IWhereToken> WhereTokens => _where;
+
+    /// <summary>
+    /// Gets the table targeted by an <c>INSERT</c> statement.
+    /// </summary>
     public string InsertTable => _insertTable;
+
+    /// <summary>
+    /// Gets the column list used for <c>INSERT</c> statements.
+    /// </summary>
     public IReadOnlyList<string> InsertColumns => _insertColumns;
+
+    /// <summary>
+    /// Gets the rows of values used for <c>INSERT</c> statements.
+    /// </summary>
     public IReadOnlyList<IReadOnlyList<object>> InsertValues => _values;
+
+    /// <summary>
+    /// Gets a value indicating whether the query is configured as an upsert.
+    /// </summary>
     public bool IsUpsert => _isUpsert;
+
+    /// <summary>
+    /// Gets the columns used to detect conflicts during an upsert.
+    /// </summary>
     public IReadOnlyList<string> ConflictColumns => _conflictColumns;
+
+    /// <summary>
+    /// Gets the subset of columns that should be updated during an upsert.
+    /// </summary>
     public IReadOnlyList<string> UpsertUpdateOnlyColumns => _upsertUpdateOnly;
+
+    /// <summary>
+    /// Gets the table targeted by an <c>UPDATE</c> statement.
+    /// </summary>
     public string UpdateTable => _updateTable;
+
+    /// <summary>
+    /// Gets the column/value pairs configured for an <c>UPDATE</c> statement.
+    /// </summary>
     public IReadOnlyList<(string Column, object Value)> SetValues => _set;
+
+    /// <summary>
+    /// Gets the table targeted by a <c>DELETE</c> statement.
+    /// </summary>
     public string DeleteTable => _deleteTable;
+
+    /// <summary>
+    /// Gets the column expressions used for ordering.
+    /// </summary>
     public IReadOnlyList<string> OrderByColumns => _orderBy;
+
+    /// <summary>
+    /// Gets the column expressions used for grouping.
+    /// </summary>
     public IReadOnlyList<string> GroupByColumns => _groupBy;
+
+    /// <summary>
+    /// Gets the predicates configured for the <c>HAVING</c> clause.
+    /// </summary>
     public IReadOnlyList<(string Column, string Operator, object Value)> HavingClauses => _having;
+
+    /// <summary>
+    /// Gets the join definitions applied to the query.
+    /// </summary>
     public IReadOnlyList<(string Type, string Table, string? Condition)> Joins => _joins;
+
+    /// <summary>
+    /// Gets the compound queries appended to the current query.
+    /// </summary>
     public IReadOnlyList<(string Type, Query Query)> CompoundQueries => _compoundQueries;
+
+    /// <summary>
+    /// Gets a value indicating whether the query uses <c>DISTINCT</c>.
+    /// </summary>
     public bool IsDistinct => _distinct;
+
+    /// <summary>
+    /// Gets the configured <c>LIMIT</c> value, if any.
+    /// </summary>
     public int? LimitValue => _limit;
+
+    /// <summary>
+    /// Gets the configured <c>OFFSET</c> value, if any.
+    /// </summary>
     public int? OffsetValue => _offset;
+
+    /// <summary>
+    /// Gets a value indicating whether the query should use <c>TOP</c> semantics.
+    /// </summary>
     public bool UseTop => _useTop;
+
+    /// <summary>
+    /// Gets the number of open grouping tokens to validate balanced conditions.
+    /// </summary>
     public int OpenGroups => _openGroups;
 }
 
+/// <summary>
+/// Marker interface for <c>WHERE</c> clause tokens.
+/// </summary>
 public interface IWhereToken { }
 
+/// <summary>
+/// Represents a comparison predicate in the <c>WHERE</c> clause.
+/// </summary>
+/// <param name="Column">The column being compared.</param>
+/// <param name="Operator">The comparison operator.</param>
+/// <param name="Value">The comparison value.</param>
 public sealed record ConditionToken(string Column, string Operator, object Value) : IWhereToken;
 
+/// <summary>
+/// Represents a logical operator token (e.g., AND/OR).
+/// </summary>
+/// <param name="Operator">The logical operator text.</param>
 public sealed record OperatorToken(string Operator) : IWhereToken;
 
+/// <summary>
+/// Marks the start of a grouped condition.
+/// </summary>
 public sealed record GroupStartToken() : IWhereToken;
 
+/// <summary>
+/// Marks the end of a grouped condition.
+/// </summary>
 public sealed record GroupEndToken() : IWhereToken;
 
+/// <summary>
+/// Represents an <c>IS NULL</c> predicate.
+/// </summary>
+/// <param name="Column">The column evaluated for null.</param>
 public sealed record NullToken(string Column) : IWhereToken;
 
+/// <summary>
+/// Represents an <c>IS NOT NULL</c> predicate.
+/// </summary>
+/// <param name="Column">The column evaluated for non-null values.</param>
 public sealed record NotNullToken(string Column) : IWhereToken;
 
+/// <summary>
+/// Represents an <c>IN</c> predicate with literal values.
+/// </summary>
+/// <param name="Column">The column being compared.</param>
+/// <param name="Values">The values to test.</param>
 public sealed record InToken(string Column, IReadOnlyList<object> Values) : IWhereToken;
 
+/// <summary>
+/// Represents a <c>NOT IN</c> predicate with literal values.
+/// </summary>
+/// <param name="Column">The column being compared.</param>
+/// <param name="Values">The values to exclude.</param>
 public sealed record NotInToken(string Column, IReadOnlyList<object> Values) : IWhereToken;
 
+/// <summary>
+/// Represents a <c>BETWEEN</c> predicate.
+/// </summary>
+/// <param name="Column">The column being compared.</param>
+/// <param name="Start">The inclusive start value.</param>
+/// <param name="End">The inclusive end value.</param>
 public sealed record BetweenToken(string Column, object Start, object End) : IWhereToken;
 
+/// <summary>
+/// Represents a <c>NOT BETWEEN</c> predicate.
+/// </summary>
+/// <param name="Column">The column being compared.</param>
+/// <param name="Start">The inclusive start value.</param>
+/// <param name="End">The inclusive end value.</param>
 public sealed record NotBetweenToken(string Column, object Start, object End) : IWhereToken;
 

--- a/DbaClientX.Core/QueryBuilder/QueryBuilder.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryBuilder.cs
@@ -2,16 +2,35 @@ using System.Collections.Generic;
 
 namespace DBAClientX.QueryBuilder;
 
+/// <summary>
+/// Provides factory helpers for building and compiling SQL queries.
+/// </summary>
 public static class QueryBuilder
 {
+    /// <summary>
+    /// Creates a new query instance.
+    /// </summary>
+    /// <returns>A new <see cref="Query"/>.</returns>
     public static Query Query() => new Query();
 
+    /// <summary>
+    /// Compiles a query into SQL text using the specified dialect.
+    /// </summary>
+    /// <param name="query">The query to compile.</param>
+    /// <param name="dialect">The target SQL dialect.</param>
+    /// <returns>The SQL text representation.</returns>
     public static string Compile(Query query, SqlDialect dialect = SqlDialect.SqlServer)
     {
         var compiler = new QueryCompiler(dialect);
         return compiler.Compile(query);
     }
 
+    /// <summary>
+    /// Compiles a query into SQL text and captures the associated parameter values.
+    /// </summary>
+    /// <param name="query">The query to compile.</param>
+    /// <param name="dialect">The target SQL dialect.</param>
+    /// <returns>A tuple containing the SQL text and ordered parameter values.</returns>
     public static (string Sql, IReadOnlyList<object> Parameters) CompileWithParameters(Query query, SqlDialect dialect = SqlDialect.SqlServer)
     {
         var compiler = new QueryCompiler(dialect);

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -7,6 +7,9 @@ using System.Text;
 
 namespace DBAClientX.QueryBuilder;
 
+/// <summary>
+/// Compiles <see cref="Query"/> objects into SQL text tailored to a specific <see cref="SqlDialect"/>.
+/// </summary>
 public class QueryCompiler
 {
     private readonly SqlDialect _dialect;
@@ -15,20 +18,39 @@ public class QueryCompiler
     private static readonly ConcurrentDictionary<string, string> _cache = new();
     private static readonly ConcurrentQueue<string> _cacheOrder = new();
 
+    /// <summary>
+    /// Gets the maximum number of compiled statements stored in the shared cache.
+    /// </summary>
     public static int CacheSizeLimit => MaxCacheSize;
+
+    /// <summary>
+    /// Gets the current number of cached statements.
+    /// </summary>
     public static int CacheCount => _cache.Count;
 
+    /// <summary>
+    /// Clears all cached compiled statements.
+    /// </summary>
     public static void ClearCache()
     {
         _cache.Clear();
         while (_cacheOrder.TryDequeue(out _)) { }
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueryCompiler"/> class for the specified dialect.
+    /// </summary>
+    /// <param name="dialect">The SQL dialect targeted by the compiler.</param>
     public QueryCompiler(SqlDialect dialect = SqlDialect.SqlServer)
     {
         _dialect = dialect;
     }
 
+    /// <summary>
+    /// Compiles the supplied query into SQL text.
+    /// </summary>
+    /// <param name="query">The query to compile.</param>
+    /// <returns>The SQL text.</returns>
     public string Compile(Query query)
     {
         var key = BuildCacheKey(query);
@@ -42,6 +64,11 @@ public class QueryCompiler
         return sql;
     }
 
+    /// <summary>
+    /// Compiles the supplied query into SQL text and collects ordered parameter values.
+    /// </summary>
+    /// <param name="query">The query to compile.</param>
+    /// <returns>A tuple containing the SQL text and parameter values.</returns>
     public (string Sql, IReadOnlyList<object> Parameters) CompileWithParameters(Query query)
     {
         var key = BuildCacheKey(query);

--- a/DbaClientX.Core/QueryBuilder/SqlDialect.cs
+++ b/DbaClientX.Core/QueryBuilder/SqlDialect.cs
@@ -5,9 +5,28 @@ namespace DBAClientX.QueryBuilder;
 /// </summary>
 public enum SqlDialect
 {
+    /// <summary>
+    /// Microsoft SQL Server.
+    /// </summary>
     SqlServer,
+
+    /// <summary>
+    /// PostgreSQL.
+    /// </summary>
     PostgreSql,
+
+    /// <summary>
+    /// MySQL.
+    /// </summary>
     MySql,
+
+    /// <summary>
+    /// SQLite.
+    /// </summary>
     SQLite,
+
+    /// <summary>
+    /// Oracle Database.
+    /// </summary>
     Oracle
 }

--- a/DbaClientX.Core/ReturnType.cs
+++ b/DbaClientX.Core/ReturnType.cs
@@ -1,14 +1,27 @@
-﻿namespace DBAClientX;
+namespace DBAClientX;
 
 /// <summary>
-/// Return type for SQL query
+/// Defines the shape of the data returned by query execution helpers.
 /// </summary>
-public enum ReturnType {
-    DataSet,
-    DataTable,
-    DataRow,
+public enum ReturnType
+{
     /// <summary>
-    /// Works only with PowerShell
+    /// Materialize the result as a <see cref="System.Data.DataSet"/> containing all result sets.
+    /// </summary>
+    DataSet,
+
+    /// <summary>
+    /// Materialize the first result set as a <see cref="System.Data.DataTable"/>.
+    /// </summary>
+    DataTable,
+
+    /// <summary>
+    /// Materialize the first row of the first result set as a <see cref="System.Data.DataRow"/>.
+    /// </summary>
+    DataRow,
+
+    /// <summary>
+    /// Materialize the first result set as a <see cref="System.Data.DataTable"/> optimized for PowerShell interoperability.
     /// </summary>
     PSObject
 }


### PR DESCRIPTION
## Summary
- add XML documentation to the core database client base class and related exceptions
- document the query builder utilities, enums, and helper classes for consistent public API coverage

## Testing
- dotnet build DbaClientX.sln

------
https://chatgpt.com/codex/tasks/task_e_68de2e552924832e937feef33774f77c