### PR TITLE
Refactor cmdlet properties to initialize with empty strings and updat…

### DIFF
--- a/DbaClientX.Core/DbTypeConverter.cs
+++ b/DbaClientX.Core/DbTypeConverter.cs
@@ -10,7 +10,7 @@ namespace DBAClientX;
 /// </summary>
 public static class DbTypeConverter
 {
-    private static class TypeCache<TDbType>
+    private static class TypeCache<TDbType> where TDbType : notnull
     {
         /// <summary>
         /// Cache of provider-specific types mapped to <see cref="DbType"/> values.
@@ -32,6 +32,7 @@ public static class DbTypeConverter
         Func<TParameter> parameterFactory,
         Action<TParameter, TDbType> assignType)
         where TParameter : DbParameter
+        where TDbType : notnull
     {
         if (types == null)
         {

--- a/DbaClientX.Core/DbaClientX.Core.csproj
+++ b/DbaClientX.Core/DbaClientX.Core.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX Core library</Description>
     <AssemblyName>DbaClientX.Core</AssemblyName>
     <AssemblyTitle>DbaClientX.Core</AssemblyTitle>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.Core/Mapping/DbPropertyAccessor.cs
+++ b/DbaClientX.Core/Mapping/DbPropertyAccessor.cs
@@ -216,8 +216,9 @@ public static class DbPropertyAccessor
         return false;
     }
 
-    private static PropertyInfo? FindPropertyIgnoreCase(Type type, string name)
+    private static PropertyInfo? FindPropertyIgnoreCase(Type? type, string name)
     {
+        if (type is null) return null;
         // Prefer case-insensitive name match, public instance properties
         var p = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
         return p;

--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -11,19 +11,19 @@ public class Query
 {
     private readonly List<string> _select = new();
     private bool _distinct;
-    private string _from;
+    private string? _from;
     private (Query Query, string Alias)? _fromSubquery;
     private readonly List<(string Type, string Table, string? Condition)> _joins = new();
     private readonly List<IWhereToken> _where = new();
-    private string _insertTable;
+    private string? _insertTable;
     private readonly List<string> _insertColumns = new();
     private readonly List<IReadOnlyList<object>> _values = new();
     private bool _isUpsert;
     private readonly List<string> _conflictColumns = new();
     private readonly List<string> _upsertUpdateOnly = new();
-    private string _updateTable;
+    private string? _updateTable;
     private readonly List<(string Column, object Value)> _set = new();
-    private string _deleteTable;
+    private string? _deleteTable;
     private readonly List<string> _orderBy = new();
     private readonly List<string> _groupBy = new();
     private readonly List<(string Column, string Operator, object Value)> _having = new();
@@ -830,7 +830,7 @@ public class Query
     /// <summary>
     /// Gets the table used in the <c>FROM</c> clause, when not using a subquery.
     /// </summary>
-    public string Table => _from;
+    public string? Table => _from;
 
     /// <summary>
     /// Gets the subquery used in the <c>FROM</c> clause, if any.
@@ -845,7 +845,7 @@ public class Query
     /// <summary>
     /// Gets the table targeted by an <c>INSERT</c> statement.
     /// </summary>
-    public string InsertTable => _insertTable;
+    public string? InsertTable => _insertTable;
 
     /// <summary>
     /// Gets the column list used for <c>INSERT</c> statements.
@@ -875,7 +875,7 @@ public class Query
     /// <summary>
     /// Gets the table targeted by an <c>UPDATE</c> statement.
     /// </summary>
-    public string UpdateTable => _updateTable;
+    public string? UpdateTable => _updateTable;
 
     /// <summary>
     /// Gets the column/value pairs configured for an <c>UPDATE</c> statement.
@@ -885,7 +885,7 @@ public class Query
     /// <summary>
     /// Gets the table targeted by a <c>DELETE</c> statement.
     /// </summary>
-    public string DeleteTable => _deleteTable;
+    public string? DeleteTable => _deleteTable;
 
     /// <summary>
     /// Gets the column expressions used for ordering.

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -106,7 +106,7 @@ public class QueryCompiler
         sb.Append(_dialect).Append('|');
         sb.Append(string.Join(",", query.SelectColumns)).Append('|');
         sb.Append(query.IsDistinct).Append('|');
-        sb.Append(query.Table).Append('|');
+        sb.Append(query.Table ?? string.Empty).Append('|');
         if (query.FromSubquery.HasValue)
         {
             var (sub, alias) = query.FromSubquery.Value;
@@ -160,7 +160,7 @@ public class QueryCompiler
         }
         if (!string.IsNullOrWhiteSpace(query.InsertTable))
         {
-            sb.Append("I:").Append(query.InsertTable).Append('(').Append(string.Join(",", query.InsertColumns)).Append(')').Append(':').Append(query.InsertValues.Count).Append('|');
+            sb.Append("I:").Append(query.InsertTable!).Append('(').Append(string.Join(",", query.InsertColumns)).Append(')').Append(':').Append(query.InsertValues.Count).Append('|');
             if (query.IsUpsert)
             {
                 sb.Append("U:").Append(string.Join(",", query.ConflictColumns)).Append('|');
@@ -172,11 +172,11 @@ public class QueryCompiler
         }
         if (!string.IsNullOrWhiteSpace(query.UpdateTable))
         {
-            sb.Append("UP:").Append(query.UpdateTable).Append('(').Append(string.Join(",", query.SetValues.Select(s => s.Column))).Append(')').Append('|');
+            sb.Append("UP:").Append(query.UpdateTable!).Append('(').Append(string.Join(",", query.SetValues.Select(s => s.Column))).Append(')').Append('|');
         }
         if (!string.IsNullOrWhiteSpace(query.DeleteTable))
         {
-            sb.Append("D:").Append(query.DeleteTable).Append('|');
+            sb.Append("D:").Append(query.DeleteTable!).Append('|');
         }
         if (query.OrderByColumns.Count > 0)
         {
@@ -229,7 +229,7 @@ public class QueryCompiler
             {
                 return CompileUpsert(query, parameters);
             }
-            sb.Append("INSERT INTO ").Append(QuoteIdentifier(query.InsertTable));
+            sb.Append("INSERT INTO ").Append(QuoteIdentifier(query.InsertTable!));
 
             if (query.InsertColumns.Count > 0)
             {
@@ -265,7 +265,7 @@ public class QueryCompiler
 
         if (!string.IsNullOrWhiteSpace(query.UpdateTable))
         {
-            sb.Append("UPDATE ").Append(QuoteIdentifier(query.UpdateTable));
+            sb.Append("UPDATE ").Append(QuoteIdentifier(query.UpdateTable!));
             if (query.SetValues.Count > 0)
             {
                 sb.Append(" SET ");
@@ -293,7 +293,7 @@ public class QueryCompiler
 
         if (!string.IsNullOrWhiteSpace(query.DeleteTable))
         {
-            sb.Append("DELETE FROM ").Append(QuoteIdentifier(query.DeleteTable));
+            sb.Append("DELETE FROM ").Append(QuoteIdentifier(query.DeleteTable!));
 
             if (query.WhereTokens.Count > 0)
             {
@@ -325,7 +325,7 @@ public class QueryCompiler
 
         if (!string.IsNullOrWhiteSpace(query.Table))
         {
-            sb.Append(" FROM ").Append(QuoteIdentifier(query.Table));
+            sb.Append(" FROM ").Append(QuoteIdentifier(query.Table!));
         }
         else if (query.FromSubquery.HasValue)
         {
@@ -418,7 +418,7 @@ public class QueryCompiler
         {
             case SqlDialect.PostgreSql:
             case SqlDialect.SQLite:
-                sb.Append("INSERT INTO ").Append(QuoteIdentifier(query.InsertTable));
+                sb.Append("INSERT INTO ").Append(QuoteIdentifier(query.InsertTable!));
                 sb.Append(" (").Append(string.Join(", ", query.InsertColumns.Select(QuoteIdentifier))).Append(") VALUES (");
                 for (int i = 0; i < row.Count; i++)
                 {
@@ -451,7 +451,7 @@ public class QueryCompiler
                 }
                 return sb.ToString();
             case SqlDialect.MySql:
-                sb.Append("INSERT INTO ").Append(QuoteIdentifier(query.InsertTable));
+                sb.Append("INSERT INTO ").Append(QuoteIdentifier(query.InsertTable!));
                 sb.Append(" (").Append(string.Join(", ", query.InsertColumns.Select(QuoteIdentifier))).Append(") VALUES (");
                 for (int i = 0; i < row.Count; i++)
                 {
@@ -482,7 +482,7 @@ public class QueryCompiler
                 }
                 return sb.ToString();
             case SqlDialect.SqlServer:
-                sb.Append("MERGE INTO ").Append(QuoteIdentifier(query.InsertTable)).Append(" AS target USING (VALUES (");
+                sb.Append("MERGE INTO ").Append(QuoteIdentifier(query.InsertTable!)).Append(" AS target USING (VALUES (");
                 for (int i = 0; i < row.Count; i++)
                 {
                     if (i > 0)
@@ -690,7 +690,7 @@ public class QueryCompiler
             decimal d => d.ToString(CultureInfo.InvariantCulture),
             double d => d.ToString(CultureInfo.InvariantCulture),
             float f => f.ToString(CultureInfo.InvariantCulture),
-            _ => value.ToString()
+            _ => value.ToString() ?? string.Empty
         };
     }
 }

--- a/DbaClientX.MySql/MySql.Streaming.cs
+++ b/DbaClientX.MySql/MySql.Streaming.cs
@@ -22,7 +22,7 @@ public partial class MySql
         string query,
         IDictionary<string, object?>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        CancellationToken cancellationToken = default,
         IDictionary<string, MySqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
@@ -77,7 +77,7 @@ public partial class MySql
         string procedure,
         IDictionary<string, object?>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        CancellationToken cancellationToken = default,
         IDictionary<string, MySqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
@@ -132,7 +132,7 @@ public partial class MySql
         string procedure,
         IEnumerable<DbParameter>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default)
     {
         return Stream();
 

--- a/DbaClientX.Oracle/Oracle.Streaming.cs
+++ b/DbaClientX.Oracle/Oracle.Streaming.cs
@@ -22,7 +22,7 @@ public partial class Oracle
         string query,
         IDictionary<string, object?>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        CancellationToken cancellationToken = default,
         IDictionary<string, OracleDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
@@ -77,7 +77,7 @@ public partial class Oracle
         string procedure,
         IDictionary<string, object?>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        CancellationToken cancellationToken = default,
         IDictionary<string, OracleDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
@@ -132,7 +132,7 @@ public partial class Oracle
         string procedure,
         IEnumerable<DbParameter>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default)
     {
         return Stream();
 

--- a/DbaClientX.Oracle/Oracle.Transactions.cs
+++ b/DbaClientX.Oracle/Oracle.Transactions.cs
@@ -116,6 +116,7 @@ public partial class Oracle
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
             await tx!.CommitAsync(cancellationToken).ConfigureAwait(false);
 #else
+            await Task.Yield();
             tx!.Commit();
 #endif
         }
@@ -168,6 +169,7 @@ public partial class Oracle
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
             await tx!.RollbackAsync(cancellationToken).ConfigureAwait(false);
 #else
+            await Task.Yield();
             tx!.Rollback();
 #endif
         }

--- a/DbaClientX.PostgreSql/GenericExecutors.cs
+++ b/DbaClientX.PostgreSql/GenericExecutors.cs
@@ -21,7 +21,7 @@ public static class GenericExecutors
     {
         var b = new NpgsqlConnectionStringBuilder(connectionString);
         var cli = new DBAClientX.PostgreSql();
-        return cli.ExecuteNonQueryAsync(b.Host, b.Database, b.Username, b.Password, sql, parameters, cancellationToken: ct);
+        return cli.ExecuteNonQueryAsync(b.Host ?? string.Empty, b.Database ?? string.Empty, b.Username ?? string.Empty, b.Password ?? string.Empty, sql, parameters, cancellationToken: ct);
     }
 
     /// <summary>Executes a stored procedure.</summary>
@@ -34,7 +34,7 @@ public static class GenericExecutors
     {
         var b = new NpgsqlConnectionStringBuilder(connectionString);
         var cli = new DBAClientX.PostgreSql();
-        await cli.ExecuteStoredProcedureAsync(b.Host, b.Database, b.Username, b.Password, procedure, parameters, cancellationToken: ct).ConfigureAwait(false);
+        await cli.ExecuteStoredProcedureAsync(b.Host ?? string.Empty, b.Database ?? string.Empty, b.Username ?? string.Empty, b.Password ?? string.Empty, procedure, parameters, cancellationToken: ct).ConfigureAwait(false);
         return 0;
     }
 }

--- a/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
@@ -156,6 +156,14 @@ public partial class PostgreSql
         }
     }
 
+    /// <summary>
+    /// Writes all rows from <paramref name="table"/> into <paramref name="destinationTable"/> using PostgreSQL binary COPY.
+    /// </summary>
+    /// <param name="connection">An open PostgreSQL connection.</param>
+    /// <param name="table">Source table whose rows will be copied.</param>
+    /// <param name="destinationTable">Fully qualified destination table name.</param>
+    /// <param name="bulkCopyTimeout">Optional timeout (seconds) applied to the COPY operation.</param>
+    /// <param name="transaction">Ambient transaction to enlist in, if any.</param>
     protected virtual void WriteTable(NpgsqlConnection connection, DataTable table, string destinationTable, int? bulkCopyTimeout, NpgsqlTransaction? transaction)
     {
         var columns = string.Join(", ", table.Columns.Cast<DataColumn>().Select(c => $"\"{c.ColumnName}\""));
@@ -186,6 +194,15 @@ public partial class PostgreSql
         importer.Complete();
     }
 
+    /// <summary>
+    /// Asynchronously writes all rows from <paramref name="table"/> into <paramref name="destinationTable"/> using PostgreSQL binary COPY.
+    /// </summary>
+    /// <param name="connection">An open PostgreSQL connection.</param>
+    /// <param name="table">Source table whose rows will be copied.</param>
+    /// <param name="destinationTable">Fully qualified destination table name.</param>
+    /// <param name="bulkCopyTimeout">Optional timeout (seconds) applied to the COPY operation.</param>
+    /// <param name="transaction">Ambient transaction to enlist in, if any.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     protected virtual async Task WriteTableAsync(NpgsqlConnection connection, DataTable table, string destinationTable, int? bulkCopyTimeout, NpgsqlTransaction? transaction, CancellationToken cancellationToken)
     {
         var columns = string.Join(", ", table.Columns.Cast<DataColumn>().Select(c => $"\"{c.ColumnName}\""));
@@ -216,9 +233,23 @@ public partial class PostgreSql
         await importer.CompleteAsync(cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Creates a new <see cref="NpgsqlConnection"/> for the given connection string.
+    /// </summary>
+    /// <param name="connectionString">PostgreSQL connection string.</param>
+    /// <returns>A new, unopened <see cref="NpgsqlConnection"/>.</returns>
     protected virtual NpgsqlConnection CreateConnection(string connectionString) => new(connectionString);
 
+    /// <summary>
+    /// Opens the specified <paramref name="connection"/>.
+    /// </summary>
+    /// <param name="connection">The connection to open.</param>
     protected virtual void OpenConnection(NpgsqlConnection connection) => connection.Open();
 
+    /// <summary>
+    /// Asynchronously opens the specified <paramref name="connection"/>.
+    /// </summary>
+    /// <param name="connection">The connection to open.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
     protected virtual Task OpenConnectionAsync(NpgsqlConnection connection, CancellationToken cancellationToken) => connection.OpenAsync(cancellationToken);
 }

--- a/DbaClientX.PostgreSql/PostgreSql.Streaming.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.Streaming.cs
@@ -23,7 +23,7 @@ public partial class PostgreSql
         string query,
         IDictionary<string, object?>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        CancellationToken cancellationToken = default,
         IDictionary<string, NpgsqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
@@ -63,7 +63,7 @@ public partial class PostgreSql
         string procedure,
         IDictionary<string, object?>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        CancellationToken cancellationToken = default,
         IDictionary<string, NpgsqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
@@ -103,7 +103,7 @@ public partial class PostgreSql
         string procedure,
         IEnumerable<DbParameter>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default)
     {
         return Stream();
 

--- a/DbaClientX.PostgreSql/PostgreSql.Transactions.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.Transactions.cs
@@ -164,6 +164,7 @@ public partial class PostgreSql
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
             await tx!.CommitAsync(cancellationToken).ConfigureAwait(false);
 #else
+            await Task.Yield();
             tx!.Commit();
 #endif
         }
@@ -216,6 +217,7 @@ public partial class PostgreSql
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
             await tx!.RollbackAsync(cancellationToken).ConfigureAwait(false);
 #else
+            await Task.Yield();
             tx!.Rollback();
 #endif
         }

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
@@ -31,17 +31,17 @@ public sealed class CmdletIInvokeDbaXNonQuery : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
     [Alias("DBServer", "SqlInstance", "Instance")]
     [ValidateNotNullOrEmpty]
-    public string Server { get; set; }
+    public string Server { get; set; } = string.Empty;
 
     /// <summary>Defines the target database.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
     [ValidateNotNullOrEmpty]
-    public string Database { get; set; }
+    public string Database { get; set; } = string.Empty;
 
     /// <summary>The SQL command to execute.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "DefaultCredentials")]
     [ValidateNotNullOrEmpty]
-    public string Query { get; set; }
+    public string Query { get; set; } = string.Empty;
 
     /// <summary>Sets the command timeout in seconds.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
@@ -49,28 +49,34 @@ public sealed class CmdletIInvokeDbaXNonQuery : PSCmdlet {
 
     /// <summary>Provides parameters for the SQL command.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
-    public Hashtable Parameters { get; set; }
+    public Hashtable? Parameters { get; set; }
 
     /// <summary>Optional user name for SQL authentication.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
-    public string Username { get; set; }
+    public string Username { get; set; } = string.Empty;
 
     /// <summary>Optional password for SQL authentication.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
-    public string Password { get; set; }
+    public string Password { get; set; } = string.Empty;
 
     private ActionPreference ErrorAction;
 
+    /// <summary>
+    /// Initializes cmdlet state before pipeline execution begins.
+    /// </summary>
     protected override void BeginProcessing() {
         ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
         if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            string errorActionString = this.MyInvocation.BoundParameters["ErrorAction"].ToString();
-            if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
+            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
+            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
                 ErrorAction = actionPreference;
             }
         }
     }
 
+    /// <summary>
+    /// Processes input and performs the cmdlet's primary work.
+    /// </summary>
     protected override void ProcessRecord() {
         using var sqlServer = SqlServerFactory();
         sqlServer.CommandTimeout = QueryTimeout;
@@ -78,9 +84,11 @@ public sealed class CmdletIInvokeDbaXNonQuery : PSCmdlet {
         try {
             IDictionary<string, object?>? parameters = null;
             if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
-                    de => de.Key.ToString(),
-                    de => de.Value);
+                parameters = Parameters.Cast<DictionaryEntry>()
+                    .Where(de => de.Key != null)
+                    .ToDictionary(
+                        de => de.Key!.ToString()!,
+                        de => (object?)de.Value);
             }
 
             var affected = sqlServer.ExecuteNonQuery(Server, Database, integratedSecurity, Query, parameters, username: Username, password: Password);

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
@@ -33,17 +33,17 @@ public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
     [Parameter(Mandatory = true)]
     [Alias("DBServer", "SqlInstance", "Instance")]
     [ValidateNotNullOrEmpty]
-    public string Server { get; set; }
+    public string Server { get; set; } = string.Empty;
 
     /// <summary>Defines the name of the database.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Database { get; set; }
+    public string Database { get; set; } = string.Empty;
 
     /// <summary>The SQL statement to execute.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Query { get; set; }
+    public string Query { get; set; } = string.Empty;
 
     /// <summary>Sets the timeout for the command in seconds.</summary>
     [Parameter]
@@ -60,31 +60,37 @@ public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
 
     /// <summary>Provides additional parameters for the query.</summary>
     [Parameter]
-    public Hashtable Parameters { get; set; }
+    public Hashtable? Parameters { get; set; }
 
     /// <summary>User name for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Username { get; set; }
+    public string Username { get; set; } = string.Empty;
 
     /// <summary>Password for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Password { get; set; }
+    public string Password { get; set; } = string.Empty;
 
     private ActionPreference ErrorAction;
 
+    /// <summary>
+    /// Initializes cmdlet state before pipeline execution begins.
+    /// </summary>
     protected override Task BeginProcessingAsync() {
         ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
         if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            string errorActionString = this.MyInvocation.BoundParameters["ErrorAction"].ToString();
-            if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
+            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
+            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
                 ErrorAction = actionPreference;
             }
         }
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Processes input and performs the cmdlet's primary work.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         using var mySql = MySqlFactory();
         mySql.ReturnType = ReturnType;
@@ -92,9 +98,11 @@ public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
         try {
             IDictionary<string, object?>? parameters = null;
             if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
-                    de => de.Key.ToString(),
-                    de => de.Value);
+                parameters = Parameters.Cast<DictionaryEntry>()
+                    .Where(de => de.Key != null)
+                    .ToDictionary(
+                        de => de.Key!.ToString()!,
+                        de => (object?)de.Value);
             }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
             if (Stream.IsPresent) {

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
@@ -78,13 +78,7 @@ public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
     /// Initializes cmdlet state before pipeline execution begins.
     /// </summary>
     protected override Task BeginProcessingAsync() {
-        ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
-        if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
-            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
-                ErrorAction = actionPreference;
-            }
-        }
+        ErrorAction = this.ResolveErrorAction();
         return Task.CompletedTask;
     }
 
@@ -96,14 +90,7 @@ public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
         mySql.ReturnType = ReturnType;
         mySql.CommandTimeout = QueryTimeout;
         try {
-            IDictionary<string, object?>? parameters = null;
-            if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>()
-                    .Where(de => de.Key != null)
-                    .ToDictionary(
-                        de => de.Key!.ToString()!,
-                        de => (object?)de.Value);
-            }
+            var parameters = PowerShellHelpers.ToDictionaryOrNull(Parameters);
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
             if (Stream.IsPresent) {
                 var enumerable = mySql.QueryStreamAsync(Server, Database, Username, Password, Query, parameters, cancellationToken: CancelToken);

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySqlNonQuery.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySqlNonQuery.cs
@@ -62,13 +62,7 @@ public sealed class CmdletInvokeDbaXMySqlNonQuery : PSCmdlet {
     /// Initializes cmdlet state before pipeline execution begins.
     /// </summary>
     protected override void BeginProcessing() {
-        ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
-        if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
-            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
-                ErrorAction = actionPreference;
-            }
-        }
+        ErrorAction = this.ResolveErrorAction();
     }
 
     /// <summary>
@@ -78,14 +72,7 @@ public sealed class CmdletInvokeDbaXMySqlNonQuery : PSCmdlet {
         using var mySql = MySqlFactory();
         mySql.CommandTimeout = QueryTimeout;
         try {
-            IDictionary<string, object?>? parameters = null;
-            if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>()
-                    .Where(de => de.Key != null)
-                    .ToDictionary(
-                        de => de.Key!.ToString()!,
-                        de => (object?)de.Value);
-            }
+            var parameters = PowerShellHelpers.ToDictionaryOrNull(Parameters);
             var affected = mySql.ExecuteNonQuery(Server, Database, Username, Password, Query, parameters);
             WriteObject(affected);
         } catch (Exception ex) {

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySqlScalar.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySqlScalar.cs
@@ -58,13 +58,7 @@ public sealed class CmdletInvokeDbaXMySqlScalar : AsyncPSCmdlet {
     /// Initializes cmdlet state before pipeline execution begins.
     /// </summary>
     protected override Task BeginProcessingAsync() {
-        ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
-        if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
-            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
-                ErrorAction = actionPreference;
-            }
-        }
+        ErrorAction = this.ResolveErrorAction();
         return Task.CompletedTask;
     }
 
@@ -75,14 +69,7 @@ public sealed class CmdletInvokeDbaXMySqlScalar : AsyncPSCmdlet {
         using var mySql = MySqlFactory();
         mySql.CommandTimeout = QueryTimeout;
         try {
-            IDictionary<string, object?>? parameters = null;
-            if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>()
-                    .Where(de => de.Key != null)
-                    .ToDictionary(
-                        de => de.Key!.ToString()!,
-                        de => (object?)de.Value);
-            }
+            var parameters = PowerShellHelpers.ToDictionaryOrNull(Parameters);
             var result = await mySql.ExecuteScalarAsync(Server, Database, Username, Password, Query, parameters, cancellationToken: CancelToken).ConfigureAwait(false);
             switch (ReturnType) {
                 case ReturnType.DataTable:

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySqlScalar.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySqlScalar.cs
@@ -17,17 +17,17 @@ public sealed class CmdletInvokeDbaXMySqlScalar : AsyncPSCmdlet {
     [Parameter(Mandatory = true)]
     [Alias("DBServer", "SqlInstance", "Instance")]
     [ValidateNotNullOrEmpty]
-    public string Server { get; set; }
+    public string Server { get; set; } = string.Empty;
 
     /// <summary>Defines the target database.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Database { get; set; }
+    public string Database { get; set; } = string.Empty;
 
     /// <summary>The SQL command to execute.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Query { get; set; }
+    public string Query { get; set; } = string.Empty;
 
     /// <summary>Sets the command timeout in seconds.</summary>
     [Parameter]
@@ -40,40 +40,48 @@ public sealed class CmdletInvokeDbaXMySqlScalar : AsyncPSCmdlet {
 
     /// <summary>Provides parameters for the SQL command.</summary>
     [Parameter]
-    public Hashtable Parameters { get; set; }
+    public Hashtable? Parameters { get; set; }
 
     /// <summary>User name for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Username { get; set; }
+    public string Username { get; set; } = string.Empty;
 
     /// <summary>Password for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Password { get; set; }
+    public string Password { get; set; } = string.Empty;
 
     private ActionPreference ErrorAction;
 
+    /// <summary>
+    /// Initializes cmdlet state before pipeline execution begins.
+    /// </summary>
     protected override Task BeginProcessingAsync() {
         ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
         if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            string errorActionString = this.MyInvocation.BoundParameters["ErrorAction"].ToString();
-            if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
+            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
+            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
                 ErrorAction = actionPreference;
             }
         }
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Processes input and performs the cmdlet's primary work.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         using var mySql = MySqlFactory();
         mySql.CommandTimeout = QueryTimeout;
         try {
             IDictionary<string, object?>? parameters = null;
             if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
-                    de => de.Key.ToString(),
-                    de => de.Value);
+                parameters = Parameters.Cast<DictionaryEntry>()
+                    .Where(de => de.Key != null)
+                    .ToDictionary(
+                        de => de.Key!.ToString()!,
+                        de => (object?)de.Value);
             }
             var result = await mySql.ExecuteScalarAsync(Server, Database, Username, Password, Query, parameters, cancellationToken: CancelToken).ConfigureAwait(false);
             switch (ReturnType) {

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXOracle.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXOracle.cs
@@ -77,13 +77,7 @@ public sealed class CmdletInvokeDbaXOracle : AsyncPSCmdlet {
     /// Initializes cmdlet state before pipeline execution begins.
     /// </summary>
     protected override Task BeginProcessingAsync() {
-        ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
-        if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
-            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
-                ErrorAction = actionPreference;
-            }
-        }
+        ErrorAction = this.ResolveErrorAction();
         return Task.CompletedTask;
     }
 
@@ -95,14 +89,7 @@ public sealed class CmdletInvokeDbaXOracle : AsyncPSCmdlet {
         oracle.ReturnType = ReturnType;
         oracle.CommandTimeout = QueryTimeout;
         try {
-            IDictionary<string, object?>? parameters = null;
-            if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>()
-                    .Where(de => de.Key != null)
-                    .ToDictionary(
-                        de => de.Key!.ToString()!,
-                        de => (object?)de.Value);
-            }
+            var parameters = PowerShellHelpers.ToDictionaryOrNull(Parameters);
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
             if (Stream.IsPresent) {
                 var enumerable = oracle.QueryStreamAsync(Server, Database, Username, Password, Query, parameters, cancellationToken: CancelToken);

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXOracle.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXOracle.cs
@@ -32,17 +32,17 @@ public sealed class CmdletInvokeDbaXOracle : AsyncPSCmdlet {
     [Parameter(Mandatory = true)]
     [Alias("DBServer", "SqlInstance", "Instance")]
     [ValidateNotNullOrEmpty]
-    public string Server { get; set; }
+    public string Server { get; set; } = string.Empty;
 
     /// <summary>Defines the name of the database.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Database { get; set; }
+    public string Database { get; set; } = string.Empty;
 
     /// <summary>The SQL statement to execute.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Query { get; set; }
+    public string Query { get; set; } = string.Empty;
 
     /// <summary>Sets the timeout for the command in seconds.</summary>
     [Parameter]
@@ -59,31 +59,37 @@ public sealed class CmdletInvokeDbaXOracle : AsyncPSCmdlet {
 
     /// <summary>Provides additional parameters for the query.</summary>
     [Parameter]
-    public Hashtable Parameters { get; set; }
+    public Hashtable? Parameters { get; set; }
 
     /// <summary>User name for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Username { get; set; }
+    public string Username { get; set; } = string.Empty;
 
     /// <summary>Password for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Password { get; set; }
+    public string Password { get; set; } = string.Empty;
 
     private ActionPreference ErrorAction;
 
+    /// <summary>
+    /// Initializes cmdlet state before pipeline execution begins.
+    /// </summary>
     protected override Task BeginProcessingAsync() {
         ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
         if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            string errorActionString = this.MyInvocation.BoundParameters["ErrorAction"].ToString();
-            if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
+            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
+            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
                 ErrorAction = actionPreference;
             }
         }
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Processes input and performs the cmdlet's primary work.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         using var oracle = OracleFactory();
         oracle.ReturnType = ReturnType;
@@ -91,9 +97,11 @@ public sealed class CmdletInvokeDbaXOracle : AsyncPSCmdlet {
         try {
             IDictionary<string, object?>? parameters = null;
             if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
-                    de => de.Key.ToString(),
-                    de => de.Value);
+                parameters = Parameters.Cast<DictionaryEntry>()
+                    .Where(de => de.Key != null)
+                    .ToDictionary(
+                        de => de.Key!.ToString()!,
+                        de => (object?)de.Value);
             }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
             if (Stream.IsPresent) {

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXOracleNonQuery.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXOracleNonQuery.cs
@@ -60,13 +60,7 @@ public sealed class CmdletInvokeDbaXOracleNonQuery : PSCmdlet {
     /// Initializes cmdlet state before pipeline execution begins.
     /// </summary>
     protected override void BeginProcessing() {
-        ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
-        if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
-            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
-                ErrorAction = actionPreference;
-            }
-        }
+        ErrorAction = this.ResolveErrorAction();
     }
 
     /// <summary>
@@ -76,14 +70,7 @@ public sealed class CmdletInvokeDbaXOracleNonQuery : PSCmdlet {
         using var oracle = OracleFactory();
         oracle.CommandTimeout = QueryTimeout;
         try {
-            IDictionary<string, object?>? parameters = null;
-            if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>()
-                    .Where(de => de.Key != null)
-                    .ToDictionary(
-                        de => de.Key!.ToString()!,
-                        de => de.Value);
-            }
+            var parameters = PowerShellHelpers.ToDictionaryOrNull(Parameters);
             var affected = oracle.ExecuteNonQuery(Server, Database, Username, Password, Query, parameters);
             WriteObject(affected);
         } catch (Exception ex) {

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXOracleNonQuery.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXOracleNonQuery.cs
@@ -24,17 +24,17 @@ public sealed class CmdletInvokeDbaXOracleNonQuery : PSCmdlet {
     [Parameter(Mandatory = true)]
     [Alias("DBServer", "SqlInstance", "Instance")]
     [ValidateNotNullOrEmpty]
-    public string Server { get; set; }
+    public string Server { get; set; } = string.Empty;
 
     /// <summary>Defines the target database.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Database { get; set; }
+    public string Database { get; set; } = string.Empty;
 
     /// <summary>The SQL command to execute.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Query { get; set; }
+    public string Query { get; set; } = string.Empty;
 
     /// <summary>Sets the command timeout in seconds.</summary>
     [Parameter]
@@ -42,39 +42,47 @@ public sealed class CmdletInvokeDbaXOracleNonQuery : PSCmdlet {
 
     /// <summary>Provides parameters for the SQL command.</summary>
     [Parameter]
-    public Hashtable Parameters { get; set; }
+    public Hashtable? Parameters { get; set; }
 
     /// <summary>User name for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Username { get; set; }
+    public string Username { get; set; } = string.Empty;
 
     /// <summary>Password for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Password { get; set; }
+    public string Password { get; set; } = string.Empty;
 
     private ActionPreference ErrorAction;
 
+    /// <summary>
+    /// Initializes cmdlet state before pipeline execution begins.
+    /// </summary>
     protected override void BeginProcessing() {
         ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
         if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            string errorActionString = this.MyInvocation.BoundParameters["ErrorAction"].ToString();
-            if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
+            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
+            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
                 ErrorAction = actionPreference;
             }
         }
     }
 
+    /// <summary>
+    /// Processes input and performs the cmdlet's primary work.
+    /// </summary>
     protected override void ProcessRecord() {
         using var oracle = OracleFactory();
         oracle.CommandTimeout = QueryTimeout;
         try {
             IDictionary<string, object?>? parameters = null;
             if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
-                    de => de.Key.ToString(),
-                    de => de.Value);
+                parameters = Parameters.Cast<DictionaryEntry>()
+                    .Where(de => de.Key != null)
+                    .ToDictionary(
+                        de => de.Key!.ToString()!,
+                        de => de.Value);
             }
             var affected = oracle.ExecuteNonQuery(Server, Database, Username, Password, Query, parameters);
             WriteObject(affected);

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXOracleScalar.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXOracleScalar.cs
@@ -58,13 +58,7 @@ public sealed class CmdletInvokeDbaXOracleScalar : AsyncPSCmdlet {
     /// Initializes cmdlet state before pipeline execution begins.
     /// </summary>
     protected override Task BeginProcessingAsync() {
-        ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
-        if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
-            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
-                ErrorAction = actionPreference;
-            }
-        }
+        ErrorAction = this.ResolveErrorAction();
         return Task.CompletedTask;
     }
 
@@ -75,14 +69,7 @@ public sealed class CmdletInvokeDbaXOracleScalar : AsyncPSCmdlet {
         using var oracle = OracleFactory();
         oracle.CommandTimeout = QueryTimeout;
         try {
-            IDictionary<string, object?>? parameters = null;
-            if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>()
-                    .Where(de => de.Key != null)
-                    .ToDictionary(
-                        de => de.Key!.ToString()!,
-                        de => (object?)de.Value);
-            }
+            var parameters = PowerShellHelpers.ToDictionaryOrNull(Parameters);
             var result = await oracle.ExecuteScalarAsync(Server, Database, Username, Password, Query, parameters, cancellationToken: CancelToken).ConfigureAwait(false);
             switch (ReturnType) {
                 case ReturnType.DataTable:

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSqlNonQuery.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSqlNonQuery.cs
@@ -26,17 +26,17 @@ public sealed class CmdletInvokeDbaXPostgreSqlNonQuery : PSCmdlet {
     [Parameter(Mandatory = true)]
     [Alias("DBServer", "SqlInstance", "Instance")]
     [ValidateNotNullOrEmpty]
-    public string Server { get; set; }
+    public string Server { get; set; } = string.Empty;
 
     /// <summary>Defines the target database.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Database { get; set; }
+    public string Database { get; set; } = string.Empty;
 
     /// <summary>The SQL command to execute.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Query { get; set; }
+    public string Query { get; set; } = string.Empty;
 
     /// <summary>Sets the command timeout in seconds.</summary>
     [Parameter]
@@ -44,39 +44,47 @@ public sealed class CmdletInvokeDbaXPostgreSqlNonQuery : PSCmdlet {
 
     /// <summary>Provides parameters for the SQL command.</summary>
     [Parameter]
-    public Hashtable Parameters { get; set; }
+    public Hashtable? Parameters { get; set; }
 
     /// <summary>User name for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Username { get; set; }
+    public string Username { get; set; } = string.Empty;
 
     /// <summary>Password for authentication.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Password { get; set; }
+    public string Password { get; set; } = string.Empty;
 
     private ActionPreference ErrorAction;
 
+    /// <summary>
+    /// Initializes cmdlet state before pipeline execution begins.
+    /// </summary>
     protected override void BeginProcessing() {
         ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
         if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            string errorActionString = this.MyInvocation.BoundParameters["ErrorAction"].ToString();
-            if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
+            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
+            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
                 ErrorAction = actionPreference;
             }
         }
     }
 
+    /// <summary>
+    /// Processes input and performs the cmdlet's primary work.
+    /// </summary>
     protected override void ProcessRecord() {
         using var postgreSql = PostgreSqlFactory();
         postgreSql.CommandTimeout = QueryTimeout;
         try {
             IDictionary<string, object?>? parameters = null;
             if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
-                    de => de.Key.ToString(),
-                    de => de.Value);
+                parameters = Parameters.Cast<DictionaryEntry>()
+                    .Where(de => de.Key != null)
+                    .ToDictionary(
+                        de => de.Key!.ToString()!,
+                        de => (object?)de.Value);
             }
             var affected = postgreSql.ExecuteNonQuery(Server, Database, Username, Password, Query, parameters);
             WriteObject(affected);

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
@@ -32,12 +32,12 @@ public sealed class CmdletInvokeDbaXSQLite : AsyncPSCmdlet {
     /// <summary>Specifies the path to the SQLite database file.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Database { get; set; }
+    public string Database { get; set; } = string.Empty;
 
     /// <summary>Defines the SQL query to execute.</summary>
     [Parameter(Mandatory = true)]
     [ValidateNotNullOrEmpty]
-    public string Query { get; set; }
+    public string Query { get; set; } = string.Empty;
 
     /// <summary>Sets the command timeout in seconds.</summary>
     [Parameter]
@@ -54,31 +54,40 @@ public sealed class CmdletInvokeDbaXSQLite : AsyncPSCmdlet {
 
     /// <summary>Provides additional query parameters.</summary>
     [Parameter]
-    public Hashtable Parameters { get; set; }
+    public Hashtable? Parameters { get; set; }
 
     private ActionPreference ErrorAction;
 
+    /// <summary>
+    /// Initializes cmdlet state before pipeline execution begins.
+    /// </summary>
     protected override Task BeginProcessingAsync() {
         ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
         if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            string errorActionString = this.MyInvocation.BoundParameters["ErrorAction"].ToString();
-            if (Enum.TryParse(errorActionString, true, out ActionPreference actionPreference)) {
+            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
+            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
                 ErrorAction = actionPreference;
             }
         }
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Processes input and performs the cmdlet's primary work.
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
+        await Task.Yield();
         using var sqlite = SQLiteFactory();
         sqlite.ReturnType = ReturnType;
         sqlite.CommandTimeout = QueryTimeout;
         try {
             IDictionary<string, object?>? parameters = null;
             if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>().ToDictionary(
-                    de => de.Key.ToString(),
-                    de => de.Value);
+                parameters = Parameters.Cast<DictionaryEntry>()
+                    .Where(de => de.Key != null)
+                    .ToDictionary(
+                        de => de.Key!.ToString()!,
+                        de => (object?)de.Value);
             }
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
             if (Stream.IsPresent) {

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
@@ -62,13 +62,7 @@ public sealed class CmdletInvokeDbaXSQLite : AsyncPSCmdlet {
     /// Initializes cmdlet state before pipeline execution begins.
     /// </summary>
     protected override Task BeginProcessingAsync() {
-        ErrorAction = (ActionPreference)this.SessionState.PSVariable.GetValue("ErrorActionPreference");
-        if (this.MyInvocation.BoundParameters.ContainsKey("ErrorAction")) {
-            var errorActionObj = this.MyInvocation.BoundParameters["ErrorAction"];
-            if (errorActionObj != null && Enum.TryParse(errorActionObj.ToString(), true, out ActionPreference actionPreference)) {
-                ErrorAction = actionPreference;
-            }
-        }
+        ErrorAction = this.ResolveErrorAction();
         return Task.CompletedTask;
     }
 
@@ -81,14 +75,7 @@ public sealed class CmdletInvokeDbaXSQLite : AsyncPSCmdlet {
         sqlite.ReturnType = ReturnType;
         sqlite.CommandTimeout = QueryTimeout;
         try {
-            IDictionary<string, object?>? parameters = null;
-            if (Parameters != null) {
-                parameters = Parameters.Cast<DictionaryEntry>()
-                    .Where(de => de.Key != null)
-                    .ToDictionary(
-                        de => de.Key!.ToString()!,
-                        de => (object?)de.Value);
-            }
+            var parameters = PowerShellHelpers.ToDictionaryOrNull(Parameters);
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
             if (Stream.IsPresent) {
                 var enumerable = sqlite.QueryStreamAsync(Database, Query, parameters, cancellationToken: CancelToken);

--- a/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
@@ -37,7 +37,7 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
     /// <summary>Name of the table to select from.</summary>
     [Parameter(Mandatory = true, Position = 0)]
     [ValidateNotNullOrEmpty]
-    public string TableName { get; set; }
+    public string TableName { get; set; } = string.Empty;
 
     /// <summary>Compiles the query to a SQL string.</summary>
     [Parameter(Mandatory = false)]
@@ -53,6 +53,9 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
 
     private ActionPreference errorAction = ActionPreference.Continue;
 
+    /// <summary>
+    /// Initializes cmdlet state before pipeline execution begins.
+    /// </summary>
     protected override void BeginProcessing() {
         if (MyInvocation.BoundParameters.TryGetValue("ErrorAction", out var value)) {
             if (Enum.TryParse(value.ToString(), true, out ActionPreference actionPreference)) {
@@ -61,6 +64,9 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
         }
     }
 
+    /// <summary>
+    /// Processes input and performs the cmdlet's primary work.
+    /// </summary>
     protected override void ProcessRecord() {
         var query = DBAClientX.QueryBuilder.QueryBuilder.Query().From(TableName);
 

--- a/DbaClientX.PowerShell/Communication/PowerShellHelpers.cs
+++ b/DbaClientX.PowerShell/Communication/PowerShellHelpers.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+
+namespace DBAClientX.PowerShell;
+
+/// <summary>
+/// Shared helpers for PowerShell cmdlets to reduce duplication and keep behaviors consistent.
+/// </summary>
+internal static class PowerShellHelpers
+{
+    /// <summary>
+    /// Converts a Hashtable of parameters (as supplied from PowerShell) into a nullable
+    /// dictionary with string keys and nullable object values, filtering out null keys.
+    /// Returns null when <paramref name="parameters"/> is null to preserve existing semantics.
+    /// </summary>
+    internal static IDictionary<string, object?>? ToDictionaryOrNull(Hashtable? parameters)
+        => parameters is null
+            ? null
+            : parameters
+                .Cast<DictionaryEntry>()
+                .Where(de => de.Key != null)
+                .ToDictionary(de => de.Key!.ToString()!, de => (object?)de.Value);
+}
+
+internal static class CmdletExtensions
+{
+    /// <summary>
+    /// Reads ErrorActionPreference and optionally overrides it with the explicit -ErrorAction bound parameter.
+    /// </summary>
+    public static ActionPreference ResolveErrorAction(this PSCmdlet cmdlet)
+    {
+        var pref = (ActionPreference)cmdlet.SessionState.PSVariable.GetValue("ErrorActionPreference");
+        if (cmdlet.MyInvocation.BoundParameters.TryGetValue("ErrorAction", out var value) &&
+            value != null && Enum.TryParse(value.ToString(), true, out ActionPreference actionPreference))
+        {
+            pref = actionPreference;
+        }
+        return pref;
+    }
+}

--- a/DbaClientX.SQLite/SQLite.BulkOperations.cs
+++ b/DbaClientX.SQLite/SQLite.BulkOperations.cs
@@ -239,7 +239,10 @@ public partial class SQLite
             if (dispose)
             {
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
-                await connection.DisposeAsync().ConfigureAwait(false);
+                if (connection != null)
+                {
+                    await connection.DisposeAsync().ConfigureAwait(false);
+                }
 #else
                 connection?.Dispose();
 #endif

--- a/DbaClientX.SQLite/SQLite.Transactions.cs
+++ b/DbaClientX.SQLite/SQLite.Transactions.cs
@@ -144,6 +144,7 @@ public partial class SQLite
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
             await tx!.CommitAsync(cancellationToken).ConfigureAwait(false);
 #else
+            await Task.Yield();
             tx!.Commit();
 #endif
         }
@@ -196,6 +197,7 @@ public partial class SQLite
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
             await tx!.RollbackAsync(cancellationToken).ConfigureAwait(false);
 #else
+            await Task.Yield();
             tx!.Rollback();
 #endif
         }

--- a/DbaClientX.SqlServer/SqlServer.ParallelExecution.cs
+++ b/DbaClientX.SqlServer/SqlServer.ParallelExecution.cs
@@ -22,7 +22,7 @@ public partial class SqlServer
     /// <returns>A list containing the result of each query in submission order.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="queries"/> is <see langword="null"/>.</exception>
     /// <remarks>
-    /// Each query is executed via <see cref="QueryAsync(string, string, bool, string, IDictionary{string, object?}?, bool, CancellationToken, IDictionary{string, SqlDbType}?, IDictionary{string, ParameterDirection}?, string?, string?)"/>.
+    /// Each query is executed via <see cref="QueryAsync"/>.
     /// </remarks>
     public async Task<IReadOnlyList<object?>> RunQueriesInParallel(
         IEnumerable<string> queries,

--- a/DbaClientX.SqlServer/SqlServer.Streaming.cs
+++ b/DbaClientX.SqlServer/SqlServer.Streaming.cs
@@ -21,7 +21,7 @@ public partial class SqlServer
         string query,
         IDictionary<string, object?>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        CancellationToken cancellationToken = default,
         IDictionary<string, SqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null,
         string? username = null,
@@ -64,7 +64,7 @@ public partial class SqlServer
         string procedure,
         IDictionary<string, object?>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        CancellationToken cancellationToken = default,
         IDictionary<string, SqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null,
         string? username = null,
@@ -107,7 +107,7 @@ public partial class SqlServer
         string procedure,
         IEnumerable<DbParameter>? parameters = null,
         bool useTransaction = false,
-        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        CancellationToken cancellationToken = default,
         string? username = null,
         string? password = null)
     {

--- a/DbaClientX.SqlServer/SqlServer.Transactions.cs
+++ b/DbaClientX.SqlServer/SqlServer.Transactions.cs
@@ -171,6 +171,7 @@ public partial class SqlServer
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
             await tx!.CommitAsync(cancellationToken).ConfigureAwait(false);
 #else
+            await Task.Yield();
             tx!.Commit();
 #endif
         }
@@ -223,6 +224,7 @@ public partial class SqlServer
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
             await tx!.RollbackAsync(cancellationToken).ConfigureAwait(false);
 #else
+            await Task.Yield();
             tx!.Rollback();
 #endif
         }

--- a/DbaClientX.Tests/DatabaseClientBasePerformanceTests.cs
+++ b/DbaClientX.Tests/DatabaseClientBasePerformanceTests.cs
@@ -1,4 +1,6 @@
 using System;
+#pragma warning disable CS8765 // Nullability of parameter doesn't match overridden member
+#pragma warning disable CS8764 // Nullability of return type doesn't match overridden member
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
@@ -54,7 +56,7 @@ public class DatabaseClientBasePerformanceTests
         public override bool IsNullable { get; set; }
         public override string ParameterName { get; set; } = string.Empty;
         public override string SourceColumn { get; set; } = string.Empty;
-        public override object? Value { get; set; }
+        public override object Value { get; set; } = new object();
         public override bool SourceColumnNullMapping { get; set; }
         public override int Size { get; set; }
         public override void ResetDbType() { }

--- a/DbaClientX.Tests/MySqlNonQueryTests.cs
+++ b/DbaClientX.Tests/MySqlNonQueryTests.cs
@@ -92,8 +92,8 @@ public class MySqlNonQueryTests
 
         await mySql.ExecuteNonQueryAsync("h", "d", "u", "p", "UPDATE t SET c=1 WHERE id=@id", parameters);
 
-        Assert.Contains(mySql.Captured, p => p.Name == "@id" && (int)p.Value == 5);
-        Assert.Contains(mySql.Captured, p => p.Name == "@name" && (string)p.Value == "test");
+        Assert.Contains(mySql.Captured, p => p.Name == "@id" && p.Value is int v && v == 5);
+        Assert.Contains(mySql.Captured, p => p.Name == "@name" && p.Value is string s && s == "test");
     }
 
     [Fact]

--- a/DbaClientX.Tests/MySqlStoredProcedureStreamTests.cs
+++ b/DbaClientX.Tests/MySqlStoredProcedureStreamTests.cs
@@ -15,7 +15,7 @@ public class MySqlStoredProcedureStreamTests
     {
         public List<MySqlParameter> Captured { get; } = new();
 
-        public override IAsyncEnumerable<DataRow> ExecuteStoredProcedureStreamAsync(string host, string database, string username, string password, string procedure, IEnumerable<DbParameter>? parameters = null, bool useTransaction = false, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public override IAsyncEnumerable<DataRow> ExecuteStoredProcedureStreamAsync(string host, string database, string username, string password, string procedure, IEnumerable<DbParameter>? parameters = null, bool useTransaction = false, CancellationToken cancellationToken = default)
         {
             return Stream();
 
@@ -52,7 +52,7 @@ public class MySqlStoredProcedureStreamTests
         }
 
         Assert.Equal(new[] { 1 }, list);
-        Assert.Contains(mySql.Captured, p => p.ParameterName == "@id" && (int)p.Value == 1);
+        Assert.Contains(mySql.Captured, p => p.ParameterName == "@id" && p.Value is int v && v == 1);
     }
 }
 

--- a/DbaClientX.Tests/MySqlTests.cs
+++ b/DbaClientX.Tests/MySqlTests.cs
@@ -196,8 +196,8 @@ public class MySqlTests
 
         await mySql.QueryAsync("h", "d", "u", "p", "SELECT 1", parameters);
 
-        Assert.Contains(mySql.Captured, p => p.Name == "@id" && (int)p.Value == 5);
-        Assert.Contains(mySql.Captured, p => p.Name == "@name" && (string)p.Value == "test");
+        Assert.Contains(mySql.Captured, p => p.Name == "@id" && p.Value is int v && v == 5);
+        Assert.Contains(mySql.Captured, p => p.Name == "@name" && p.Value is string s && s == "test");
     }
 
     [Fact]
@@ -296,8 +296,8 @@ public class MySqlTests
         };
         mySql.ExecuteStoredProcedure("h", "d", "u", "p", "sp_test", parameters);
         Assert.Equal(CommandType.StoredProcedure, mySql.CapturedCommandType);
-        Assert.Contains(mySql.Captured, p => p.ParameterName == "@id" && (int)p.Value == 1);
-        Assert.Contains(mySql.Captured, p => p.ParameterName == "@name" && (string)p.Value == "n");
+        Assert.Contains(mySql.Captured, p => p.ParameterName == "@id" && p.Value is int v && v == 1);
+        Assert.Contains(mySql.Captured, p => p.ParameterName == "@name" && p.Value is string s && s == "n");
     }
 
     [Fact]

--- a/DbaClientX.Tests/OracleTests.cs
+++ b/DbaClientX.Tests/OracleTests.cs
@@ -186,8 +186,8 @@ public class OracleTests
 
         await oracle.QueryAsync("h", "svc", "u", "p", "SELECT 1 FROM dual", parameters);
 
-        Assert.Contains(oracle.Captured, p => p.Name == ":id" && (int)p.Value == 5);
-        Assert.Contains(oracle.Captured, p => p.Name == ":name" && (string)p.Value == "test");
+        Assert.Contains(oracle.Captured, p => p.Name == ":id" && p.Value is int v && v == 5);
+        Assert.Contains(oracle.Captured, p => p.Name == ":name" && p.Value is string s && s == "test");
     }
 
     [Fact]
@@ -289,8 +289,8 @@ public class OracleTests
         };
         oracle.ExecuteStoredProcedure("h", "svc", "u", "p", "sp_test", parameters);
         Assert.Equal(CommandType.StoredProcedure, oracle.CapturedCommandType);
-        Assert.Contains(oracle.Captured, p => p.ParameterName == ":id" && (int)p.Value == 1);
-        Assert.Contains(oracle.Captured, p => p.ParameterName == ":name" && (string)p.Value == "n");
+        Assert.Contains(oracle.Captured, p => p.ParameterName == ":id" && p.Value is int v && v == 1);
+        Assert.Contains(oracle.Captured, p => p.ParameterName == ":name" && p.Value is string s && s == "n");
     }
 
     [Fact]

--- a/DbaClientX.Tests/PostgreSqlTests.cs
+++ b/DbaClientX.Tests/PostgreSqlTests.cs
@@ -198,8 +198,8 @@ public class PostgreSqlTests
 
         await pg.QueryAsync("h", "d", "u", "p", "SELECT 1", parameters);
 
-        Assert.Contains(pg.Captured, p => p.Name == "@id" && (int)p.Value == 5);
-        Assert.Contains(pg.Captured, p => p.Name == "@name" && (string)p.Value == "test");
+        Assert.Contains(pg.Captured, p => p.Name == "@id" && p.Value is int v && v == 5);
+        Assert.Contains(pg.Captured, p => p.Name == "@name" && p.Value is string s && s == "test");
     }
 
     [Fact]
@@ -289,8 +289,8 @@ public class PostgreSqlTests
         };
         pg.ExecuteStoredProcedure("h", "d", "u", "p", "sp_test", parameters);
         Assert.Equal(CommandType.StoredProcedure, pg.CapturedCommandType);
-        Assert.Contains(pg.Captured, p => p.ParameterName == "@id" && (int)p.Value == 1);
-        Assert.Contains(pg.Captured, p => p.ParameterName == "@name" && (string)p.Value == "n");
+        Assert.Contains(pg.Captured, p => p.ParameterName == "@id" && p.Value is int v && v == 1);
+        Assert.Contains(pg.Captured, p => p.ParameterName == "@name" && p.Value is string s && s == "n");
     }
 
     [Fact]

--- a/DbaClientX.Tests/QueryStreamCancellationTests.cs
+++ b/DbaClientX.Tests/QueryStreamCancellationTests.cs
@@ -1,4 +1,6 @@
 using System;
+#pragma warning disable CS8765 // Nullability of parameter doesn't match overridden member
+#pragma warning disable CS8764 // Nullability of return type doesn't match overridden member
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
@@ -49,12 +51,12 @@ public class QueryStreamCancellationTests
             _onDispose = onDispose;
         }
 
-        public override string? CommandText { get; set; }
+        public override string CommandText { get; set; } = string.Empty;
         public override int CommandTimeout { get; set; }
         public override CommandType CommandType { get; set; }
         public override bool DesignTimeVisible { get; set; }
         public override UpdateRowSource UpdatedRowSource { get; set; }
-        protected override DbConnection? DbConnection { get; set; }
+        protected override DbConnection DbConnection { get; set; } = null!;
         protected override DbParameterCollection DbParameterCollection { get; } = new TestDbParameterCollection();
         protected override DbTransaction? DbTransaction { get; set; }
 
@@ -162,7 +164,7 @@ public class QueryStreamCancellationTests
         public override bool IsNullable { get; set; }
         public override string ParameterName { get; set; } = string.Empty;
         public override string SourceColumn { get; set; } = string.Empty;
-        public override object? Value { get; set; }
+        public override object Value { get; set; } = new object();
         public override bool SourceColumnNullMapping { get; set; }
         public override int Size { get; set; }
         public override byte Precision { get; set; }

--- a/DbaClientX.Tests/RetryTests.cs
+++ b/DbaClientX.Tests/RetryTests.cs
@@ -1,4 +1,6 @@
 using System;
+#pragma warning disable CS8765 // Nullability of parameter doesn't match overridden member
+#pragma warning disable CS8764 // Nullability of return type doesn't match overridden member
 using System.Collections;
 using System.Data;
 using System.Data.Common;
@@ -98,7 +100,7 @@ public class RetryTests
             public override bool IsNullable { get; set; }
             public override string ParameterName { get; set; } = string.Empty;
             public override string SourceColumn { get; set; } = string.Empty;
-            public override object? Value { get; set; }
+            public override object Value { get; set; } = new object();
             public override bool SourceColumnNullMapping { get; set; }
             public override int Size { get; set; }
             public override void ResetDbType() { }

--- a/DbaClientX.Tests/SqlServerNonQueryTests.cs
+++ b/DbaClientX.Tests/SqlServerNonQueryTests.cs
@@ -51,8 +51,8 @@ public class SqlServerNonQueryTests
 
         sqlServer.ExecuteNonQuery("s", "db", true, "UPDATE t SET c=1 WHERE id=@id", parameters);
 
-        Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && (int)p.Value == 5);
-        Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && (string)p.Value == "test");
+        Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && p.Value is int v && v == 5);
+        Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && p.Value is string s && s == "test");
     }
 
     [Fact]
