### PR TITLE
feat(sqlite): ✨ add graceful shutdown maintenance helpers

### DIFF
--- a/DbaClientX.SQLite/README.md
+++ b/DbaClientX.SQLite/README.md
@@ -1,6 +1,7 @@
 # DbaClientX.SQLite
 
 SQLite provider for DbaClientX (Microsoft.Data.Sqlite). Supports non-query, scalar, queries, streaming, transactions, bulk insert.
+Also includes SQLite maintenance helpers for WAL checkpointing, `PRAGMA optimize`, and graceful shutdown preparation.
 
 - Target Frameworks: `net8.0`, `net472`
 - NuGet: `DBAClientX.SQLite`
@@ -35,7 +36,19 @@ await foreach (DataRow row in sq.QueryStreamAsync(
 }
 ```
 
+Graceful shutdown maintenance:
+
+```csharp
+var sq = new DBAClientX.SQLite();
+await sq.PrepareForShutdownAsync(
+    database: "app.db",
+    options: new SqliteShutdownMaintenanceOptions
+    {
+        CheckpointMode = SqliteCheckpointMode.Truncate,
+        OptimizeAfterCheckpoint = true
+    });
+```
+
 ## See also
 
 - Core mapping + invoker: `DBAClientX.Core`
-

--- a/DbaClientX.SQLite/SQLite.Maintenance.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.cs
@@ -1,0 +1,139 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+
+namespace DBAClientX;
+
+/// <summary>
+/// Provides SQLite maintenance helpers for checkpointing and graceful shutdown preparation.
+/// </summary>
+public partial class SQLite
+{
+    /// <summary>
+    /// Executes <c>PRAGMA wal_checkpoint(...)</c> using the supplied checkpoint mode.
+    /// </summary>
+    /// <param name="database">Absolute or relative path of the SQLite database file.</param>
+    /// <param name="mode">Checkpoint mode to apply.</param>
+    /// <param name="cancellationToken">Token used to cancel command execution.</param>
+    /// <param name="busyTimeoutMs">Optional busy timeout in milliseconds.</param>
+    /// <returns>A task that completes when the checkpoint has finished.</returns>
+    public virtual Task CheckpointAsync(
+        string database,
+        SqliteCheckpointMode mode = SqliteCheckpointMode.Passive,
+        CancellationToken cancellationToken = default,
+        int? busyTimeoutMs = null)
+    {
+        string checkpoint = mode switch
+        {
+            SqliteCheckpointMode.Full => "FULL",
+            SqliteCheckpointMode.Restart => "RESTART",
+            SqliteCheckpointMode.Truncate => "TRUNCATE",
+            _ => "PASSIVE"
+        };
+
+        return ExecuteMaintenancePragmaAsync(
+            database,
+            $"PRAGMA wal_checkpoint({checkpoint});",
+            cancellationToken,
+            busyTimeoutMs);
+    }
+
+    /// <summary>
+    /// Executes <c>PRAGMA optimize</c> against the supplied SQLite database file.
+    /// </summary>
+    /// <param name="database">Absolute or relative path of the SQLite database file.</param>
+    /// <param name="cancellationToken">Token used to cancel command execution.</param>
+    /// <param name="busyTimeoutMs">Optional busy timeout in milliseconds.</param>
+    /// <returns>A task that completes when optimization has finished.</returns>
+    public virtual Task OptimizeAsync(
+        string database,
+        CancellationToken cancellationToken = default,
+        int? busyTimeoutMs = null)
+    {
+        return ExecuteMaintenancePragmaAsync(
+            database,
+            "PRAGMA optimize;",
+            cancellationToken,
+            busyTimeoutMs);
+    }
+
+    /// <summary>
+    /// Performs best-effort SQLite maintenance suitable for a graceful application shutdown.
+    /// </summary>
+    /// <param name="database">Absolute or relative path of the SQLite database file.</param>
+    /// <param name="options">Optional shutdown maintenance settings.</param>
+    /// <param name="cancellationToken">Token used to cancel command execution.</param>
+    /// <returns>A task that completes when shutdown maintenance has finished.</returns>
+    public virtual async Task PrepareForShutdownAsync(
+        string database,
+        SqliteShutdownMaintenanceOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        EnsureNoActiveTransaction();
+        var effectiveOptions = options ?? new SqliteShutdownMaintenanceOptions();
+
+        await CheckpointAsync(
+                database,
+                effectiveOptions.CheckpointMode,
+                cancellationToken,
+                effectiveOptions.BusyTimeoutMs)
+            .ConfigureAwait(false);
+
+        if (effectiveOptions.OptimizeAfterCheckpoint)
+        {
+            await OptimizeAsync(database, cancellationToken, effectiveOptions.BusyTimeoutMs).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ExecuteMaintenancePragmaAsync(
+        string database,
+        string pragma,
+        CancellationToken cancellationToken,
+        int? busyTimeoutMs)
+    {
+        ValidateDatabasePath(database);
+        ValidateCommandText(pragma);
+        EnsureNoActiveTransaction();
+
+        SqliteConnection? connection = null;
+        try
+        {
+            connection = new SqliteConnection(BuildOperationalConnectionString(database));
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await ApplyBusyTimeoutAsync(connection, busyTimeoutMs, cancellationToken).ConfigureAwait(false);
+
+            using var command = connection.CreateCommand();
+            command.CommandText = pragma;
+            var commandTimeout = CommandTimeout;
+            if (commandTimeout > 0)
+            {
+                command.CommandTimeout = commandTimeout;
+            }
+
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute SQLite maintenance command.", pragma, ex);
+        }
+        finally
+        {
+            if (connection != null)
+            {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+                await connection.DisposeAsync().ConfigureAwait(false);
+#else
+                connection.Dispose();
+#endif
+            }
+        }
+    }
+
+    private void EnsureNoActiveTransaction()
+    {
+        if (IsInTransaction)
+        {
+            throw new DbaTransactionException("SQLite maintenance cannot run while a transaction is active.");
+        }
+    }
+}

--- a/DbaClientX.SQLite/SqliteShutdownMaintenanceOptions.cs
+++ b/DbaClientX.SQLite/SqliteShutdownMaintenanceOptions.cs
@@ -1,0 +1,51 @@
+namespace DBAClientX;
+
+/// <summary>
+/// Controls graceful shutdown maintenance executed against a SQLite database.
+/// </summary>
+public sealed class SqliteShutdownMaintenanceOptions
+{
+    /// <summary>
+    /// Gets or sets the checkpoint mode applied before the connection is closed.
+    /// </summary>
+    public SqliteCheckpointMode CheckpointMode { get; set; } = SqliteCheckpointMode.Truncate;
+
+    /// <summary>
+    /// Gets or sets the optional busy timeout in milliseconds used by the maintenance connection.
+    /// </summary>
+    /// <remarks>
+    /// Set to <see langword="null"/> to use the client instance <see cref="SQLite.BusyTimeoutMs"/>.
+    /// </remarks>
+    public int? BusyTimeoutMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether <c>PRAGMA optimize</c> should be executed after checkpointing.
+    /// </summary>
+    public bool OptimizeAfterCheckpoint { get; set; } = true;
+}
+
+/// <summary>
+/// SQLite checkpoint modes supported by <c>PRAGMA wal_checkpoint</c>.
+/// </summary>
+public enum SqliteCheckpointMode
+{
+    /// <summary>
+    /// Passive checkpointing that does not block active readers or writers.
+    /// </summary>
+    Passive = 0,
+
+    /// <summary>
+    /// Full checkpointing that waits for active writers to finish.
+    /// </summary>
+    Full = 1,
+
+    /// <summary>
+    /// Restart checkpointing that resets the WAL once checkpointing finishes.
+    /// </summary>
+    Restart = 2,
+
+    /// <summary>
+    /// Truncate checkpointing that truncates the WAL file after checkpointing completes.
+    /// </summary>
+    Truncate = 3
+}

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -310,6 +310,58 @@ public class SqliteTests
         }
     }
 
+    [Fact]
+    public async Task PrepareForShutdownAsync_WalDatabase_CheckpointsAndKeepsDatabaseHealthy()
+    {
+        var path = Path.GetTempFileName();
+        string walPath = path + "-wal";
+
+        try
+        {
+            using var sqlite = new DBAClientX.SQLite();
+            await sqlite.ExecuteNonQueryAsync(path, "PRAGMA journal_mode=WAL;");
+            await sqlite.ExecuteNonQueryAsync(path, "CREATE TABLE t(id INTEGER, payload TEXT);");
+            await sqlite.ExecuteNonQueryAsync(path, "INSERT INTO t(id, payload) VALUES (1, $payload);", new Dictionary<string, object?>
+            {
+                ["$payload"] = new string('x', 4096)
+            });
+
+            await sqlite.PrepareForShutdownAsync(path, new SqliteShutdownMaintenanceOptions
+            {
+                CheckpointMode = SqliteCheckpointMode.Truncate,
+                OptimizeAfterCheckpoint = true
+            });
+
+            if (File.Exists(walPath))
+            {
+                Assert.Equal(0, new FileInfo(walPath).Length);
+            }
+
+            await using var connection = new SqliteConnection(DBAClientX.SQLite.BuildConnectionString(path));
+            await connection.OpenAsync();
+            await using var command = connection.CreateCommand();
+            command.CommandText = "PRAGMA integrity_check;";
+            object? result = await command.ExecuteScalarAsync();
+            Assert.Equal("ok", result?.ToString());
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    [Fact]
+    public async Task PrepareForShutdownAsync_WhenTransactionActive_Throws()
+    {
+        using var sqlite = new DBAClientX.SQLite();
+        await sqlite.BeginTransactionAsync(":memory:");
+
+        await Assert.ThrowsAsync<DBAClientX.DbaTransactionException>(async () =>
+            await sqlite.PrepareForShutdownAsync(":memory:"));
+
+        await sqlite.RollbackAsync();
+    }
+
     private class DelaySqlite : DBAClientX.SQLite
     {
         private readonly TimeSpan _delay;
@@ -440,10 +492,19 @@ public class SqliteTests
 
     private static void Cleanup(string path)
     {
-        if (File.Exists(path))
+        TryDelete(path);
+        TryDelete(path + "-wal");
+        TryDelete(path + "-shm");
+    }
+
+    private static void TryDelete(string path)
+    {
+        if (!File.Exists(path))
         {
-            File.Delete(path);
+            return;
         }
+
+        File.Delete(path);
     }
 
     private static SqliteConnection GetTransactionConnection(DBAClientX.SQLite sqlite)


### PR DESCRIPTION
## Summary
- add reusable SQLite checkpoint, optimize, and graceful shutdown helpers to `DBAClientX.SQLite`
- add typed shutdown maintenance options and checkpoint mode enum
- cover WAL checkpoint and active-transaction guard behavior in tests

## Validation
- `dotnet.exe test DbaClientX.Tests\DbaClientX.Tests.csproj -c Debug -f net10.0 --no-restore --filter FullyQualifiedName~SqliteTests`
