### PR TITLE
Add typed PostgreSQL query mapping APIs

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -745,6 +745,64 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
+    /// Asynchronously executes a query and maps each row with a caller-provided mapper.
+    /// </summary>
+    /// <typeparam name="T">The row result type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="connection">The open database connection.</param>
+    /// <param name="transaction">The transaction to enlist in, if any.</param>
+    /// <param name="query">The query to execute.</param>
+    /// <param name="map">A mapper that converts the current data record into a result value.</param>
+    /// <param name="initialize">Optional callback invoked once after the reader opens and before the first row is read.</param>
+    /// <param name="parameters">Optional parameter values.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <param name="parameterTypes">Optional parameter types.</param>
+    /// <param name="parameterDirections">Optional parameter directions.</param>
+    /// <returns>The mapped result rows.</returns>
+    protected virtual async Task<IReadOnlyList<T>> ExecuteMappedQueryAsync<T>(
+        DbConnection connection,
+        DbTransaction? transaction,
+        string query,
+        Func<IDataRecord, T> map,
+        Action<IDataRecord>? initialize = null,
+        IDictionary<string, object?>? parameters = null,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, DbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateCommandText(query);
+        if (map == null)
+        {
+            throw new ArgumentNullException(nameof(map));
+        }
+
+        return await ExecuteWithRetryAsync(async () =>
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = query;
+            command.Transaction = transaction;
+            AddParameters(command, parameters, parameterTypes, parameterDirections);
+            var commandTimeout = CommandTimeout;
+            if (commandTimeout > 0)
+            {
+                command.CommandTimeout = commandTimeout;
+            }
+
+            var rows = new List<T>();
+            using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+            {
+                initialize?.Invoke(reader);
+                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    rows.Add(map(reader));
+                }
+            }
+
+            UpdateOutputParameters(command, parameters);
+            return (IReadOnlyList<T>)rows;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Asynchronously executes a non-query command (INSERT/UPDATE/DELETE) with retry support.
     /// </summary>
     /// <param name="connection">The open database connection.</param>
@@ -898,6 +956,85 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
                 row[i] = reader.IsDBNull(i) ? DBNull.Value : reader.GetValue(i);
             }
             yield return row;