@@ -232,8 +232,8 @@ public class SqlServerNonQueryTests
 
         await sqlServer.ExecuteNonQueryAsync("s", "db", true, "UPDATE t SET c=1 WHERE id=@id", parameters);
 
-        Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && (int)p.Value == 5);
-        Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && (string)p.Value == "test");
+        Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && p.Value is int v && v == 5);
+        Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && p.Value is string s && s == "test");
     }
 
     [Fact]

--- a/DbaClientX.Tests/SqlServerTests.cs
+++ b/DbaClientX.Tests/SqlServerTests.cs
@@ -197,8 +197,8 @@ public class SqlServerTests
 
         await sqlServer.QueryAsync("ignored", "ignored", true, "SELECT 1", parameters);
 
-        Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && (int)p.Value == 5);
-        Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && (string)p.Value == "test");
+        Assert.Contains(sqlServer.Captured, p => p.Name == "@id" && p.Value is int v && v == 5);
+        Assert.Contains(sqlServer.Captured, p => p.Name == "@name" && p.Value is string s && s == "test");
     }
 
     [Fact]
@@ -288,8 +288,8 @@ public class SqlServerTests
         };
         sqlServer.ExecuteStoredProcedure("s", "db", true, "sp_test", parameters);
         Assert.Equal(CommandType.StoredProcedure, sqlServer.CapturedCommandType);
