### PR TITLE
Update package dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,11 +11,11 @@
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
     <PackageVersion Include="MySqlConnector" Version="2.5.0" />
-    <PackageVersion Include="Oracle.ManagedDataAccess" Version="23.26.100" />
-    <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.26.100" />
+    <PackageVersion Include="Oracle.ManagedDataAccess" Version="23.26.200" />
+    <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.26.200" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.5" />
     <PackageVersion Include="System.Text.Json" Version="10.0.5" />
@@ -24,8 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Keep these conditional pins aligned with the TFMs each provider still ships assets for. -->
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.14" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.5.5" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.6.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageVersion Include="Npgsql" Version="8.0.9" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageVersion Include="Npgsql" Version="10.0.2" Condition="'$(TargetFramework)' != 'net472'" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Bump Microsoft.NET.Test.Sdk from 18.3.0 to 18.4.0.
- Bump Oracle.ManagedDataAccess and Oracle.ManagedDataAccess.Core from 23.26.100 to 23.26.200.
- Bump Microsoft.PowerShell.SDK for net10.0 test coverage from 7.5.5 to 7.6.0.
- Leave Microsoft.Data.SqlClient on 7.0.0, which is already the latest release and carries the reduced dependency graph.
- Keep compatibility-conditioned pins for net8.0 PowerShell SDK and net472 Npgsql, since newer package lines no longer ship the matching reference/assets for those TFMs.

## PowerShell compatibility note
The published PowerShell module project references PowerShellStandard.Library and is packaged for net472 and net8.0. The Microsoft.PowerShell.SDK bump in this PR applies to the test project net10.0 graph, not the shipped PowerShell binary module. That keeps the module aligned with Windows PowerShell 5.1 via net472 and the current PowerShell 7 line via net8.0.

## Validation
- dotnet restore DbaClientX.sln
- dotnet list DbaClientX.sln package --outdated
- dotnet build DbaClientX.sln --no-restore -c Release
- dotnet test DbaClientX.sln --no-build -c Release
- Imported DBAClientX.PowerShell.dll directly from the Release net8.0 build under local PowerShell 7.5.5
- Imported DBAClientX.PowerShell.dll directly from the Release net472 build under local Windows PowerShell 5.1