+        }
+
+        UpdateOutputParameters(command, parameters);
+        yield break;
+    }
+
+    /// <summary>
+    /// Asynchronously streams query rows through a caller-provided mapper.
+    /// </summary>
+    /// <typeparam name="T">The row result type produced by <paramref name="map"/>.</typeparam>
+    /// <param name="connection">The open database connection.</param>
+    /// <param name="transaction">The transaction to enlist in, if any.</param>
+    /// <param name="query">The query to execute.</param>
+    /// <param name="map">A mapper that converts the current data record into a result value.</param>
+    /// <param name="initialize">Optional callback invoked once after the reader opens and before the first row is read.</param>
+    /// <param name="parameters">Optional parameter values.</param>
+    /// <param name="cancellationToken">Token used to cancel the iteration.</param>
+    /// <param name="parameterTypes">Optional parameter types.</param>
+    /// <param name="parameterDirections">Optional parameter directions.</param>
+    /// <param name="dbParameters">Provider-specific parameters to attach directly to the command.</param>
+    /// <param name="commandType">Command type to use (Text or StoredProcedure).</param>
+    /// <returns>An asynchronous stream of mapped result rows.</returns>
+    protected virtual async IAsyncEnumerable<T> ExecuteMappedQueryStreamAsync<T>(
+        DbConnection connection,
+        DbTransaction? transaction,
+        string query,
+        Func<IDataRecord, T> map,
+        Action<IDataRecord>? initialize = null,
+        IDictionary<string, object?>? parameters = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default,
+        IDictionary<string, DbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        IEnumerable<DbParameter>? dbParameters = null,
+        CommandType commandType = CommandType.Text)
+    {
+        ValidateCommandText(query, commandType);
+        if (map == null)
+        {
+            throw new ArgumentNullException(nameof(map));
+        }
+        var maxAttempts = MaxRetryAttempts < 1 ? 1 : MaxRetryAttempts;
+        var attempt = 0;
+
+        using var command = connection.CreateCommand();
+        command.CommandText = query;
+        command.Transaction = transaction;
+        command.CommandType = commandType;
+        AddParameters(command, parameters, parameterTypes, parameterDirections);
+        AddParameters(command, dbParameters);
+        var commandTimeout = CommandTimeout;
+        if (commandTimeout > 0)
+        {
+            command.CommandTimeout = commandTimeout;
+        }
+
+        async Task<DbDataReader> OpenReaderAsync()
+        {
+            while (true)
+            {
+                try
+                {
+                    return await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex) when (IsTransient(ex) && ++attempt < maxAttempts)
+                {
+                    var delay = ComputeBackoffDelay(attempt);
+                    if (delay > TimeSpan.Zero)
+                    {
+                        await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+
+        await using var reader = await OpenReaderAsync().ConfigureAwait(false);
+        initialize?.Invoke(reader);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            yield return map(reader);
         }
 
         UpdateOutputParameters(command, parameters);

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -371,8 +371,9 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         }
         // Exponential backoff with jitter (full jitter)
         var factor = Math.Pow(2, Math.Max(0, attempt - 1));
-        var ms = baseDelay.TotalMilliseconds * factor;
-        var jitter = _rand.Value!.NextDouble() * baseDelay.TotalMilliseconds; // 0..base
+        var baseMilliseconds = baseDelay.TotalMilliseconds;
+        var ms = baseMilliseconds * factor;
+        var jitter = _rand.Value!.NextDouble() * baseMilliseconds; // 0..base
         var total = Math.Min(ms + jitter, MaxBackoffMilliseconds);
         return TimeSpan.FromMilliseconds(total);
     }

--- a/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
@@ -67,7 +67,7 @@ public partial class PostgreSql
     /// <summary>
     /// Asynchronously executes a SQL query and maps each row with a caller-provided mapper.
     /// </summary>
-    public virtual async Task<IReadOnlyList<T>> QueryAsync<T>(
+    public virtual Task<IReadOnlyList<T>> QueryAsync<T>(
         string host,
         string database,
         string username,
@@ -79,12 +79,12 @@ public partial class PostgreSql
         CancellationToken cancellationToken = default,
         IDictionary<string, NpgsqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
-        => await QueryAsListAsync(host, database, username, password, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+        => QueryAsListAsync(host, database, username, password, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
 
     /// <summary>
     /// Asynchronously executes a SQL query and maps each row with a caller-provided mapper.
     /// </summary>
-    public virtual async Task<IReadOnlyList<T>> QueryAsListAsync<T>(
+    public virtual Task<IReadOnlyList<T>> QueryAsListAsync<T>(
         string host,
         string database,
         string username,
@@ -102,13 +102,13 @@ public partial class PostgreSql
         if (map == null) throw new ArgumentNullException(nameof(map));
 
         var connectionString = BuildConnectionString(host, database, username, password);
-        return await QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections, initialize).ConfigureAwait(false);
+        return QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections, initialize);
     }
 
     /// <summary>
     /// Asynchronously executes a SQL query using a full PostgreSQL connection string and maps each row with a caller-provided mapper.
     /// </summary>
-    public virtual async Task<IReadOnlyList<T>> QueryAsync<T>(
+    public virtual Task<IReadOnlyList<T>> QueryAsync<T>(
         string connectionString,
         string query,
         Func<IDataRecord, T> map,
@@ -117,7 +117,7 @@ public partial class PostgreSql
         CancellationToken cancellationToken = default,
         IDictionary<string, NpgsqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
-        => await QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+        => QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
 
     /// <summary>
     /// Asynchronously executes a SQL query using a full PostgreSQL connection string and maps each row with a caller-provided mapper.

--- a/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
@@ -27,6 +27,23 @@ public partial class PostgreSql
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return await QueryAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full PostgreSQL connection string.
+    /// </summary>
+    public virtual async Task<object?> QueryAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         NpgsqlConnection? connection = null;
         NpgsqlTransaction? transaction = null;
@@ -40,6 +57,98 @@ public partial class PostgreSql
         catch (Exception ex)
         {
             throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+        }
+        finally
+        {
+            await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual async Task<IReadOnlyList<T>> QueryAsync<T>(
+        string host,
+        string database,
+        string username,
+        string password,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+        => await QueryAsListAsync(host, database, username, password, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+
+    /// <summary>
+    /// Asynchronously executes a SQL query and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual async Task<IReadOnlyList<T>> QueryAsListAsync<T>(
+        string host,
+        string database,
+        string username,
+        string password,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        var connectionString = BuildConnectionString(host, database, username, password);
+        return await QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections, initialize).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full PostgreSQL connection string and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual async Task<IReadOnlyList<T>> QueryAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+        => await QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full PostgreSQL connection string and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual async Task<IReadOnlyList<T>> QueryAsListAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        NpgsqlConnection? connection = null;
+        NpgsqlTransaction? transaction = null;
+        var dispose = false;
+        try
+        {
+            (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return await ExecuteMappedQueryAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
         }
         finally
         {

--- a/DbaClientX.PostgreSql/PostgreSql.Streaming.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.Streaming.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -28,12 +29,28 @@ public partial class PostgreSql
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         ValidateCommandText(query);
+        var connectionString = BuildConnectionString(host, database, username, password);
+        return QueryStreamAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Streams query results asynchronously from a full PostgreSQL connection string, yielding rows as they become available.
+    /// </summary>
+    public virtual IAsyncEnumerable<DataRow> QueryStreamAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
         return Stream();
 
         async IAsyncEnumerable<DataRow> Stream()
         {
-            var connectionString = BuildConnectionString(host, database, username, password);
-
             var (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             var dbTypes = ConvertParameterTypes(parameterTypes);
             try
@@ -112,6 +129,68 @@ public partial class PostgreSql
             try
             {
                 await foreach (var row in ExecuteQueryStreamAsync(connection, transaction, procedure, cancellationToken: cancellationToken, dbParameters: parameters, commandType: CommandType.StoredProcedure).ConfigureAwait(false))
+                {
+                    yield return row;
+                }
+            }
+            finally
+            {
+                await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Streams query results asynchronously through a caller-provided mapper.
+    /// </summary>
+    public virtual IAsyncEnumerable<T> QueryStreamAsync<T>(
+        string host,
+        string database,
+        string username,
+        string password,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        var connectionString = BuildConnectionString(host, database, username, password);
+        return QueryStreamAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections, initialize);
+    }
+
+    /// <summary>
+    /// Streams query results asynchronously from a full PostgreSQL connection string through a caller-provided mapper.
+    /// </summary>
+    public virtual IAsyncEnumerable<T> QueryStreamAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        return Stream();
+
+        async IAsyncEnumerable<T> Stream()
+        {
+            var (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            try
+            {
+                await foreach (var row in ExecuteMappedQueryStreamAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false))
                 {
                     yield return row;
                 }

--- a/DbaClientX.PostgreSql/PostgreSql.Streaming.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.Streaming.cs
@@ -51,8 +51,8 @@ public partial class PostgreSql
 
         async IAsyncEnumerable<DataRow> Stream()
         {
-            var (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             var dbTypes = ConvertParameterTypes(parameterTypes);
+            var (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             try
             {
                 await foreach (var row in ExecuteQueryStreamAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false))
@@ -88,9 +88,9 @@ public partial class PostgreSql
         async IAsyncEnumerable<DataRow> Stream()
         {
             var connectionString = BuildConnectionString(host, database, username, password);
+            var dbTypes = ConvertParameterTypes(parameterTypes);
 
             var (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
-            var dbTypes = ConvertParameterTypes(parameterTypes);
             try
             {
                 await foreach (var row in ExecuteQueryStreamAsync(connection, transaction, procedure, parameters, cancellationToken, dbTypes, parameterDirections, commandType: CommandType.StoredProcedure).ConfigureAwait(false))
@@ -186,8 +186,8 @@ public partial class PostgreSql
 
         async IAsyncEnumerable<T> Stream()
         {
-            var (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             var dbTypes = ConvertParameterTypes(parameterTypes);
+            var (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             try
             {
                 await foreach (var row in ExecuteMappedQueryStreamAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false))

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -2,6 +2,7 @@ using System;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
+using DBAClientX.Invoker;
 using Npgsql;
 
 namespace DBAClientX;
@@ -118,9 +119,10 @@ public partial class PostgreSql : DatabaseClientBase
 
     private static void ValidateConnectionString(string connectionString)
     {
-        if (string.IsNullOrWhiteSpace(connectionString))
+        var validationResult = DbaConnectionFactory.Validate("postgresql", connectionString);
+        if (!validationResult.IsValid)
         {
-            throw new ArgumentException("Connection string cannot be null or whitespace.", nameof(connectionString));
+            throw new ArgumentException(DbaConnectionFactory.ToUserMessage(validationResult), nameof(connectionString));
         }
 
         _ = NormalizeConnectionString(connectionString);

--- a/DbaClientX.PostgreSql/PostgreSql.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.cs
@@ -116,6 +116,16 @@ public partial class PostgreSql : DatabaseClientBase
     private static string NormalizeConnectionString(string connectionString)
         => new NpgsqlConnectionStringBuilder(connectionString).ConnectionString;
 
+    private static void ValidateConnectionString(string connectionString)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new ArgumentException("Connection string cannot be null or whitespace.", nameof(connectionString));
+        }
+
+        _ = NormalizeConnectionString(connectionString);
+    }
+
     private static void ValidateRequiredConnectionValue(string value, string paramName, string displayName)
     {
         if (string.IsNullOrWhiteSpace(value))

--- a/DbaClientX.PostgreSql/README.md
+++ b/DbaClientX.PostgreSql/README.md
@@ -2,7 +2,7 @@
 
 PostgreSQL provider for DbaClientX. Simple API over Npgsql with streaming, retries, and transactions.
 
-- Target Frameworks: `net8.0`, `net472`
+- Target Frameworks: `net472`, `net8.0`, `net10.0`
 - NuGet: `DBAClientX.PostgreSql`
 
 ## Install
@@ -36,7 +36,26 @@ await foreach (DataRow row in pg.QueryStreamAsync(
 }
 ```
 
+Typed mapped query:
+
+```csharp
+int idOrdinal = -1;
+int nameOrdinal = -1;
+var rows = await pg.QueryAsListAsync(
+    connectionString: "Host=localhost;Database=app;Username=user;Password=p@ss;SSL Mode=Require",
+    query: "SELECT id, name FROM public.users ORDER BY id",
+    initialize: row => {
+        idOrdinal = row.GetOrdinal("id");
+        nameOrdinal = row.GetOrdinal("name");
+    },
+    map: row => new UserRow(
+        Id: row.GetInt32(idOrdinal),
+        Name: row.IsDBNull(nameOrdinal) ? null : row.GetString(nameOrdinal)),
+    cancellationToken: ct);
+```
+
+For larger result sets, use `QueryStreamAsync<T>` with the same mapper shape to avoid buffering all rows.
+
 ## See also
 
 - Core mapping + invoker: `DBAClientX.Core`
-

--- a/DbaClientX.Tests/DatabaseClientBaseOutputParameterTests.cs
+++ b/DbaClientX.Tests/DatabaseClientBaseOutputParameterTests.cs
@@ -20,6 +20,22 @@ public class DatabaseClientBaseOutputParameterTests
 
         public Task<object?> RunQueryAsync(DbConnection connection, IDictionary<string, object?> parameters, IDictionary<string, ParameterDirection> directions)
             => ExecuteQueryAsync(connection, null, "q", parameters, parameterDirections: directions);
+
+        public Task<IReadOnlyList<T>> RunMappedQueryAsync<T>(
+            DbConnection connection,
+            Func<IDataRecord, T> map,
+            Action<IDataRecord>? initialize = null,
+            IDictionary<string, object?>? parameters = null,
+            IDictionary<string, ParameterDirection>? directions = null)
+            => ExecuteMappedQueryAsync(connection, null, "q", map, initialize, parameters, parameterDirections: directions);
+
+        public IAsyncEnumerable<T> RunMappedStream<T>(
+            DbConnection connection,
+            Func<IDataRecord, T> map,
+            Action<IDataRecord>? initialize = null,
+            IDictionary<string, object?>? parameters = null,
+            IDictionary<string, ParameterDirection>? directions = null)
+            => ExecuteMappedQueryStreamAsync(connection, null, "q", map, initialize, parameters, parameterDirections: directions);
     }
 
     private sealed class FakeConnection : DbConnection
@@ -252,5 +268,69 @@ public class DatabaseClientBaseOutputParameterTests
         Assert.Single(parameters);
         Assert.True(parameters.ContainsKey("@Out"));
         Assert.Equal(5, parameters["@Out"]);
+    }
+
+    [Fact]
+    public async Task ExecuteMappedQueryAsync_MapsRowsAndRunsInitializer()
+    {
+        using var client = new TestClient();
+        using var connection = new FakeConnection();
+        var initializeCount = 0;
+        var idOrdinal = -1;
+
+        IReadOnlyList<int> rows = await client.RunMappedQueryAsync(
+            connection,
+            record => record.GetInt32(idOrdinal),
+            record => {
+                initializeCount++;
+                idOrdinal = record.GetOrdinal("id");
+            });
+
+        Assert.Equal(new[] { 1 }, rows);
+        Assert.Equal(1, initializeCount);
+        Assert.Equal(0, idOrdinal);
+    }
+
+    [Fact]
+    public async Task ExecuteMappedQueryAsync_UpdatesOutputParameters()
+    {
+        using var client = new TestClient();
+        using var connection = new FakeConnection();
+        var parameters = new Dictionary<string, object?> { ["@out"] = null };
+        var directions = new Dictionary<string, ParameterDirection> { ["@out"] = ParameterDirection.Output };
+
+        IReadOnlyList<int> rows = await client.RunMappedQueryAsync(
+            connection,
+            record => record.GetInt32(0),
+            parameters: parameters,
+            directions: directions);
+
+        Assert.Equal(new[] { 1 }, rows);
+        Assert.Equal(5, parameters["@out"]);
+    }
+
+    [Fact]
+    public async Task ExecuteMappedQueryStreamAsync_MapsRowsAndRunsInitializer()
+    {
+        using var client = new TestClient();
+        using var connection = new FakeConnection();
+        var rows = new List<int>();
+        var initializeCount = 0;
+        var idOrdinal = -1;
+
+        await foreach (int row in client.RunMappedStream(
+            connection,
+            record => record.GetInt32(idOrdinal),
+            record => {
+                initializeCount++;
+                idOrdinal = record.GetOrdinal("id");
+            }))
+        {
+            rows.Add(row);
+        }
+
+        Assert.Equal(new[] { 1 }, rows);
+        Assert.Equal(1, initializeCount);
+        Assert.Equal(0, idOrdinal);
     }
 }

--- a/DbaClientX.Tests/PostgreSqlQueryStreamTests.cs
+++ b/DbaClientX.Tests/PostgreSqlQueryStreamTests.cs
@@ -71,7 +71,7 @@ public class PostgreSqlQueryStreamTests
     public void QueryStreamAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
     {
         using var pg = new OpenFailurePg();
-        const string connectionString = "Host=127.0.0.1;Port=1;Database=certwatch;Username=guest;Password=;SSL Mode=Disable";
+        const string connectionString = "Host=127.0.0.1;Port=65432;Database=certwatch;Username=guest;Password=;SSL Mode=Require";
 
         Assert.Throws<ArgumentNullException>(() =>
             pg.QueryStreamAsync<int>(connectionString, "SELECT 1", null!));

--- a/DbaClientX.Tests/PostgreSqlQueryStreamTests.cs
+++ b/DbaClientX.Tests/PostgreSqlQueryStreamTests.cs
@@ -66,4 +66,17 @@ public class PostgreSqlQueryStreamTests
         Assert.Equal(0, pg.SyncDisposeCalls);
         Assert.Equal(1, pg.AsyncDisposeCalls);
     }
+
+    [Fact]
+    public void QueryStreamAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
+    {
+        using var pg = new OpenFailurePg();
+        const string connectionString = "Host=127.0.0.1;Port=1;Database=certwatch;Username=guest;Password=;SSL Mode=Disable";
+
+        Assert.Throws<ArgumentNullException>(() =>
+            pg.QueryStreamAsync<int>(connectionString, "SELECT 1", null!));
+
+        Assert.Equal(0, pg.SyncDisposeCalls);
+        Assert.Equal(0, pg.AsyncDisposeCalls);
+    }
 }

--- a/DbaClientX.Tests/PostgreSqlTests.cs
+++ b/DbaClientX.Tests/PostgreSqlTests.cs
@@ -553,7 +553,7 @@ public class PostgreSqlTests
     public async Task QueryAsync_WithConnectionString_UsesProvidedSettings()
     {
         using var pg = new DBAClientX.PostgreSql();
-        const string connectionString = "Host=127.0.0.1;Port=1;Database=certwatch;Username=guest;Password=;SSL Mode=Disable;Timeout=1;Command Timeout=1";
+        const string connectionString = "Host=127.0.0.1;Port=65432;Database=certwatch;Username=guest;Password=;SSL Mode=Require;Timeout=1;Command Timeout=1";
 
         var exception = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(() =>
             pg.QueryAsync(connectionString, "SELECT 1"));
@@ -566,11 +566,26 @@ public class PostgreSqlTests
     public async Task QueryAsListAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
     {
         using var pg = new OpenFailurePostgreSql();
-        const string connectionString = "Host=127.0.0.1;Port=1;Database=certwatch;Username=guest;Password=;SSL Mode=Disable";
+        const string connectionString = "Host=127.0.0.1;Port=65432;Database=certwatch;Username=guest;Password=;SSL Mode=Require";
 
         await Assert.ThrowsAsync<ArgumentNullException>(() =>
             pg.QueryAsListAsync<int>(connectionString, "SELECT 1", null!));
 
+        Assert.Equal(0, pg.SyncDisposeCalls);
+        Assert.Equal(0, pg.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task QueryAsync_WithInsecureConnectionString_ThrowsBeforeOpeningConnection()
+    {
+        using var pg = new OpenFailurePostgreSql();
+        const string connectionString = "Host=db.example.com;Database=certwatch;Username=guest;Password=;SSL Mode=Disable";
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            pg.QueryAsync(connectionString, "SELECT 1"));
+
+        Assert.Equal("connectionString", exception.ParamName);
+        Assert.Contains("require SSL", exception.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(0, pg.SyncDisposeCalls);
         Assert.Equal(0, pg.AsyncDisposeCalls);
     }

--- a/DbaClientX.Tests/PostgreSqlTests.cs
+++ b/DbaClientX.Tests/PostgreSqlTests.cs
@@ -550,6 +550,32 @@ public class PostgreSqlTests
     }
 
     [Fact]
+    public async Task QueryAsync_WithConnectionString_UsesProvidedSettings()
+    {
+        using var pg = new DBAClientX.PostgreSql();
+        const string connectionString = "Host=127.0.0.1;Port=1;Database=certwatch;Username=guest;Password=;SSL Mode=Disable;Timeout=1;Command Timeout=1";
+
+        var exception = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(() =>
+            pg.QueryAsync(connectionString, "SELECT 1"));
+
+        Assert.Contains("SELECT 1", exception.Message);
+        Assert.IsNotType<ArgumentException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task QueryAsListAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
+    {
+        using var pg = new OpenFailurePostgreSql();
+        const string connectionString = "Host=127.0.0.1;Port=1;Database=certwatch;Username=guest;Password=;SSL Mode=Disable";
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            pg.QueryAsListAsync<int>(connectionString, "SELECT 1", null!));
+
+        Assert.Equal(0, pg.SyncDisposeCalls);
+        Assert.Equal(0, pg.AsyncDisposeCalls);
+    }
+
+    [Fact]
     public void ExecuteStoredProcedure_WithEmptyProcedure_Throws()
     {
         using var pg = new DBAClientX.PostgreSql();


### PR DESCRIPTION
## Summary
- add PostgreSQL connection-string query overloads for async and streaming reads
- add AOT-friendly typed row mapping APIs without reflection
- document typed mapped query usage and add focused PostgreSQL tests

## Verification
- dotnet test DbaClientX.Tests\DbaClientX.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~PostgreSql"
- dotnet build DbaClientX.PostgreSql\DbaClientX.PostgreSql.csproj -m:1
- dotnet build DbaClientX.sln -m:1