-        Assert.Contains(sqlServer.Captured, p => p.ParameterName == "@id" && (int)p.Value == 1);
-        Assert.Contains(sqlServer.Captured, p => p.ParameterName == "@name" && (string)p.Value == "n");
+        Assert.Contains(sqlServer.Captured, p => p.ParameterName == "@id" && p.Value is int v && v == 1);
+        Assert.Contains(sqlServer.Captured, p => p.ParameterName == "@name" && p.Value is string s && s == "n");
     }
 
     [Fact]


### PR DESCRIPTION
…e nullability for parameters

- Updated properties in CmdletInvokeDbaXMySqlScalar, CmdletInvokeDbaXOracle, CmdletInvokeDbaXOracleNonQuery, CmdletInvokeDbaXOracleScalar, CmdletInvokeDbaXPostgreSql, CmdletInvokeDbaXPostgreSqlNonQuery, CmdletInvokeDbaXSQLite, and CmdletNewDbaXQuery to initialize string properties with empty strings.
- Changed Hashtable properties to nullable in various cmdlets to better reflect potential absence of parameters.
- Enhanced error action handling in cmdlets to ensure null checks are performed.
- Updated SQL command execution methods to ensure parameters are processed safely with null checks.
- Adjusted tests to use pattern matching for value assertions instead of direct casts to improve type safety.
- Improved assembly resolution handling in OnImportAndRemove class to prevent null reference exceptions.
- Minor adjustments in SQLite bulk operations to ensure proper disposal of connections.
- Updated documentation comments for clarity and consistency across cmdlets.