### PR TITLE
Improve provider parity and connection handling

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -481,7 +481,15 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         };
     }
 
-    private static bool TryGetDictionaryValue<TValue>(IDictionary<string, TValue>? dictionary, string key, out TValue value)
+    /// <summary>
+    /// Looks up a dictionary value using the supplied key, falling back to a case-insensitive comparison.
+    /// </summary>
+    /// <typeparam name="TValue">The dictionary value type.</typeparam>
+    /// <param name="dictionary">The dictionary to inspect.</param>
+    /// <param name="key">The key to find.</param>
+    /// <param name="value">The value when a matching key is found.</param>
+    /// <returns><c>true</c> when the key is present; otherwise, <c>false</c>.</returns>
+    protected static bool TryGetDictionaryValue<TValue>(IDictionary<string, TValue>? dictionary, string key, out TValue value)
     {
         value = default!;
         if (dictionary == null)
@@ -551,7 +559,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             }
 
             object? result;
-            using (var reader = command.ExecuteReader())
+            using (var reader = command.ExecuteReader(CommandBehavior.SequentialAccess))
             {
                 var returnType = ReturnType;
                 if (returnType == ReturnType.DataRow)
@@ -694,7 +702,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             }
 
             object? result;
-            using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+            using (var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false))
             {
                 var returnType = ReturnType;
                 if (returnType == ReturnType.DataRow)
@@ -789,7 +797,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             }
 
             var rows = new List<T>();
-            using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+            using (var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false))
             {
                 initialize?.Invoke(reader);
                 while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -928,7 +936,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             {
                 try
                 {
-                    return await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                    return await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (IsTransient(ex) && ++attempt < maxAttempts)
                 {
@@ -1018,7 +1026,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             {
                 try
                 {
-                    return await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                    return await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (IsTransient(ex) && ++attempt < maxAttempts)
                 {

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -1026,7 +1026,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             {
                 try
                 {
-                    return await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
+                    return await command.ExecuteReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (IsTransient(ex) && ++attempt < maxAttempts)
                 {

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -797,7 +797,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             }
 
             var rows = new List<T>();
-            using (var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false))
+            using (var reader = await command.ExecuteReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false))
             {
                 initialize?.Invoke(reader);
                 while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))

--- a/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
+++ b/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
@@ -65,7 +65,7 @@ public static class DbaConnectionFactory
 
     private static readonly Dictionary<string, ProviderValidationProfile> ProviderProfiles = new(StringComparer.OrdinalIgnoreCase)
     {
-        ["sqlserver"] = new("sqlserver", RequiredServerAndDatabase),
+        ["sqlserver"] = new("sqlserver", RequiredServerAndDatabase, ValidateSqlServerOptions),
         ["postgresql"] = new("postgresql", RequiredServerAndDatabase, builder => ValidatePortRange(builder) ?? ValidatePostgreSqlOptions(builder)),
         ["mysql"] = new("mysql", RequiredServerAndDatabase, builder => ValidatePortRange(builder) ?? ValidateMySqlOptions(builder)),
         ["sqlite"] = new("sqlite", new List<string[]>
@@ -245,18 +245,43 @@ public static class DbaConnectionFactory
         return null;
     }
 
+    private static ConnectionValidationResult? ValidateSqlServerOptions(DbConnectionStringBuilder builder)
+    {
+        foreach (var key in new[] { "Encrypt", "Encryption" })
+        {
+            if (builder.TryGetValue(key, out var encrypt) && encrypt is string encryptValue)
+            {
+                if (encryptValue.Equals("False", StringComparison.OrdinalIgnoreCase)
+                    || encryptValue.Equals("No", StringComparison.OrdinalIgnoreCase)
+                    || encryptValue.Equals("Optional", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new ConnectionValidationResult(ConnectionValidationErrorCode.UnsupportedOption, "SQL Server connections must use encryption (Encrypt cannot be False, No, or Optional).", key);
+                }
+            }
+        }
+
+        return null;
+    }
+
     private static ConnectionValidationResult? ValidateMySqlOptions(DbConnectionStringBuilder builder)
     {
+        var sslModeSpecified = false;
         foreach (var key in new[] { "SslMode", "SSL Mode" })
         {
             if (builder.TryGetValue(key, out var sslMode) && sslMode is string sslValue)
             {
+                sslModeSpecified = true;
                 if (sslValue.Equals("None", StringComparison.OrdinalIgnoreCase)
                     || sslValue.Equals("Preferred", StringComparison.OrdinalIgnoreCase))
                 {
                     return new ConnectionValidationResult(ConnectionValidationErrorCode.UnsupportedOption, "MySQL connections must require SSL (SslMode cannot be None or Preferred).", key);
                 }
             }
+        }
+
+        if (!sslModeSpecified)
+        {
+            return new ConnectionValidationResult(ConnectionValidationErrorCode.MissingRequiredParameter, "MySQL connections must explicitly require SSL (SslMode must be Required or Verify*).", "SslMode");
         }
 
         return null;

--- a/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
+++ b/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
@@ -271,7 +271,13 @@ public static class DbaConnectionFactory
             if (builder.TryGetValue(key, out var sslMode))
             {
                 sslModeSpecified = true;
-                var sslValue = Convert.ToString(sslMode)?.Trim();
+                var sslValue = Convert.ToString(sslMode);
+                if (string.IsNullOrWhiteSpace(sslValue))
+                {
+                    return new ConnectionValidationResult(ConnectionValidationErrorCode.MissingRequiredParameter, "MySQL connections must explicitly require SSL (SslMode must be Required or Verify*).", key);
+                }
+
+                sslValue = sslValue.Trim();
                 if (!IsMySqlSslModeEnforcing(sslValue))
                 {
                     return new ConnectionValidationResult(ConnectionValidationErrorCode.UnsupportedOption, "MySQL connections must require SSL (SslMode must be Required, VerifyCA, or VerifyFull).", key);
@@ -295,7 +301,13 @@ public static class DbaConnectionFactory
             if (builder.TryGetValue(key, out var sslMode))
             {
                 sslModeSpecified = true;
-                var sslValue = Convert.ToString(sslMode)?.Trim();
+                var sslValue = Convert.ToString(sslMode);
+                if (string.IsNullOrWhiteSpace(sslValue))
+                {
+                    return new ConnectionValidationResult(ConnectionValidationErrorCode.MissingRequiredParameter, "PostgreSQL connections must explicitly require SSL (SslMode must be Require or Verify*).", key);
+                }
+
+                sslValue = sslValue.Trim();
                 if (!IsPostgreSqlSslModeEnforcing(sslValue))
                 {
                     return new ConnectionValidationResult(ConnectionValidationErrorCode.UnsupportedOption, "PostgreSQL connections must require SSL (SslMode must be Require, VerifyCA, or VerifyFull).", key);

--- a/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
+++ b/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
@@ -268,13 +268,13 @@ public static class DbaConnectionFactory
         var sslModeSpecified = false;
         foreach (var key in new[] { "SslMode", "SSL Mode" })
         {
-            if (builder.TryGetValue(key, out var sslMode) && sslMode is string sslValue)
+            if (builder.TryGetValue(key, out var sslMode))
             {
                 sslModeSpecified = true;
-                if (sslValue.Equals("None", StringComparison.OrdinalIgnoreCase)
-                    || sslValue.Equals("Preferred", StringComparison.OrdinalIgnoreCase))
+                var sslValue = Convert.ToString(sslMode)?.Trim();
+                if (!IsMySqlSslModeEnforcing(sslValue))
                 {
-                    return new ConnectionValidationResult(ConnectionValidationErrorCode.UnsupportedOption, "MySQL connections must require SSL (SslMode cannot be None or Preferred).", key);
+                    return new ConnectionValidationResult(ConnectionValidationErrorCode.UnsupportedOption, "MySQL connections must require SSL (SslMode must be Required, VerifyCA, or VerifyFull).", key);
                 }
             }
         }
@@ -292,14 +292,13 @@ public static class DbaConnectionFactory
         var sslModeSpecified = false;
         foreach (var key in new[] { "SslMode", "SSL Mode" })
         {
-            if (builder.TryGetValue(key, out var sslMode) && sslMode is string sslValue)
+            if (builder.TryGetValue(key, out var sslMode))
             {
                 sslModeSpecified = true;
-                if (sslValue.Equals("Disable", StringComparison.OrdinalIgnoreCase)
-                    || sslValue.Equals("Allow", StringComparison.OrdinalIgnoreCase)
-                    || sslValue.Equals("Prefer", StringComparison.OrdinalIgnoreCase))
+                var sslValue = Convert.ToString(sslMode)?.Trim();
+                if (!IsPostgreSqlSslModeEnforcing(sslValue))
                 {
-                    return new ConnectionValidationResult(ConnectionValidationErrorCode.UnsupportedOption, "PostgreSQL connections must require SSL (SslMode cannot be Disable, Allow, or Prefer).", key);
+                    return new ConnectionValidationResult(ConnectionValidationErrorCode.UnsupportedOption, "PostgreSQL connections must require SSL (SslMode must be Require, VerifyCA, or VerifyFull).", key);
                 }
             }
         }
@@ -311,6 +310,18 @@ public static class DbaConnectionFactory
 
         return null;
     }
+
+    private static bool IsMySqlSslModeEnforcing(string? sslMode)
+        => sslMode is not null
+           && (sslMode.Equals("Required", StringComparison.OrdinalIgnoreCase)
+               || sslMode.Equals("VerifyCA", StringComparison.OrdinalIgnoreCase)
+               || sslMode.Equals("VerifyFull", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsPostgreSqlSslModeEnforcing(string? sslMode)
+        => sslMode is not null
+           && (sslMode.Equals("Require", StringComparison.OrdinalIgnoreCase)
+               || sslMode.Equals("VerifyCA", StringComparison.OrdinalIgnoreCase)
+               || sslMode.Equals("VerifyFull", StringComparison.OrdinalIgnoreCase));
 
     private static ConnectionValidationResult? ValidateDisallowedOptions(DbConnectionStringBuilder builder)
     {

--- a/DbaClientX.MySql/MySql.AsyncCommandExecution.cs
+++ b/DbaClientX.MySql/MySql.AsyncCommandExecution.cs
@@ -27,6 +27,23 @@ public partial class MySql
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return await QueryAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a SQL query asynchronously using a full MySQL connection string.
+    /// </summary>
+    public virtual async Task<object?> QueryAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         MySqlConnection? connection = null;
         MySqlTransaction? transaction = null;
@@ -40,6 +57,98 @@ public partial class MySql
         catch (Exception ex)
         {
             throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+        }
+        finally
+        {
+            await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Executes a SQL query asynchronously and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual Task<IReadOnlyList<T>> QueryAsync<T>(
+        string host,
+        string database,
+        string username,
+        string password,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+        => QueryAsListAsync(host, database, username, password, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
+
+    /// <summary>
+    /// Executes a SQL query asynchronously and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual Task<IReadOnlyList<T>> QueryAsListAsync<T>(
+        string host,
+        string database,
+        string username,
+        string password,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        var connectionString = BuildConnectionString(host, database, username, password);
+        return QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections, initialize);
+    }
+
+    /// <summary>
+    /// Executes a SQL query asynchronously using a full MySQL connection string and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual Task<IReadOnlyList<T>> QueryAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+        => QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
+
+    /// <summary>
+    /// Executes a SQL query asynchronously using a full MySQL connection string and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual async Task<IReadOnlyList<T>> QueryAsListAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        MySqlConnection? connection = null;
+        MySqlTransaction? transaction = null;
+        var dispose = false;
+        try
+        {
+            (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return await ExecuteMappedQueryAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
         }
         finally
         {
@@ -67,7 +176,10 @@ public partial class MySql
         return await ExecuteNonQueryAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
     }
 
-    internal virtual async Task<int> ExecuteNonQueryAsync(
+    /// <summary>
+    /// Executes a SQL statement that does not produce a result set asynchronously using a full MySQL connection string.
+    /// </summary>
+    public virtual async Task<int> ExecuteNonQueryAsync(
         string connectionString,
         string query,
         IDictionary<string, object?>? parameters = null,
@@ -76,6 +188,7 @@ public partial class MySql
         IDictionary<string, MySqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
+        ValidateConnectionString(connectionString);
         ValidateCommandText(query);
         MySqlConnection? connection = null;
         MySqlTransaction? transaction = null;
@@ -113,6 +226,23 @@ public partial class MySql
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return await ExecuteScalarAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes a SQL query asynchronously using a full MySQL connection string and returns the first column of the first row in the result set.
+    /// </summary>
+    public virtual async Task<object?> ExecuteScalarAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         MySqlConnection? connection = null;
         MySqlTransaction? transaction = null;

--- a/DbaClientX.MySql/MySql.CommandExecution.cs
+++ b/DbaClientX.MySql/MySql.CommandExecution.cs
@@ -11,9 +11,9 @@ public partial class MySql
     private sealed class MySqlParameterTypeMap : Dictionary<string, DbType>
     {
         public MySqlParameterTypeMap(IDictionary<string, MySqlDbType> providerTypes)
-            : base(providerTypes.Count, StringComparer.Ordinal)
+            : base(providerTypes.Count, StringComparer.OrdinalIgnoreCase)
         {
-            ProviderTypes = new Dictionary<string, MySqlDbType>(providerTypes, StringComparer.Ordinal);
+            ProviderTypes = new Dictionary<string, MySqlDbType>(providerTypes, StringComparer.OrdinalIgnoreCase);
             foreach (var pair in providerTypes)
             {
                 var parameter = new MySqlParameter { MySqlDbType = pair.Value };
@@ -21,7 +21,7 @@ public partial class MySql
             }
         }
 
-        public IReadOnlyDictionary<string, MySqlDbType> ProviderTypes { get; }
+        public IDictionary<string, MySqlDbType> ProviderTypes { get; }
     }
 
     /// <summary>
@@ -40,6 +40,22 @@ public partial class MySql
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return Query(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a SQL query using a full MySQL connection string and materializes the result using the shared pipeline.
+    /// </summary>
+    public virtual object? Query(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         MySqlConnection? connection = null;
         MySqlTransaction? transaction = null;
@@ -79,6 +95,22 @@ public partial class MySql
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return ExecuteScalar(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a SQL query using a full MySQL connection string and returns the first column of the first row in the result set.
+    /// </summary>
+    public virtual object? ExecuteScalar(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         MySqlConnection? connection = null;
         MySqlTransaction? transaction = null;
@@ -121,7 +153,10 @@ public partial class MySql
         return ExecuteNonQuery(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
     }
 
-    internal virtual int ExecuteNonQuery(
+    /// <summary>
+    /// Executes a SQL statement that does not produce a result set using a full MySQL connection string.
+    /// </summary>
+    public virtual int ExecuteNonQuery(
         string connectionString,
         string query,
         IDictionary<string, object?>? parameters = null,
@@ -129,6 +164,7 @@ public partial class MySql
         IDictionary<string, MySqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
+        ValidateConnectionString(connectionString);
         ValidateCommandText(query);
         MySqlConnection? connection = null;
         MySqlTransaction? transaction = null;
@@ -209,11 +245,11 @@ public partial class MySql
                 Value = value
             };
 
-            if (mySqlTypes.ProviderTypes.TryGetValue(pair.Key, out var providerType))
+            if (TryGetDictionaryValue(mySqlTypes.ProviderTypes, pair.Key, out var providerType))
             {
                 parameter.MySqlDbType = providerType;
             }
-            else if (parameterTypes.TryGetValue(pair.Key, out var explicitType))
+            else if (TryGetDictionaryValue(parameterTypes, pair.Key, out var explicitType))
             {
                 parameter.DbType = explicitType;
             }
@@ -222,7 +258,7 @@ public partial class MySql
                 parameter.DbType = InferParameterDbType(value);
             }
 
-            if (parameterDirections != null && parameterDirections.TryGetValue(pair.Key, out var direction))
+            if (TryGetDictionaryValue(parameterDirections, pair.Key, out var direction))
             {
                 parameter.Direction = direction;
             }

--- a/DbaClientX.MySql/MySql.StoredProcedures.cs
+++ b/DbaClientX.MySql/MySql.StoredProcedures.cs
@@ -26,6 +26,22 @@ public partial class MySql
     {
         ValidateCommandText(procedure, CommandType.StoredProcedure);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return ExecuteStoredProcedure(connectionString, procedure, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a stored procedure using a full MySQL connection string and returns the aggregated results.
+    /// </summary>
+    public virtual object? ExecuteStoredProcedure(
+        string connectionString,
+        string procedure,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
 
         MySqlConnection? connection = null;
         MySqlTransaction? transaction = null;
@@ -43,7 +59,7 @@ public partial class MySql
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = command.ExecuteReader();
+            using var reader = command.ExecuteReader(CommandBehavior.SequentialAccess);
             var tableIndex = 0;
             do
             {
@@ -91,7 +107,10 @@ public partial class MySql
         return await ExecuteStoredProcedureAsync(connectionString, procedure, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
     }
 
-    internal virtual async Task<object?> ExecuteStoredProcedureAsync(
+    /// <summary>
+    /// Executes a stored procedure asynchronously using a full MySQL connection string and returns the aggregated results.
+    /// </summary>
+    public virtual async Task<object?> ExecuteStoredProcedureAsync(
         string connectionString,
         string procedure,
         IDictionary<string, object?>? parameters = null,
@@ -100,6 +119,9 @@ public partial class MySql
         IDictionary<string, MySqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
+
         MySqlConnection? connection = null;
         MySqlTransaction? transaction = null;
         var dispose = false;
@@ -116,7 +138,7 @@ public partial class MySql
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             var tableIndex = 0;
             do
             {
@@ -171,7 +193,7 @@ public partial class MySql
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = command.ExecuteReader();
+            using var reader = command.ExecuteReader(CommandBehavior.SequentialAccess);
             var tableIndex = 0;
             do
             {
@@ -228,7 +250,7 @@ public partial class MySql
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             var tableIndex = 0;
             do
             {

--- a/DbaClientX.MySql/MySql.Streaming.cs
+++ b/DbaClientX.MySql/MySql.Streaming.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -27,12 +28,28 @@ public partial class MySql
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         ValidateCommandText(query);
+        var connectionString = BuildConnectionString(host, database, username, password);
+        return QueryStreamAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Streams rows produced by a query asynchronously from a full MySQL connection string.
+    /// </summary>
+    public virtual IAsyncEnumerable<DataRow> QueryStreamAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
         return Stream();
 
         async IAsyncEnumerable<DataRow> Stream()
         {
-            var connectionString = BuildConnectionString(host, database, username, password);
-
             MySqlConnection? connection = null;
             MySqlTransaction? transaction = null;
             var dispose = false;
@@ -42,6 +59,68 @@ public partial class MySql
             try
             {
                 await foreach (var row in ExecuteQueryStreamAsync(connection!, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false))
+                {
+                    yield return row;
+                }
+            }
+            finally
+            {
+                await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Streams rows produced by a query asynchronously through a caller-provided mapper.
+    /// </summary>
+    public virtual IAsyncEnumerable<T> QueryStreamAsync<T>(
+        string host,
+        string database,
+        string username,
+        string password,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        var connectionString = BuildConnectionString(host, database, username, password);
+        return QueryStreamAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections, initialize);
+    }
+
+    /// <summary>
+    /// Streams rows produced by a query asynchronously from a full MySQL connection string through a caller-provided mapper.
+    /// </summary>
+    public virtual IAsyncEnumerable<T> QueryStreamAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, MySqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        return Stream();
+
+        async IAsyncEnumerable<T> Stream()
+        {
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            var (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await foreach (var row in ExecuteMappedQueryStreamAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false))
                 {
                     yield return row;
                 }

--- a/DbaClientX.MySql/MySql.cs
+++ b/DbaClientX.MySql/MySql.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
+using DBAClientX.Invoker;
 using MySqlConnector;
 
 namespace DBAClientX;
@@ -129,6 +130,17 @@ public partial class MySql : DatabaseClientBase
 
     private static string NormalizeConnectionString(string connectionString)
         => new MySqlConnectionStringBuilder(connectionString).ConnectionString;
+
+    private static void ValidateConnectionString(string connectionString)
+    {
+        var validationResult = DbaConnectionFactory.Validate("mysql", connectionString);
+        if (!validationResult.IsValid)
+        {
+            throw new ArgumentException(DbaConnectionFactory.ToUserMessage(validationResult), nameof(connectionString));
+        }
+
+        _ = NormalizeConnectionString(connectionString);
+    }
 
     private static void ValidateRequiredConnectionValue(string value, string paramName, string displayName)
     {

--- a/DbaClientX.MySql/README.md
+++ b/DbaClientX.MySql/README.md
@@ -35,7 +35,49 @@ await foreach (DataRow row in my.ExecuteStoredProcedureStreamAsync(
 }
 ```
 
+Typed mapped query:
+
+```csharp
+var rows = await my.QueryAsListAsync(
+    connectionString: "Server=localhost;Database=app;User ID=user;Password=p@ss;SslMode=Required",
+    query: "SELECT id, name FROM users ORDER BY id",
+    map: row => new UserRow(
+        Id: row.GetInt32(row.GetOrdinal("id")),
+        Name: row.GetString(row.GetOrdinal("name"))),
+    cancellationToken: ct);
+```
+
+For larger result sets, use `QueryStreamAsync<T>` with the same mapper shape to avoid buffering all rows.
+
+Non-query from a full connection string:
+
+```csharp
+await my.ExecuteNonQueryAsync(
+    connectionString: "Server=localhost;Database=app;User ID=user;Password=p@ss;SslMode=Required",
+    query: "UPDATE users SET last_seen=UTC_TIMESTAMP() WHERE id=@id",
+    parameters: new Dictionary<string, object?> { ["@id"] = 1 },
+    cancellationToken: ct);
+```
+
+Scalar from a full connection string:
+
+```csharp
+var count = await my.ExecuteScalarAsync(
+    connectionString: "Server=localhost;Database=app;User ID=user;Password=p@ss;SslMode=Required",
+    query: "SELECT COUNT(*) FROM users",
+    cancellationToken: ct);
+```
+
+Stored procedure from a full connection string:
+
+```csharp
+var result = await my.ExecuteStoredProcedureAsync(
+    connectionString: "Server=localhost;Database=app;User ID=user;Password=p@ss;SslMode=Required",
+    procedure: "get_recent_users",
+    parameters: new Dictionary<string, object?> { ["p_limit"] = 100 },
+    cancellationToken: ct);
+```
+
 ## See also
 
 - Core mapping + invoker: `DBAClientX.Core`
-

--- a/DbaClientX.Oracle/GenericExecutors.cs
+++ b/DbaClientX.Oracle/GenericExecutors.cs
@@ -12,6 +12,8 @@ namespace DBAClientX.OracleGeneric;
 /// </summary>
 public static class GenericExecutors
 {
+    internal static Func<DBAClientX.Oracle> ClientFactory { get; set; } = static () => new DBAClientX.Oracle();
+
     /// <summary>Executes a parameterized SQL statement.</summary>
     /// <param name="host">Oracle host name or address.</param>
     /// <param name="serviceName">Oracle service or SID.</param>
@@ -21,11 +23,11 @@ public static class GenericExecutors
     /// <param name="parameters">Parameter name/value map.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of affected rows.</returns>
-    public static Task<int> ExecuteSqlAsync(string host, string serviceName, string username, string password, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
+    public static async Task<int> ExecuteSqlAsync(string host, string serviceName, string username, string password, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
     {
         ValidateCommandText(sql, nameof(sql), "SQL text");
-        var cli = new DBAClientX.Oracle();
-        return cli.ExecuteNonQueryAsync(host, serviceName, username, password, sql, parameters, cancellationToken: ct);
+        using var cli = ClientFactory();
+        return await cli.ExecuteNonQueryAsync(host, serviceName, username, password, sql, parameters, cancellationToken: ct).ConfigureAwait(false);
     }
 
     /// <summary>Executes a parameterized SQL statement using a connection string.</summary>
@@ -34,14 +36,12 @@ public static class GenericExecutors
     /// <param name="parameters">Parameter name/value map.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of affected rows.</returns>
-    public static Task<int> ExecuteSqlAsync(string connectionString, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
+    public static async Task<int> ExecuteSqlAsync(string connectionString, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
     {
         ValidateConnectionString(connectionString);
         ValidateCommandText(sql, nameof(sql), "SQL text");
-        var b = new global::Oracle.ManagedDataAccess.Client.OracleConnectionStringBuilder(connectionString);
-        var (host, service) = SplitDataSource(b.DataSource);
-        var cli = new DBAClientX.Oracle();
-        return cli.ExecuteNonQueryAsync(host, service, b.UserID, b.Password, sql, parameters, cancellationToken: ct);
+        using var cli = ClientFactory();
+        return await cli.ExecuteNonQueryAsync(connectionString, sql, parameters, cancellationToken: ct).ConfigureAwait(false);
     }
 
     /// <summary>Executes a stored procedure.</summary>
@@ -56,7 +56,7 @@ public static class GenericExecutors
     public static async Task<int> ExecuteProcedureAsync(string host, string serviceName, string username, string password, string procedure, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
     {
         ValidateCommandText(procedure, nameof(procedure), "Stored procedure name");
-        var cli = new DBAClientX.Oracle();
+        using var cli = ClientFactory();
         await cli.ExecuteStoredProcedureAsync(host, serviceName, username, password, procedure, parameters, cancellationToken: ct).ConfigureAwait(false);
         return 0;
     }
@@ -71,28 +71,9 @@ public static class GenericExecutors
     {
         ValidateConnectionString(connectionString);
         ValidateCommandText(procedure, nameof(procedure), "Stored procedure name");
-        var b = new global::Oracle.ManagedDataAccess.Client.OracleConnectionStringBuilder(connectionString);
-        var (host, service) = SplitDataSource(b.DataSource);
-        var cli = new DBAClientX.Oracle();
-        await cli.ExecuteStoredProcedureAsync(host, service, b.UserID, b.Password, procedure, parameters, cancellationToken: ct).ConfigureAwait(false);
+        using var cli = ClientFactory();
+        await cli.ExecuteStoredProcedureAsync(connectionString, procedure, parameters, cancellationToken: ct).ConfigureAwait(false);
         return 0;
-    }
-
-    private static (string Host, string ServiceName) SplitDataSource(string? dataSource)
-    {
-        var value = dataSource ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            return (string.Empty, string.Empty);
-        }
-
-        var slash = value.LastIndexOf('/');
-        if (slash > 0 && slash < value.Length - 1)
-        {
-            return (value.Substring(0, slash), value.Substring(slash + 1));
-        }
-
-        return (value, value);
     }
 
     private static void ValidateConnectionString(string connectionString)

--- a/DbaClientX.Oracle/Oracle.AsyncCommandExecution.cs
+++ b/DbaClientX.Oracle/Oracle.AsyncCommandExecution.cs
@@ -27,6 +27,23 @@ public partial class Oracle
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, serviceName, username, password);
+        return await QueryAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full Oracle connection string.
+    /// </summary>
+    public virtual async Task<object?> QueryAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         OracleConnection? connection = null;
         OracleTransaction? transaction = null;
@@ -40,6 +57,98 @@ public partial class Oracle
         catch (Exception ex)
         {
             throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+        }
+        finally
+        {
+            await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual Task<IReadOnlyList<T>> QueryAsync<T>(
+        string host,
+        string serviceName,
+        string username,
+        string password,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+        => QueryAsListAsync(host, serviceName, username, password, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
+
+    /// <summary>
+    /// Asynchronously executes a SQL query and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual Task<IReadOnlyList<T>> QueryAsListAsync<T>(
+        string host,
+        string serviceName,
+        string username,
+        string password,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        var connectionString = BuildConnectionString(host, serviceName, username, password);
+        return QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections, initialize);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full Oracle connection string and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual Task<IReadOnlyList<T>> QueryAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+        => QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full Oracle connection string and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual async Task<IReadOnlyList<T>> QueryAsListAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        OracleConnection? connection = null;
+        OracleTransaction? transaction = null;
+        var dispose = false;
+        try
+        {
+            (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return await ExecuteMappedQueryAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
         }
         finally
         {
@@ -64,6 +173,23 @@ public partial class Oracle
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, serviceName, username, password);
+        return await ExecuteScalarAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full Oracle connection string and returns the first column of the first row in the result set.
+    /// </summary>
+    public virtual async Task<object?> ExecuteScalarAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         OracleConnection? connection = null;
         OracleTransaction? transaction = null;
@@ -77,6 +203,40 @@ public partial class Oracle
         catch (Exception ex)
         {
             throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
+        }
+        finally
+        {
+            await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL statement using a full Oracle connection string.
+    /// </summary>
+    public virtual async Task<int> ExecuteNonQueryAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
+
+        OracleConnection? connection = null;
+        OracleTransaction? transaction = null;
+        var dispose = false;
+        try
+        {
+            (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return await base.ExecuteNonQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
         }
         finally
         {

--- a/DbaClientX.Oracle/Oracle.CommandExecution.cs
+++ b/DbaClientX.Oracle/Oracle.CommandExecution.cs
@@ -11,9 +11,9 @@ public partial class Oracle
     private sealed class OracleParameterTypeMap : Dictionary<string, DbType>
     {
         public OracleParameterTypeMap(IDictionary<string, OracleDbType> providerTypes)
-            : base(providerTypes.Count, StringComparer.Ordinal)
+            : base(providerTypes.Count, StringComparer.OrdinalIgnoreCase)
         {
-            ProviderTypes = new Dictionary<string, OracleDbType>(providerTypes, StringComparer.Ordinal);
+            ProviderTypes = new Dictionary<string, OracleDbType>(providerTypes, StringComparer.OrdinalIgnoreCase);
             foreach (var pair in providerTypes)
             {
                 var parameter = new OracleParameter { OracleDbType = pair.Value };
@@ -21,7 +21,7 @@ public partial class Oracle
             }
         }
 
-        public IReadOnlyDictionary<string, OracleDbType> ProviderTypes { get; }
+        public IDictionary<string, OracleDbType> ProviderTypes { get; }
     }
 
     /// <summary>
@@ -40,6 +40,22 @@ public partial class Oracle
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, serviceName, username, password);
+        return Query(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a SQL query using a full Oracle connection string and materializes the results into the default return format.
+    /// </summary>
+    public virtual object? Query(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         OracleConnection? connection = null;
         OracleTransaction? transaction = null;
@@ -79,6 +95,22 @@ public partial class Oracle
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, serviceName, username, password);
+        return ExecuteScalar(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a SQL query using a full Oracle connection string and returns the first column of the first row in the result set.
+    /// </summary>
+    public virtual object? ExecuteScalar(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         OracleConnection? connection = null;
         OracleTransaction? transaction = null;
@@ -118,6 +150,22 @@ public partial class Oracle
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, serviceName, username, password);
+        return ExecuteNonQuery(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a SQL statement using a full Oracle connection string.
+    /// </summary>
+    public virtual int ExecuteNonQuery(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         OracleConnection? connection = null;
         OracleTransaction? transaction = null;
@@ -198,11 +246,11 @@ public partial class Oracle
                 Value = value
             };
 
-            if (oracleTypes.ProviderTypes.TryGetValue(pair.Key, out var providerType))
+            if (TryGetDictionaryValue(oracleTypes.ProviderTypes, pair.Key, out var providerType))
             {
                 parameter.OracleDbType = providerType;
             }
-            else if (parameterTypes.TryGetValue(pair.Key, out var explicitType))
+            else if (TryGetDictionaryValue(parameterTypes, pair.Key, out var explicitType))
             {
                 parameter.DbType = explicitType;
             }
@@ -211,7 +259,7 @@ public partial class Oracle
                 parameter.DbType = InferParameterDbType(value);
             }
 
-            if (parameterDirections != null && parameterDirections.TryGetValue(pair.Key, out var direction))
+            if (TryGetDictionaryValue(parameterDirections, pair.Key, out var direction))
             {
                 parameter.Direction = direction;
             }

--- a/DbaClientX.Oracle/Oracle.StoredProcedures.cs
+++ b/DbaClientX.Oracle/Oracle.StoredProcedures.cs
@@ -26,6 +26,22 @@ public partial class Oracle
     {
         ValidateCommandText(procedure, CommandType.StoredProcedure);
         var connectionString = BuildConnectionString(host, serviceName, username, password);
+        return ExecuteStoredProcedure(connectionString, procedure, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes an Oracle stored procedure using a full connection string and materializes the results into the default return format.
+    /// </summary>
+    public virtual object? ExecuteStoredProcedure(
+        string connectionString,
+        string procedure,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
 
         OracleConnection? connection = null;
         OracleTransaction? transaction = null;
@@ -43,7 +59,7 @@ public partial class Oracle
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = command.ExecuteReader();
+            using var reader = command.ExecuteReader(CommandBehavior.SequentialAccess);
             var tableIndex = 0;
             do
             {
@@ -72,13 +88,10 @@ public partial class Oracle
     }
 
     /// <summary>
-    /// Asynchronously executes an Oracle stored procedure and materializes the results into the default <see cref="DatabaseClientBase"/> return format.
+    /// Asynchronously executes an Oracle stored procedure using a full connection string and materializes the results into the default return format.
     /// </summary>
     public virtual async Task<object?> ExecuteStoredProcedureAsync(
-        string host,
-        string serviceName,
-        string username,
-        string password,
+        string connectionString,
         string procedure,
         IDictionary<string, object?>? parameters = null,
         bool useTransaction = false,
@@ -86,8 +99,8 @@ public partial class Oracle
         IDictionary<string, OracleDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
+        ValidateConnectionString(connectionString);
         ValidateCommandText(procedure, CommandType.StoredProcedure);
-        var connectionString = BuildConnectionString(host, serviceName, username, password);
 
         OracleConnection? connection = null;
         OracleTransaction? transaction = null;
@@ -105,7 +118,7 @@ public partial class Oracle
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             var tableIndex = 0;
             do
             {
@@ -126,11 +139,28 @@ public partial class Oracle
         }
         finally
         {
-            if (dispose)
-            {
-                DisposeConnection(connection!);
-            }
+            await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Asynchronously executes an Oracle stored procedure and materializes the results into the default <see cref="DatabaseClientBase"/> return format.
+    /// </summary>
+    public virtual async Task<object?> ExecuteStoredProcedureAsync(
+        string host,
+        string serviceName,
+        string username,
+        string password,
+        string procedure,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
+        var connectionString = BuildConnectionString(host, serviceName, username, password);
+        return await ExecuteStoredProcedureAsync(connectionString, procedure, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -163,7 +193,7 @@ public partial class Oracle
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = command.ExecuteReader();
+            using var reader = command.ExecuteReader(CommandBehavior.SequentialAccess);
             var tableIndex = 0;
             do
             {
@@ -220,7 +250,7 @@ public partial class Oracle
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             var tableIndex = 0;
             do
             {

--- a/DbaClientX.Oracle/Oracle.Streaming.cs
+++ b/DbaClientX.Oracle/Oracle.Streaming.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -27,17 +28,95 @@ public partial class Oracle
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
         ValidateCommandText(query);
+        var connectionString = BuildConnectionString(host, serviceName, username, password);
+        return QueryStreamAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Streams the results of a SQL query from a full Oracle connection string as an asynchronous sequence of <see cref="DataRow"/> instances.
+    /// </summary>
+    public virtual IAsyncEnumerable<DataRow> QueryStreamAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
         return Stream();
 
         async IAsyncEnumerable<DataRow> Stream()
         {
-            var connectionString = BuildConnectionString(host, serviceName, username, password);
-
             var (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             var dbTypes = ConvertParameterTypes(parameterTypes);
             try
             {
                 await foreach (var row in ExecuteQueryStreamAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false))
+                {
+                    yield return row;
+                }
+            }
+            finally
+            {
+                await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Streams the results of a SQL query through a caller-provided mapper.
+    /// </summary>
+    public virtual IAsyncEnumerable<T> QueryStreamAsync<T>(
+        string host,
+        string serviceName,
+        string username,
+        string password,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        var connectionString = BuildConnectionString(host, serviceName, username, password);
+        return QueryStreamAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections, initialize);
+    }
+
+    /// <summary>
+    /// Streams the results of a SQL query from a full Oracle connection string through a caller-provided mapper.
+    /// </summary>
+    public virtual IAsyncEnumerable<T> QueryStreamAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, OracleDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        return Stream();
+
+        async IAsyncEnumerable<T> Stream()
+        {
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            var (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await foreach (var row in ExecuteMappedQueryStreamAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false))
                 {
                     yield return row;
                 }

--- a/DbaClientX.Oracle/Oracle.cs
+++ b/DbaClientX.Oracle/Oracle.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
+using DBAClientX.Invoker;
 using Oracle.ManagedDataAccess.Client;
 
 namespace DBAClientX;
@@ -120,6 +121,17 @@ public partial class Oracle : DatabaseClientBase
 
     private static string NormalizeConnectionString(string connectionString)
         => new OracleConnectionStringBuilder(connectionString).ConnectionString;
+
+    private static void ValidateConnectionString(string connectionString)
+    {
+        var validationResult = DbaConnectionFactory.Validate("oracle", connectionString);
+        if (!validationResult.IsValid)
+        {
+            throw new ArgumentException(DbaConnectionFactory.ToUserMessage(validationResult), nameof(connectionString));
+        }
+
+        _ = NormalizeConnectionString(connectionString);
+    }
 
     private static void ValidateRequiredConnectionValue(string value, string paramName, string displayName)
     {

--- a/DbaClientX.Oracle/README.md
+++ b/DbaClientX.Oracle/README.md
@@ -36,7 +36,49 @@ await foreach (DataRow row in ora.QueryStreamAsync(
 }
 ```
 
+Typed mapped query:
+
+```csharp
+var rows = await ora.QueryAsListAsync(
+    connectionString: "Data Source=oraclesrv/orclpdb1;User Id=user;Password=p@ss",
+    query: "SELECT id, name FROM users ORDER BY id",
+    map: row => new UserRow(
+        Id: row.GetInt32(row.GetOrdinal("ID")),
+        Name: row.GetString(row.GetOrdinal("NAME"))),
+    cancellationToken: ct);
+```
+
+For larger result sets, use `QueryStreamAsync<T>` with the same mapper shape to avoid buffering all rows.
+
+Non-query from a full connection string:
+
+```csharp
+await ora.ExecuteNonQueryAsync(
+    connectionString: "Data Source=oraclesrv/orclpdb1;User Id=user;Password=p@ss",
+    query: "UPDATE users SET last_login = SYSTIMESTAMP WHERE id = :id",
+    parameters: new Dictionary<string, object?> { [":id"] = 1 },
+    cancellationToken: ct);
+```
+
+Scalar from a full connection string:
+
+```csharp
+var count = await ora.ExecuteScalarAsync(
+    connectionString: "Data Source=oraclesrv/orclpdb1;User Id=user;Password=p@ss",
+    query: "SELECT COUNT(*) FROM users",
+    cancellationToken: ct);
+```
+
+Stored procedure from a full connection string:
+
+```csharp
+var result = await ora.ExecuteStoredProcedureAsync(
+    connectionString: "Data Source=oraclesrv/orclpdb1;User Id=user;Password=p@ss",
+    procedure: "GET_RECENT_USERS",
+    parameters: new Dictionary<string, object?> { [":limit"] = 100 },
+    cancellationToken: ct);
+```
+
 ## See also
 
 - Core mapping + invoker: `DBAClientX.Core`
-

--- a/DbaClientX.PostgreSql/GenericExecutors.cs
+++ b/DbaClientX.PostgreSql/GenericExecutors.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX.Invoker;
-using Npgsql;
 
 namespace DBAClientX.PostgreSqlGeneric;
 
@@ -13,19 +12,20 @@ namespace DBAClientX.PostgreSqlGeneric;
 /// </summary>
 public static class GenericExecutors
 {
+    internal static Func<DBAClientX.PostgreSql> ClientFactory { get; set; } = static () => new DBAClientX.PostgreSql();
+
     /// <summary>Executes a parameterized SQL statement.</summary>
     /// <param name="connectionString">Npgsql connection string.</param>
     /// <param name="sql">SQL text to execute.</param>
     /// <param name="parameters">Parameter name/value map.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of affected rows.</returns>
-    public static Task<int> ExecuteSqlAsync(string connectionString, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
+    public static async Task<int> ExecuteSqlAsync(string connectionString, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
     {
         ValidateConnectionString(connectionString);
         ValidateCommandText(sql, nameof(sql), "SQL text");
-        var b = new NpgsqlConnectionStringBuilder(connectionString);
-        var cli = new DBAClientX.PostgreSql();
-        return cli.ExecuteNonQueryAsync(b.Host ?? string.Empty, b.Database ?? string.Empty, b.Username ?? string.Empty, b.Password ?? string.Empty, sql, parameters, cancellationToken: ct);
+        using var cli = ClientFactory();
+        return await cli.ExecuteNonQueryAsync(connectionString, sql, parameters, cancellationToken: ct).ConfigureAwait(false);
     }
 
     /// <summary>Executes a stored procedure.</summary>
@@ -38,9 +38,8 @@ public static class GenericExecutors
     {
         ValidateConnectionString(connectionString);
         ValidateCommandText(procedure, nameof(procedure), "Stored procedure name");
-        var b = new NpgsqlConnectionStringBuilder(connectionString);
-        var cli = new DBAClientX.PostgreSql();
-        await cli.ExecuteStoredProcedureAsync(b.Host ?? string.Empty, b.Database ?? string.Empty, b.Username ?? string.Empty, b.Password ?? string.Empty, procedure, parameters, cancellationToken: ct).ConfigureAwait(false);
+        using var cli = ClientFactory();
+        await cli.ExecuteStoredProcedureAsync(connectionString, procedure, parameters, cancellationToken: ct).ConfigureAwait(false);
         return 0;
     }
 

--- a/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
@@ -173,6 +173,23 @@ public partial class PostgreSql
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return await ExecuteNonQueryAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL command that does not produce a result set using a full PostgreSQL connection string.
+    /// </summary>
+    public virtual async Task<int> ExecuteNonQueryAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         NpgsqlConnection? connection = null;
         NpgsqlTransaction? transaction = null;
@@ -210,6 +227,23 @@ public partial class PostgreSql
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return await ExecuteScalarAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a scalar SQL command using a full PostgreSQL connection string and returns the first column of the first row in the result set.
+    /// </summary>
+    public virtual async Task<object?> ExecuteScalarAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         NpgsqlConnection? connection = null;
         NpgsqlTransaction? transaction = null;

--- a/DbaClientX.PostgreSql/PostgreSql.CommandExecution.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.CommandExecution.cs
@@ -12,9 +12,9 @@ public partial class PostgreSql
     private sealed class NpgsqlParameterTypeMap : Dictionary<string, DbType>
     {
         public NpgsqlParameterTypeMap(IDictionary<string, NpgsqlDbType> providerTypes)
-            : base(providerTypes.Count, StringComparer.Ordinal)
+            : base(providerTypes.Count, StringComparer.OrdinalIgnoreCase)
         {
-            ProviderTypes = new Dictionary<string, NpgsqlDbType>(providerTypes, StringComparer.Ordinal);
+            ProviderTypes = new Dictionary<string, NpgsqlDbType>(providerTypes, StringComparer.OrdinalIgnoreCase);
             foreach (var pair in providerTypes)
             {
                 var parameter = new NpgsqlParameter { NpgsqlDbType = pair.Value };
@@ -22,7 +22,7 @@ public partial class PostgreSql
             }
         }
 
-        public IReadOnlyDictionary<string, NpgsqlDbType> ProviderTypes { get; }
+        public IDictionary<string, NpgsqlDbType> ProviderTypes { get; }
     }
 
     /// <summary>
@@ -41,6 +41,22 @@ public partial class PostgreSql
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return Query(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a SQL query using a full PostgreSQL connection string and materializes the result using the shared pipeline.
+    /// </summary>
+    public virtual object? Query(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         NpgsqlConnection? connection = null;
         NpgsqlTransaction? transaction = null;
@@ -80,6 +96,22 @@ public partial class PostgreSql
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return ExecuteScalar(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a scalar SQL command using a full PostgreSQL connection string and returns the first column of the first row in the result set.
+    /// </summary>
+    public virtual object? ExecuteScalar(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         NpgsqlConnection? connection = null;
         NpgsqlTransaction? transaction = null;
@@ -119,6 +151,22 @@ public partial class PostgreSql
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return ExecuteNonQuery(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a SQL command that does not produce a result set using a full PostgreSQL connection string.
+    /// </summary>
+    public virtual int ExecuteNonQuery(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         NpgsqlConnection? connection = null;
         NpgsqlTransaction? transaction = null;
@@ -199,11 +247,11 @@ public partial class PostgreSql
                 Value = value
             };
 
-            if (npgsqlTypes.ProviderTypes.TryGetValue(pair.Key, out var providerType))
+            if (TryGetDictionaryValue(npgsqlTypes.ProviderTypes, pair.Key, out var providerType))
             {
                 parameter.NpgsqlDbType = providerType;
             }
-            else if (parameterTypes.TryGetValue(pair.Key, out var explicitType))
+            else if (TryGetDictionaryValue(parameterTypes, pair.Key, out var explicitType))
             {
                 parameter.DbType = explicitType;
             }
@@ -212,7 +260,7 @@ public partial class PostgreSql
                 parameter.DbType = InferParameterDbType(value);
             }
 
-            if (parameterDirections != null && parameterDirections.TryGetValue(pair.Key, out var direction))
+            if (TryGetDictionaryValue(parameterDirections, pair.Key, out var direction))
             {
                 parameter.Direction = direction;
             }

--- a/DbaClientX.PostgreSql/PostgreSql.StoredProcedures.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.StoredProcedures.cs
@@ -27,6 +27,22 @@ public partial class PostgreSql
     {
         ValidateCommandText(procedure, CommandType.StoredProcedure);
         var connectionString = BuildConnectionString(host, database, username, password);
+        return ExecuteStoredProcedure(connectionString, procedure, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a stored procedure using a full PostgreSQL connection string and materializes the results into the shared format.
+    /// </summary>
+    public virtual object? ExecuteStoredProcedure(
+        string connectionString,
+        string procedure,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
 
         NpgsqlConnection? connection = null;
         NpgsqlTransaction? transaction = null;
@@ -44,7 +60,7 @@ public partial class PostgreSql
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = command.ExecuteReader();
+            using var reader = command.ExecuteReader(CommandBehavior.SequentialAccess);
             var tableIndex = 0;
             do
             {
@@ -73,13 +89,10 @@ public partial class PostgreSql
     }
 
     /// <summary>
-    /// Asynchronously executes a stored procedure and materializes the results into the shared <see cref="DatabaseClientBase"/> format.
+    /// Asynchronously executes a stored procedure using a full PostgreSQL connection string and materializes the results into the shared format.
     /// </summary>
     public virtual async Task<object?> ExecuteStoredProcedureAsync(
-        string host,
-        string database,
-        string username,
-        string password,
+        string connectionString,
         string procedure,
         IDictionary<string, object?>? parameters = null,
         bool useTransaction = false,
@@ -87,8 +100,8 @@ public partial class PostgreSql
         IDictionary<string, NpgsqlDbType>? parameterTypes = null,
         IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
+        ValidateConnectionString(connectionString);
         ValidateCommandText(procedure, CommandType.StoredProcedure);
-        var connectionString = BuildConnectionString(host, database, username, password);
 
         NpgsqlConnection? connection = null;
         NpgsqlTransaction? transaction = null;
@@ -106,7 +119,7 @@ public partial class PostgreSql
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             var tableIndex = 0;
             do
             {
@@ -127,11 +140,28 @@ public partial class PostgreSql
         }
         finally
         {
-            if (dispose)
-            {
-                DisposeConnection(connection!);
-            }
+            await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Asynchronously executes a stored procedure and materializes the results into the shared <see cref="DatabaseClientBase"/> format.
+    /// </summary>
+    public virtual async Task<object?> ExecuteStoredProcedureAsync(
+        string host,
+        string database,
+        string username,
+        string password,
+        string procedure,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
+        var connectionString = BuildConnectionString(host, database, username, password);
+        return await ExecuteStoredProcedureAsync(connectionString, procedure, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -164,7 +194,7 @@ public partial class PostgreSql
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = command.ExecuteReader();
+            using var reader = command.ExecuteReader(CommandBehavior.SequentialAccess);
             var tableIndex = 0;
             do
             {
@@ -221,7 +251,7 @@ public partial class PostgreSql
             ApplyCommandTimeout(command);
 
             var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             var tableIndex = 0;
             do
             {

--- a/DbaClientX.PostgreSql/README.md
+++ b/DbaClientX.PostgreSql/README.md
@@ -56,6 +56,35 @@ var rows = await pg.QueryAsListAsync(
 
 For larger result sets, use `QueryStreamAsync<T>` with the same mapper shape to avoid buffering all rows.
 
+Non-query from a full connection string:
+
+```csharp
+await pg.ExecuteNonQueryAsync(
+    connectionString: "Host=localhost;Database=app;Username=user;Password=p@ss;SSL Mode=Require",
+    query: "UPDATE public.users SET last_seen=NOW() WHERE id=@id",
+    parameters: new Dictionary<string, object?> { ["@id"] = 1 },
+    cancellationToken: ct);
+```
+
+Scalar from a full connection string:
+
+```csharp
+var count = await pg.ExecuteScalarAsync(
+    connectionString: "Host=localhost;Database=app;Username=user;Password=p@ss;SSL Mode=Require",
+    query: "SELECT COUNT(*) FROM public.users",
+    cancellationToken: ct);
+```
+
+Stored procedure from a full connection string:
+
+```csharp
+var result = await pg.ExecuteStoredProcedureAsync(
+    connectionString: "Host=localhost;Database=app;Username=user;Password=p@ss;SSL Mode=Require",
+    procedure: "public.refresh_stats",
+    parameters: new Dictionary<string, object?> { ["@days"] = 7 },
+    cancellationToken: ct);
+```
+
 ## See also
 
 - Core mapping + invoker: `DBAClientX.Core`

--- a/DbaClientX.SQLite/README.md
+++ b/DbaClientX.SQLite/README.md
@@ -36,6 +36,20 @@ await foreach (DataRow row in sq.QueryStreamAsync(
 }
 ```
 
+Typed mapped query:
+
+```csharp
+var rows = await sq.QueryAsListAsync(
+    database: "app.db",
+    query: "SELECT Id, Name FROM Users ORDER BY Id",
+    map: row => new UserRow(
+        Id: row.GetInt32(row.GetOrdinal("Id")),
+        Name: row.GetString(row.GetOrdinal("Name"))),
+    cancellationToken: ct);
+```
+
+For larger result sets, use `QueryStreamAsync<T>` with the same mapper shape to avoid buffering all rows.
+
 Graceful shutdown maintenance:
 
 ```csharp

--- a/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
@@ -200,7 +200,7 @@ public partial class SQLite
                     command.CommandTimeout = commandTimeout;
                 }
 
-                using var reader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
+                using var reader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult, cancellationToken).ConfigureAwait(false);
                 initialize?.Invoke(reader);
 
                 var results = new List<T>();

--- a/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
@@ -52,6 +52,65 @@ public partial class SQLite
     }
 
     /// <summary>
+    /// Asynchronously executes a SQL query and maps each returned row using the provided callback.
+    /// </summary>
+    public virtual Task<IReadOnlyList<T>> QueryAsync<T>(
+        string database,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqliteType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+        => QueryAsListAsync(database, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
+
+    /// <summary>
+    /// Asynchronously executes a SQL query and maps each returned row using the provided callback.
+    /// </summary>
+    public virtual async Task<IReadOnlyList<T>> QueryAsListAsync<T>(
+        string database,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqliteType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        var connectionString = BuildOperationalConnectionString(database);
+
+        SqliteConnection? connection = null;
+        SqliteTransaction? transaction = null;
+        var dispose = false;
+        try
+        {
+            (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return await ExecuteMappedQueryAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
+        }
+        finally
+        {
+            if (dispose && connection != null)
+            {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+                await connection.DisposeAsync().ConfigureAwait(false);
+#else
+                connection.Dispose();
+#endif
+            }
+        }
+    }
+
+    /// <summary>
     /// Asynchronously executes a SQL query against a read-only connection and materializes the result using the shared pipeline from <see cref="DatabaseClientBase"/>.
     /// </summary>
     public virtual async Task<object?> QueryReadOnlyAsync(
@@ -141,7 +200,7 @@ public partial class SQLite
                     command.CommandTimeout = commandTimeout;
                 }
 
-                using var reader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult, cancellationToken).ConfigureAwait(false);
+                using var reader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult | CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
                 initialize?.Invoke(reader);
 
                 var results = new List<T>();

--- a/DbaClientX.SQLite/SQLite.Streaming.cs
+++ b/DbaClientX.SQLite/SQLite.Streaming.cs
@@ -1,4 +1,5 @@
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Threading;
@@ -60,6 +61,57 @@ public partial class SQLite
 #else
                 connection.Dispose();
 #endif
+            }
+        }
+    }
+
+    /// <summary>
+    /// Streams query results asynchronously through a caller-provided mapper.
+    /// </summary>
+    public virtual IAsyncEnumerable<T> QueryStreamAsync<T>(
+        string database,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqliteType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        return Stream();
+
+        async IAsyncEnumerable<T> Stream()
+        {
+            var connectionString = BuildOperationalConnectionString(database);
+
+            SqliteConnection? connection = null;
+            SqliteTransaction? transaction = null;
+            var dispose = false;
+
+            (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            try
+            {
+                await foreach (var row in ExecuteMappedQueryStreamAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false))
+                {
+                    yield return row;
+                }
+            }
+            finally
+            {
+                if (dispose)
+                {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+                    await connection.DisposeAsync().ConfigureAwait(false);
+#else
+                    connection.Dispose();
+#endif
+                }
             }
         }
     }

--- a/DbaClientX.SqlServer/GenericExecutors.cs
+++ b/DbaClientX.SqlServer/GenericExecutors.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX.Invoker;
@@ -14,6 +13,8 @@ namespace DBAClientX.SqlServerGeneric;
 /// </summary>
 public static class GenericExecutors
 {
+    internal static Func<DBAClientX.SqlServer> ClientFactory { get; set; } = static () => new DBAClientX.SqlServer();
+
     /// <summary>
     /// Executes a parameterized SQL statement using <paramref name="connectionString"/>.
     /// </summary>
@@ -22,13 +23,12 @@ public static class GenericExecutors
     /// <param name="parameters">Parameter name/value map (e.g., {"@UserName":"alice"}).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Number of affected rows (as reported by the provider).</returns>
-    public static Task<int> ExecuteSqlAsync(string connectionString, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
+    public static async Task<int> ExecuteSqlAsync(string connectionString, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
     {
         ValidateConnectionString(connectionString);
         ValidateCommandText(sql, nameof(sql), "SQL text");
-        var b = new SqlConnectionStringBuilder(connectionString);
-        var cli = new DBAClientX.SqlServer();
-        return cli.ExecuteNonQueryAsync(b.DataSource, b.InitialCatalog, b.IntegratedSecurity, sql, parameters, cancellationToken: ct, username: b.UserID, password: b.Password);
+        using var cli = ClientFactory();
+        return await cli.ExecuteNonQueryAsync(connectionString, sql, parameters, cancellationToken: ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -43,9 +43,8 @@ public static class GenericExecutors
     {
         ValidateConnectionString(connectionString);
         ValidateCommandText(procedure, nameof(procedure), "Stored procedure name");
-        var b = new SqlConnectionStringBuilder(connectionString);
-        var cli = new DBAClientX.SqlServer();
-        await cli.ExecuteStoredProcedureAsync(b.DataSource, b.InitialCatalog, b.IntegratedSecurity, procedure, parameters, cancellationToken: ct, username: b.UserID, password: b.Password).ConfigureAwait(false);
+        using var cli = ClientFactory();
+        await cli.ExecuteStoredProcedureAsync(connectionString, procedure, parameters, cancellationToken: ct).ConfigureAwait(false);
         return 0;
     }
 

--- a/DbaClientX.SqlServer/README.md
+++ b/DbaClientX.SqlServer/README.md
@@ -36,6 +36,49 @@ await foreach (DataRow row in cli.QueryStreamAsync(
 }
 ```
 
+Typed mapped query:
+
+```csharp
+var rows = await cli.QueryAsListAsync(
+    connectionString: "Server=.;Database=App;Integrated Security=True;Trust Server Certificate=True",
+    query: "SELECT TOP 100 Id, Name FROM dbo.Users ORDER BY Id",
+    map: row => new UserRow(
+        Id: row.GetInt32(row.GetOrdinal("Id")),
+        Name: row.GetString(row.GetOrdinal("Name"))),
+    cancellationToken: ct);
+```
+
+For larger result sets, use `QueryStreamAsync<T>` with the same mapper shape to avoid buffering all rows.
+
+Non-query from a full connection string:
+
+```csharp
+await cli.ExecuteNonQueryAsync(
+    connectionString: "Server=.;Database=App;Integrated Security=True;Encrypt=True",
+    query: "UPDATE dbo.Users SET LastLogin=SYSUTCDATETIME() WHERE Id=@Id",
+    parameters: new Dictionary<string, object?> { ["@Id"] = 1 },
+    cancellationToken: ct);
+```
+
+Scalar from a full connection string:
+
+```csharp
+var count = await cli.ExecuteScalarAsync(
+    connectionString: "Server=.;Database=App;Integrated Security=True;Encrypt=True",
+    query: "SELECT COUNT(*) FROM dbo.Users",
+    cancellationToken: ct);
+```
+
+Stored procedure from a full connection string:
+
+```csharp
+var result = await cli.ExecuteStoredProcedureAsync(
+    connectionString: "Server=.;Database=App;Integrated Security=True;Encrypt=True",
+    procedure: "dbo.GetRecentUsers",
+    parameters: new Dictionary<string, object?> { ["@Limit"] = 100 },
+    cancellationToken: ct);
+```
+
 Transactions:
 
 ```csharp

--- a/DbaClientX.SqlServer/SqlServer.AsyncCommandExecution.cs
+++ b/DbaClientX.SqlServer/SqlServer.AsyncCommandExecution.cs
@@ -27,6 +27,23 @@ public partial class SqlServer
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return await ExecuteNonQueryAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL statement using a full SQL Server connection string.
+    /// </summary>
+    public virtual async Task<int> ExecuteNonQueryAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;
@@ -40,6 +57,40 @@ public partial class SqlServer
         catch (Exception ex)
         {
             throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+        }
+        finally
+        {
+            await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full SQL Server connection string.
+    /// </summary>
+    public virtual async Task<object?> QueryAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
+
+        SqlConnection? connection = null;
+        SqlTransaction? transaction = null;
+        var dispose = false;
+        try
+        {
+            (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return await ExecuteQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
         }
         finally
         {
@@ -65,6 +116,23 @@ public partial class SqlServer
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return await ExecuteScalarAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full SQL Server connection string and returns a single scalar value.
+    /// </summary>
+    public virtual async Task<object?> ExecuteScalarAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;
@@ -78,6 +146,100 @@ public partial class SqlServer
         catch (Exception ex)
         {
             throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+        }
+        finally
+        {
+            await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual Task<IReadOnlyList<T>> QueryAsync<T>(
+        string serverOrInstance,
+        string database,
+        bool integratedSecurity,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        string? username = null,
+        string? password = null)
+        => QueryAsListAsync(serverOrInstance, database, integratedSecurity, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections, username, password);
+
+    /// <summary>
+    /// Asynchronously executes a SQL query and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual Task<IReadOnlyList<T>> QueryAsListAsync<T>(
+        string serverOrInstance,
+        string database,
+        bool integratedSecurity,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        string? username = null,
+        string? password = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections, initialize);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full SQL Server connection string and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual Task<IReadOnlyList<T>> QueryAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+        => QueryAsListAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full SQL Server connection string and maps each row with a caller-provided mapper.
+    /// </summary>
+    public virtual async Task<IReadOnlyList<T>> QueryAsListAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        SqlConnection? connection = null;
+        SqlTransaction? transaction = null;
+        var dispose = false;
+        try
+        {
+            (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            return await ExecuteMappedQueryAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
         }
         finally
         {

--- a/DbaClientX.SqlServer/SqlServer.AsyncCommandExecution.cs
+++ b/DbaClientX.SqlServer/SqlServer.AsyncCommandExecution.cs
@@ -116,7 +116,7 @@ public partial class SqlServer
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
-        return await ExecuteScalarAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
+        return await QueryAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -141,11 +141,11 @@ public partial class SqlServer
         {
             (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             var dbTypes = ConvertParameterTypes(parameterTypes);
-            return await ExecuteQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+            return await ExecuteScalarAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+            throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
         }
         finally
         {

--- a/DbaClientX.SqlServer/SqlServer.CommandExecution.cs
+++ b/DbaClientX.SqlServer/SqlServer.CommandExecution.cs
@@ -24,6 +24,22 @@ public partial class SqlServer
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return Query(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a SQL query using a full SQL Server connection string and materializes the result using the shared pipeline.
+    /// </summary>
+    public virtual object? Query(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;
@@ -64,6 +80,22 @@ public partial class SqlServer
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return ExecuteScalar(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a SQL query using a full SQL Server connection string and returns a single scalar value.
+    /// </summary>
+    public virtual object? ExecuteScalar(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;
@@ -104,6 +136,22 @@ public partial class SqlServer
     {
         ValidateCommandText(query);
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return ExecuteNonQuery(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a SQL statement using a full SQL Server connection string.
+    /// </summary>
+    public virtual int ExecuteNonQuery(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
 
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;

--- a/DbaClientX.SqlServer/SqlServer.ParallelExecution.cs
+++ b/DbaClientX.SqlServer/SqlServer.ParallelExecution.cs
@@ -22,7 +22,7 @@ public partial class SqlServer
     /// <returns>A list containing the result of each query in submission order.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="queries"/> is <see langword="null"/>.</exception>
     /// <remarks>
-    /// Each query is executed via <see cref="QueryAsync"/>.
+    /// Each query is executed via <c>QueryAsync</c>.
     /// </remarks>
     public async Task<IReadOnlyList<object?>> RunQueriesInParallel(
         IEnumerable<string> queries,

--- a/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
+++ b/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
@@ -44,7 +44,7 @@ public partial class SqlServer
             }
 
             var dataSet = new DataSet();
-            using var reader = command.ExecuteReader();
+            using var reader = command.ExecuteReader(CommandBehavior.SequentialAccess);
             var tableIndex = 0;
             do
             {
@@ -105,7 +105,7 @@ public partial class SqlServer
             }
 
             var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             var tableIndex = 0;
             do
             {

--- a/DbaClientX.SqlServer/SqlServer.StoredProcedures.cs
+++ b/DbaClientX.SqlServer/SqlServer.StoredProcedures.cs
@@ -26,6 +26,22 @@ public partial class SqlServer
     {
         ValidateCommandText(procedure, CommandType.StoredProcedure);
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return ExecuteStoredProcedure(connectionString, procedure, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Executes a stored procedure using a full SQL Server connection string and materializes the result using the shared pipeline.
+    /// </summary>
+    public virtual object? ExecuteStoredProcedure(
+        string connectionString,
+        string procedure,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
 
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;
@@ -46,7 +62,7 @@ public partial class SqlServer
             }
 
             var dataSet = new DataSet();
-            using var reader = command.ExecuteReader();
+            using var reader = command.ExecuteReader(CommandBehavior.SequentialAccess);
             var tableIndex = 0;
             do
             {
@@ -75,23 +91,19 @@ public partial class SqlServer
     }
 
     /// <summary>
-    /// Asynchronously executes a stored procedure and materializes the result using the shared <see cref="DatabaseClientBase"/> pipeline.
+    /// Asynchronously executes a stored procedure using a full SQL Server connection string and materializes the result using the shared pipeline.
     /// </summary>
     public virtual async Task<object?> ExecuteStoredProcedureAsync(
-        string serverOrInstance,
-        string database,
-        bool integratedSecurity,
+        string connectionString,
         string procedure,
         IDictionary<string, object?>? parameters = null,
         bool useTransaction = false,
         CancellationToken cancellationToken = default,
         IDictionary<string, SqlDbType>? parameterTypes = null,
-        IDictionary<string, ParameterDirection>? parameterDirections = null,
-        string? username = null,
-        string? password = null)
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
     {
+        ValidateConnectionString(connectionString);
         ValidateCommandText(procedure, CommandType.StoredProcedure);
-        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;
@@ -112,7 +124,7 @@ public partial class SqlServer
             }
 
             var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
             var tableIndex = 0;
             do
             {
@@ -135,5 +147,26 @@ public partial class SqlServer
         {
             await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
         }
+    }
+
+    /// <summary>
+    /// Asynchronously executes a stored procedure and materializes the result using the shared <see cref="DatabaseClientBase"/> pipeline.
+    /// </summary>
+    public virtual async Task<object?> ExecuteStoredProcedureAsync(
+        string serverOrInstance,
+        string database,
+        bool integratedSecurity,
+        string procedure,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        string? username = null,
+        string? password = null)
+    {
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
+        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return await ExecuteStoredProcedureAsync(connectionString, procedure, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections).ConfigureAwait(false);
     }
 }

--- a/DbaClientX.SqlServer/SqlServer.Streaming.cs
+++ b/DbaClientX.SqlServer/SqlServer.Streaming.cs
@@ -1,4 +1,5 @@
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -28,12 +29,28 @@ public partial class SqlServer
         string? password = null)
     {
         ValidateCommandText(query);
+        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return QueryStreamAsync(connectionString, query, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full SQL Server connection string and streams the resulting rows.
+    /// </summary>
+    public virtual IAsyncEnumerable<DataRow> QueryStreamAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
         return Stream();
 
         async IAsyncEnumerable<DataRow> Stream()
         {
-            var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
-
             SqlConnection? connection = null;
             SqlTransaction? transaction = null;
             var dispose = false;
@@ -42,6 +59,69 @@ public partial class SqlServer
                 (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
                 var dbTypes = ConvertParameterTypes(parameterTypes);
                 await foreach (var row in ExecuteQueryStreamAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false))
+                {
+                    yield return row;
+                }
+            }
+            finally
+            {
+                await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query and streams rows through a caller-provided mapper.
+    /// </summary>
+    public virtual IAsyncEnumerable<T> QueryStreamAsync<T>(
+        string serverOrInstance,
+        string database,
+        bool integratedSecurity,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        string? username = null,
+        string? password = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return QueryStreamAsync(connectionString, query, map, parameters, useTransaction, cancellationToken, parameterTypes, parameterDirections, initialize);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a SQL query using a full SQL Server connection string and streams rows through a caller-provided mapper.
+    /// </summary>
+    public virtual IAsyncEnumerable<T> QueryStreamAsync<T>(
+        string connectionString,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(query);
+        if (map == null) throw new ArgumentNullException(nameof(map));
+
+        return Stream();
+
+        async IAsyncEnumerable<T> Stream()
+        {
+            var dbTypes = ConvertParameterTypes(parameterTypes);
+            var (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await foreach (var row in ExecuteMappedQueryStreamAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false))
                 {
                     yield return row;
                 }

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using DBAClientX.Invoker;
 using Microsoft.Data.SqlClient;
 
 namespace DBAClientX;
@@ -71,12 +72,18 @@ public partial class SqlServer : DatabaseClientBase
             ValidateRequiredConnectionValue(username, nameof(username), "Username");
         }
 
+        if (ssl == false)
+        {
+            throw new ArgumentException("SQL Server connections must use encryption. Pass true or omit the ssl argument.", nameof(ssl));
+        }
+
         var dataSource = port.HasValue ? $"{serverOrInstance},{port.Value}" : serverOrInstance;
         var connectionStringBuilder = new SqlConnectionStringBuilder
         {
             DataSource = dataSource,
             InitialCatalog = database,
             IntegratedSecurity = integratedSecurity,
+            Encrypt = true,
             Pooling = true
         };
         if (!integratedSecurity)
@@ -84,7 +91,7 @@ public partial class SqlServer : DatabaseClientBase
             connectionStringBuilder.UserID = username;
             connectionStringBuilder.Password = password;
         }
-        if (ssl.HasValue)
+        if (ssl == true)
         {
             connectionStringBuilder.Encrypt = ssl.Value;
         }
@@ -157,9 +164,9 @@ public partial class SqlServer : DatabaseClientBase
     private sealed class SqlServerParameterTypeMap : Dictionary<string, DbType>
     {
         public SqlServerParameterTypeMap(IDictionary<string, SqlDbType> providerTypes)
-            : base(providerTypes.Count, StringComparer.Ordinal)
+            : base(providerTypes.Count, StringComparer.OrdinalIgnoreCase)
         {
-            ProviderTypes = new Dictionary<string, SqlDbType>(providerTypes, StringComparer.Ordinal);
+            ProviderTypes = new Dictionary<string, SqlDbType>(providerTypes, StringComparer.OrdinalIgnoreCase);
             foreach (var pair in providerTypes)
             {
                 var parameter = new SqlParameter { SqlDbType = pair.Value };
@@ -167,7 +174,7 @@ public partial class SqlServer : DatabaseClientBase
             }
         }
 
-        public IReadOnlyDictionary<string, SqlDbType> ProviderTypes { get; }
+        public IDictionary<string, SqlDbType> ProviderTypes { get; }
     }
 
     private (SqlConnection Connection, SqlTransaction? Transaction, bool Dispose) ResolveConnection(string connectionString, bool useTransaction)
@@ -264,11 +271,11 @@ public partial class SqlServer : DatabaseClientBase
                 Value = value
             };
 
-            if (sqlTypes.ProviderTypes.TryGetValue(pair.Key, out var providerType))
+            if (TryGetDictionaryValue(sqlTypes.ProviderTypes, pair.Key, out var providerType))
             {
                 parameter.SqlDbType = providerType;
             }
-            else if (parameterTypes.TryGetValue(pair.Key, out var explicitType))
+            else if (TryGetDictionaryValue(parameterTypes, pair.Key, out var explicitType))
             {
                 parameter.DbType = explicitType;
             }
@@ -277,7 +284,7 @@ public partial class SqlServer : DatabaseClientBase
                 parameter.DbType = InferParameterDbType(value);
             }
 
-            if (parameterDirections != null && parameterDirections.TryGetValue(pair.Key, out var direction))
+            if (TryGetDictionaryValue(parameterDirections, pair.Key, out var direction))
             {
                 parameter.Direction = direction;
             }
@@ -320,6 +327,17 @@ public partial class SqlServer : DatabaseClientBase
 
     private static string NormalizeConnectionString(string connectionString)
         => new SqlConnectionStringBuilder(connectionString).ConnectionString;
+
+    private static void ValidateConnectionString(string connectionString)
+    {
+        var validationResult = DbaConnectionFactory.Validate("sqlserver", connectionString);
+        if (!validationResult.IsValid)
+        {
+            throw new ArgumentException(DbaConnectionFactory.ToUserMessage(validationResult), nameof(connectionString));
+        }
+
+        _ = NormalizeConnectionString(connectionString);
+    }
 
     private static void ValidateRequiredConnectionValue(string? value, string paramName, string displayName)
     {

--- a/DbaClientX.Tests/ConnectionStringBuilderTests.cs
+++ b/DbaClientX.Tests/ConnectionStringBuilderTests.cs
@@ -128,6 +128,7 @@ public class ConnectionStringBuilderTests
         Assert.Equal("srv", builder.DataSource);
         Assert.Equal("db", builder.InitialCatalog);
         Assert.True(builder.IntegratedSecurity);
+        Assert.True(builder.Encrypt);
     }
 
     [Fact]
@@ -149,6 +150,13 @@ public class ConnectionStringBuilderTests
         var builder = new SqlConnectionStringBuilder(cs);
         Assert.Equal("srv,1444", builder.DataSource);
         Assert.True(builder.Encrypt);
+    }
+
+    [Fact]
+    public void SqlServer_BuildConnectionString_RejectsDisabledEncryption()
+    {
+        var exception = Assert.Throws<ArgumentException>(() => DBAClientX.SqlServer.BuildConnectionString("srv", "db", true, ssl: false));
+        Assert.Contains("encryption", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/DbaClientX.Tests/DatabaseClientBaseOutputParameterTests.cs
+++ b/DbaClientX.Tests/DatabaseClientBaseOutputParameterTests.cs
@@ -45,11 +45,16 @@ public class DatabaseClientBaseOutputParameterTests
         public override string DataSource => string.Empty;
         public override string ServerVersion => string.Empty;
         public override ConnectionState State => ConnectionState.Open;
+        public FakeCommand? LastCommand { get; private set; }
         public override void ChangeDatabase(string databaseName) { }
         public override void Close() { }
         public override void Open() { }
         protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new NotSupportedException();
-        protected override DbCommand CreateDbCommand() => new FakeCommand();
+        protected override DbCommand CreateDbCommand()
+        {
+            LastCommand = new FakeCommand();
+            return LastCommand;
+        }
     }
 
     private sealed class FakeCommand : DbCommand
@@ -59,6 +64,7 @@ public class DatabaseClientBaseOutputParameterTests
         public override string CommandText { get; set; } = string.Empty;
         public override int CommandTimeout { get; set; }
         public override CommandType CommandType { get; set; }
+        public CommandBehavior? LastReaderBehavior { get; private set; }
         public override bool DesignTimeVisible { get; set; }
         public override UpdateRowSource UpdatedRowSource { get; set; }
         protected override DbConnection DbConnection { get; set; } = null!;
@@ -72,12 +78,14 @@ public class DatabaseClientBaseOutputParameterTests
 
         protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
         {
+            LastReaderBehavior = behavior;
             SetOutputParameterValues();
             return new FakeDataReader();
         }
 
         protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {
+            LastReaderBehavior = behavior;
             SetOutputParameterValues();
             return Task.FromResult<DbDataReader>(new FakeDataReader());
         }
@@ -289,6 +297,17 @@ public class DatabaseClientBaseOutputParameterTests
         Assert.Equal(new[] { 1 }, rows);
         Assert.Equal(1, initializeCount);
         Assert.Equal(0, idOrdinal);
+    }
+
+    [Fact]
+    public async Task ExecuteMappedQueryAsync_UsesDefaultReaderBehaviorForMapperCompatibility()
+    {
+        using var client = new TestClient();
+        using var connection = new FakeConnection();
+
+        await client.RunMappedQueryAsync(connection, record => record.GetInt32(0));
+
+        Assert.Equal(CommandBehavior.Default, connection.LastCommand?.LastReaderBehavior);
     }
 
     [Fact]

--- a/DbaClientX.Tests/DatabaseClientBaseOutputParameterTests.cs
+++ b/DbaClientX.Tests/DatabaseClientBaseOutputParameterTests.cs
@@ -352,4 +352,17 @@ public class DatabaseClientBaseOutputParameterTests
         Assert.Equal(1, initializeCount);
         Assert.Equal(0, idOrdinal);
     }
+
+    [Fact]
+    public async Task ExecuteMappedQueryStreamAsync_UsesDefaultReaderBehaviorForMapperCompatibility()
+    {
+        using var client = new TestClient();
+        using var connection = new FakeConnection();
+
+        await foreach (int _ in client.RunMappedStream(connection, record => record.GetInt32(0)))
+        {
+        }
+
+        Assert.Equal(CommandBehavior.Default, connection.LastCommand?.LastReaderBehavior);
+    }
 }

--- a/DbaClientX.Tests/DbaConnectionFactoryTests.cs
+++ b/DbaClientX.Tests/DbaConnectionFactoryTests.cs
@@ -58,15 +58,43 @@ public class DbaConnectionFactoryTests
         Assert.Contains("disabled", DbaConnectionFactory.ToUserMessage(result).ToLowerInvariant());
     }
 
-    [Fact]
-    public void Validate_MySqlConnectionString_WithSslPreferred_IsRejected()
+    [Theory]
+    [InlineData("None")]
+    [InlineData("Preferred")]
+    [InlineData("Disabled")]
+    [InlineData("Invalid")]
+    public void Validate_MySqlConnectionString_WithNonEnforcingSslMode_IsRejected(string sslMode)
     {
-        var connectionString = "Server=dbhost;Database=app;User ID=user;Password=password;SslMode=Preferred";
+        var connectionString = $"Server=dbhost;Database=app;User ID=user;Password=password;SslMode={sslMode}";
         var result = DbaConnectionFactory.Validate("mysql", connectionString);
 
         Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.UnsupportedOption, result.Code);
         Assert.True(string.Equals("SSL Mode", result.Details, StringComparison.OrdinalIgnoreCase)
             || string.Equals("SslMode", result.Details, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_MySqlConnectionString_WithEmptySslMode_IsRejected()
+    {
+        var connectionString = "Server=dbhost;Database=app;User ID=user;Password=password;SslMode=";
+        var result = DbaConnectionFactory.Validate("mysql", connectionString);
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.MissingRequiredParameter, result.Code);
+        Assert.Equal("SslMode", result.Details, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("Required")]
+    [InlineData("VerifyCA")]
+    [InlineData("VerifyFull")]
+    [InlineData("required")]
+    public void Validate_MySqlConnectionString_WithEnforcingSslMode_Succeeds(string sslMode)
+    {
+        var connectionString = $"Server=dbhost;Database=app;User ID=user;Password=password;SslMode={sslMode}";
+        var result = DbaConnectionFactory.Validate("mysql", connectionString);
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.None, result.Code);
+        Assert.True(result.IsValid);
     }
 
     [Fact]
@@ -97,6 +125,7 @@ public class DbaConnectionFactoryTests
     [InlineData("Disable")]
     [InlineData("Allow")]
     [InlineData("Prefer")]
+    [InlineData("Invalid")]
     public void Validate_PostgreSqlConnectionString_WithInsecureSslModes_IsRejected(string sslMode)
     {
         var connectionString = $"Server=dbhost;Database=app;Username=user;Password=password;SslMode={sslMode}";
@@ -105,6 +134,30 @@ public class DbaConnectionFactoryTests
         Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.UnsupportedOption, result.Code);
         Assert.True(string.Equals("SSL Mode", result.Details, StringComparison.OrdinalIgnoreCase)
             || string.Equals("SslMode", result.Details, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_PostgreSqlConnectionString_WithEmptySslMode_IsRejected()
+    {
+        var connectionString = "Server=dbhost;Database=app;Username=user;Password=password;SslMode=";
+        var result = DbaConnectionFactory.Validate("postgresql", connectionString);
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.MissingRequiredParameter, result.Code);
+        Assert.Equal("SslMode", result.Details, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("Require")]
+    [InlineData("VerifyCA")]
+    [InlineData("VerifyFull")]
+    [InlineData("require")]
+    public void Validate_PostgreSqlConnectionString_WithEnforcingSslMode_Succeeds(string sslMode)
+    {
+        var connectionString = $"Server=dbhost;Database=app;Username=user;Password=password;SslMode={sslMode}";
+        var result = DbaConnectionFactory.Validate("postgresql", connectionString);
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.None, result.Code);
+        Assert.True(result.IsValid);
     }
 
     [Fact]

--- a/DbaClientX.Tests/DbaConnectionFactoryTests.cs
+++ b/DbaClientX.Tests/DbaConnectionFactoryTests.cs
@@ -69,6 +69,30 @@ public class DbaConnectionFactoryTests
             || string.Equals("SslMode", result.Details, StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void Validate_MySqlConnectionString_WithoutSslMode_IsRejected()
+    {
+        var connectionString = "Server=dbhost;Database=app;User ID=user;Password=password";
+        var result = DbaConnectionFactory.Validate("mysql", connectionString);
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.MissingRequiredParameter, result.Code);
+        Assert.Equal("SslMode", result.Details, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("False")]
+    [InlineData("No")]
+    [InlineData("Optional")]
+    public void Validate_SqlServerConnectionString_WithDisabledEncryption_IsRejected(string encrypt)
+    {
+        var connectionString = $"Server=dbhost;Database=app;Encrypt={encrypt}";
+        var result = DbaConnectionFactory.Validate("sqlserver", connectionString);
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.UnsupportedOption, result.Code);
+        Assert.True(string.Equals("Encrypt", result.Details, StringComparison.OrdinalIgnoreCase)
+            || string.Equals("Encryption", result.Details, StringComparison.OrdinalIgnoreCase));
+    }
+
     [Theory]
     [InlineData("Disable")]
     [InlineData("Allow")]

--- a/DbaClientX.Tests/DbaConnectionFactoryTests.cs
+++ b/DbaClientX.Tests/DbaConnectionFactoryTests.cs
@@ -83,6 +83,16 @@ public class DbaConnectionFactoryTests
         Assert.Equal("SslMode", result.Details, StringComparer.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void Validate_MySqlConnectionString_WithWhitespaceSslMode_IsRejected()
+    {
+        var connectionString = "Server=dbhost;Database=app;User ID=user;Password=password;SslMode=   ";
+        var result = DbaConnectionFactory.Validate("mysql", connectionString);
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.MissingRequiredParameter, result.Code);
+        Assert.Equal("SslMode", result.Details, StringComparer.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData("Required")]
     [InlineData("VerifyCA")]
@@ -140,6 +150,16 @@ public class DbaConnectionFactoryTests
     public void Validate_PostgreSqlConnectionString_WithEmptySslMode_IsRejected()
     {
         var connectionString = "Server=dbhost;Database=app;Username=user;Password=password;SslMode=";
+        var result = DbaConnectionFactory.Validate("postgresql", connectionString);
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.MissingRequiredParameter, result.Code);
+        Assert.Equal("SslMode", result.Details, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_PostgreSqlConnectionString_WithWhitespaceSslMode_IsRejected()
+    {
+        var connectionString = "Server=dbhost;Database=app;Username=user;Password=password;SslMode=   ";
         var result = DbaConnectionFactory.Validate("postgresql", connectionString);
 
         Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.MissingRequiredParameter, result.Code);

--- a/DbaClientX.Tests/GenericExecutorsValidationTests.cs
+++ b/DbaClientX.Tests/GenericExecutorsValidationTests.cs
@@ -1,13 +1,120 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
+using NpgsqlTypes;
+using Oracle.ManagedDataAccess.Client;
+using Microsoft.Data.SqlClient;
 using Xunit;
 
 namespace DbaClientX.Tests;
 
 public class GenericExecutorsValidationTests
 {
+    private sealed class CaptureSqlServer : DBAClientX.SqlServer
+    {
+        public string? LastConnectionString { get; private set; }
+        public string? LastCommandText { get; private set; }
+
+        public override Task<int> ExecuteNonQueryAsync(
+            string connectionString,
+            string query,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, SqlDbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            LastConnectionString = connectionString;
+            LastCommandText = query;
+            return Task.FromResult(3);
+        }
+
+        public override Task<object?> ExecuteStoredProcedureAsync(
+            string connectionString,
+            string procedure,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, SqlDbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            LastConnectionString = connectionString;
+            LastCommandText = procedure;
+            return Task.FromResult<object?>(null);
+        }
+    }
+
+    private sealed class CapturePostgreSql : DBAClientX.PostgreSql
+    {
+        public string? LastConnectionString { get; private set; }
+        public string? LastCommandText { get; private set; }
+
+        public override Task<int> ExecuteNonQueryAsync(
+            string connectionString,
+            string query,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            LastConnectionString = connectionString;
+            LastCommandText = query;
+            return Task.FromResult(4);
+        }
+
+        public override Task<object?> ExecuteStoredProcedureAsync(
+            string connectionString,
+            string procedure,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, NpgsqlDbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            LastConnectionString = connectionString;
+            LastCommandText = procedure;
+            return Task.FromResult<object?>(null);
+        }
+    }
+
+    private sealed class CaptureOracle : DBAClientX.Oracle
+    {
+        public string? LastConnectionString { get; private set; }
+        public string? LastCommandText { get; private set; }
+
+        public override Task<int> ExecuteNonQueryAsync(
+            string connectionString,
+            string query,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, OracleDbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            LastConnectionString = connectionString;
+            LastCommandText = query;
+            return Task.FromResult(5);
+        }
+
+        public override Task<object?> ExecuteStoredProcedureAsync(
+            string connectionString,
+            string procedure,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, OracleDbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            LastConnectionString = connectionString;
+            LastCommandText = procedure;
+            return Task.FromResult<object?>(null);
+        }
+    }
+
     [Fact]
     public async Task PostgreSqlGeneric_ExecuteSqlAsync_RejectsBlankConnectionString()
     {
@@ -54,5 +161,201 @@ public class GenericExecutorsValidationTests
             DBAClientX.SQLiteGeneric.GenericExecutors.ExecuteSqlAsync(" ", "SELECT 1"));
 
         Assert.Equal("connectionStringOrPath", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task SqlServerGeneric_ExecuteSqlAsync_PreservesOriginalConnectionString()
+    {
+        var builder = new SqlConnectionStringBuilder
+        {
+            DataSource = "srv,1444",
+            InitialCatalog = "db",
+            IntegratedSecurity = true,
+            Encrypt = true,
+            TrustServerCertificate = true,
+            Pooling = false,
+            ApplicationName = "DbaClientX.Tests"
+        };
+        var client = new CaptureSqlServer();
+        var executorType = typeof(DBAClientX.SqlServer).Assembly.GetType("DBAClientX.SqlServerGeneric.GenericExecutors")!;
+        var factoryProperty = executorType.GetProperty("ClientFactory", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var originalFactory = (Func<DBAClientX.SqlServer>)factoryProperty.GetValue(null)!;
+        factoryProperty.SetValue(null, (Func<DBAClientX.SqlServer>)(() => client));
+
+        try
+        {
+            var method = executorType.GetMethod(
+                "ExecuteSqlAsync",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(string), typeof(string), typeof(IDictionary<string, object?>), typeof(CancellationToken) },
+                modifiers: null)!;
+            var affected = await (Task<int>)method.Invoke(null, new object?[] { builder.ConnectionString, "UPDATE t SET c = 1", null, CancellationToken.None })!;
+
+            Assert.Equal(3, affected);
+            Assert.Equal(builder.ConnectionString, client.LastConnectionString);
+            Assert.Equal("UPDATE t SET c = 1", client.LastCommandText);
+        }
+        finally
+        {
+            factoryProperty.SetValue(null, originalFactory);
+        }
+    }
+
+    [Fact]
+    public async Task SqlServerGeneric_ExecuteProcedureAsync_PreservesOriginalConnectionString()
+    {
+        var builder = new SqlConnectionStringBuilder
+        {
+            DataSource = "srv,1444",
+            InitialCatalog = "db",
+            IntegratedSecurity = true,
+            Encrypt = true,
+            TrustServerCertificate = true,
+            Pooling = false,
+            ApplicationName = "DbaClientX.Tests"
+        };
+        var client = new CaptureSqlServer();
+        var executorType = typeof(DBAClientX.SqlServer).Assembly.GetType("DBAClientX.SqlServerGeneric.GenericExecutors")!;
+        var factoryProperty = executorType.GetProperty("ClientFactory", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var originalFactory = (Func<DBAClientX.SqlServer>)factoryProperty.GetValue(null)!;
+        factoryProperty.SetValue(null, (Func<DBAClientX.SqlServer>)(() => client));
+
+        try
+        {
+            var method = executorType.GetMethod(
+                "ExecuteProcedureAsync",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(string), typeof(string), typeof(IDictionary<string, object?>), typeof(CancellationToken) },
+                modifiers: null)!;
+            var affected = await (Task<int>)method.Invoke(null, new object?[] { builder.ConnectionString, "dbo.sp_test", null, CancellationToken.None })!;
+
+            Assert.Equal(0, affected);
+            Assert.Equal(builder.ConnectionString, client.LastConnectionString);
+            Assert.Equal("dbo.sp_test", client.LastCommandText);
+        }
+        finally
+        {
+            factoryProperty.SetValue(null, originalFactory);
+        }
+    }
+
+    [Fact]
+    public async Task PostgreSqlGeneric_ExecuteSqlAsync_PreservesOriginalConnectionString()
+    {
+        var connectionString = "Host=dbhost;Port=15432;Database=app;Username=user;Password=pass;SSL Mode=Require;Timeout=17;Pooling=false;Application Name=DbaClientX.Tests";
+        var client = new CapturePostgreSql();
+        var originalFactory = DBAClientX.PostgreSqlGeneric.GenericExecutors.ClientFactory;
+        DBAClientX.PostgreSqlGeneric.GenericExecutors.ClientFactory = () => client;
+
+        try
+        {
+            var affected = await DBAClientX.PostgreSqlGeneric.GenericExecutors.ExecuteSqlAsync(connectionString, "UPDATE t SET c = 1");
+
+            Assert.Equal(4, affected);
+            Assert.Equal(connectionString, client.LastConnectionString);
+            Assert.Equal("UPDATE t SET c = 1", client.LastCommandText);
+        }
+        finally
+        {
+            DBAClientX.PostgreSqlGeneric.GenericExecutors.ClientFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public async Task PostgreSqlGeneric_ExecuteProcedureAsync_PreservesOriginalConnectionString()
+    {
+        var connectionString = "Host=dbhost;Port=15432;Database=app;Username=user;Password=pass;SSL Mode=Require;Timeout=17;Pooling=false;Application Name=DbaClientX.Tests";
+        var client = new CapturePostgreSql();
+        var originalFactory = DBAClientX.PostgreSqlGeneric.GenericExecutors.ClientFactory;
+        DBAClientX.PostgreSqlGeneric.GenericExecutors.ClientFactory = () => client;
+
+        try
+        {
+            var affected = await DBAClientX.PostgreSqlGeneric.GenericExecutors.ExecuteProcedureAsync(connectionString, "public.sp_test");
+
+            Assert.Equal(0, affected);
+            Assert.Equal(connectionString, client.LastConnectionString);
+            Assert.Equal("public.sp_test", client.LastCommandText);
+        }
+        finally
+        {
+            DBAClientX.PostgreSqlGeneric.GenericExecutors.ClientFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public async Task OracleGeneric_ExecuteSqlAsync_PreservesOriginalConnectionString()
+    {
+        var builder = new OracleConnectionStringBuilder
+        {
+            DataSource = "dbhost/svc",
+            UserID = "user",
+            Password = "pass",
+            Pooling = false,
+            ConnectionTimeout = 17
+        };
+        var client = new CaptureOracle();
+        var executorType = typeof(DBAClientX.Oracle).Assembly.GetType("DBAClientX.OracleGeneric.GenericExecutors")!;
+        var factoryProperty = executorType.GetProperty("ClientFactory", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var originalFactory = (Func<DBAClientX.Oracle>)factoryProperty.GetValue(null)!;
+        factoryProperty.SetValue(null, (Func<DBAClientX.Oracle>)(() => client));
+
+        try
+        {
+            var method = executorType.GetMethod(
+                "ExecuteSqlAsync",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(string), typeof(string), typeof(IDictionary<string, object?>), typeof(CancellationToken) },
+                modifiers: null)!;
+            var affected = await (Task<int>)method.Invoke(null, new object?[] { builder.ConnectionString, "UPDATE t SET c = 1", null, CancellationToken.None })!;
+
+            Assert.Equal(5, affected);
+            Assert.Equal(builder.ConnectionString, client.LastConnectionString);
+            Assert.Equal("UPDATE t SET c = 1", client.LastCommandText);
+        }
+        finally
+        {
+            factoryProperty.SetValue(null, originalFactory);
+        }
+    }
+
+    [Fact]
+    public async Task OracleGeneric_ExecuteProcedureAsync_PreservesOriginalConnectionString()
+    {
+        var builder = new OracleConnectionStringBuilder
+        {
+            DataSource = "dbhost/svc",
+            UserID = "user",
+            Password = "pass",
+            Pooling = false,
+            ConnectionTimeout = 17
+        };
+        var client = new CaptureOracle();
+        var executorType = typeof(DBAClientX.Oracle).Assembly.GetType("DBAClientX.OracleGeneric.GenericExecutors")!;
+        var factoryProperty = executorType.GetProperty("ClientFactory", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var originalFactory = (Func<DBAClientX.Oracle>)factoryProperty.GetValue(null)!;
+        factoryProperty.SetValue(null, (Func<DBAClientX.Oracle>)(() => client));
+
+        try
+        {
+            var method = executorType.GetMethod(
+                "ExecuteProcedureAsync",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(string), typeof(string), typeof(IDictionary<string, object?>), typeof(CancellationToken) },
+                modifiers: null)!;
+            var affected = await (Task<int>)method.Invoke(null, new object?[] { builder.ConnectionString, "sp_test", null, CancellationToken.None })!;
+
+            Assert.Equal(0, affected);
+            Assert.Equal(builder.ConnectionString, client.LastConnectionString);
+            Assert.Equal("sp_test", client.LastCommandText);
+        }
+        finally
+        {
+            factoryProperty.SetValue(null, originalFactory);
+        }
     }
 }

--- a/DbaClientX.Tests/MySqlGenericExecutorsTests.cs
+++ b/DbaClientX.Tests/MySqlGenericExecutorsTests.cs
@@ -14,7 +14,7 @@ public class MySqlGenericExecutorsTests
         public string? LastConnectionString { get; private set; }
         public string? LastCommandText { get; private set; }
 
-        internal override Task<int> ExecuteNonQueryAsync(
+        public override Task<int> ExecuteNonQueryAsync(
             string connectionString,
             string query,
             IDictionary<string, object?>? parameters = null,
@@ -28,7 +28,7 @@ public class MySqlGenericExecutorsTests
             return Task.FromResult(7);
         }
 
-        internal override Task<object?> ExecuteStoredProcedureAsync(
+        public override Task<object?> ExecuteStoredProcedureAsync(
             string connectionString,
             string procedure,
             IDictionary<string, object?>? parameters = null,

--- a/DbaClientX.Tests/ProviderMappedQueryParityTests.cs
+++ b/DbaClientX.Tests/ProviderMappedQueryParityTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
@@ -30,6 +32,44 @@ public class ProviderMappedQueryParityTests
         {
             AsyncDisposeCalls++;
             return default;
+        }
+    }
+
+    private sealed class CapturingSqlServer : DBAClientX.SqlServer
+    {
+        public int QueryAsyncCalls { get; private set; }
+        public int ScalarAsyncCalls { get; private set; }
+
+        protected override Task OpenConnectionAsync(SqlConnection connection, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        protected override ValueTask DisposeConnectionAsync(SqlConnection connection)
+            => default;
+
+        protected override Task<object?> ExecuteQueryAsync(
+            DbConnection connection,
+            DbTransaction? transaction,
+            string query,
+            IDictionary<string, object?>? parameters = null,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, DbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            QueryAsyncCalls++;
+            return Task.FromResult<object?>("query");
+        }
+
+        protected override Task<object?> ExecuteScalarAsync(
+            DbConnection connection,
+            DbTransaction? transaction,
+            string query,
+            IDictionary<string, object?>? parameters = null,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, DbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            ScalarAsyncCalls++;
+            return Task.FromResult<object?>(42);
         }
     }
 
@@ -218,6 +258,42 @@ public class ProviderMappedQueryParityTests
         Assert.Equal(0, mysql.AsyncDisposeCalls);
         Assert.Equal(0, postgreSql.AsyncDisposeCalls);
         Assert.Equal(0, oracle.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task SqlServerQueryAsync_UsesQueryExecutionPath()
+    {
+        using var connectionStringSql = new CapturingSqlServer();
+
+        var connectionStringResult = await connectionStringSql.QueryAsync(
+            "Server=.;Database=app;Integrated Security=True;Encrypt=True;TrustServerCertificate=True",
+            "SELECT 42");
+
+        Assert.Equal("query", connectionStringResult);
+        Assert.Equal(1, connectionStringSql.QueryAsyncCalls);
+        Assert.Equal(0, connectionStringSql.ScalarAsyncCalls);
+
+        using var hostSql = new CapturingSqlServer();
+
+        var hostResult = await hostSql.QueryAsync(".", "app", true, "SELECT 42");
+
+        Assert.Equal("query", hostResult);
+        Assert.Equal(1, hostSql.QueryAsyncCalls);
+        Assert.Equal(0, hostSql.ScalarAsyncCalls);
+    }
+
+    [Fact]
+    public async Task SqlServerConnectionStringExecuteScalarAsync_UsesScalarExecutionPath()
+    {
+        using var sql = new CapturingSqlServer();
+
+        var result = await sql.ExecuteScalarAsync(
+            "Server=.;Database=app;Integrated Security=True;Encrypt=True;TrustServerCertificate=True",
+            "SELECT 42");
+
+        Assert.Equal(42, result);
+        Assert.Equal(1, sql.ScalarAsyncCalls);
+        Assert.Equal(0, sql.QueryAsyncCalls);
     }
 
     [Fact]

--- a/DbaClientX.Tests/ProviderMappedQueryParityTests.cs
+++ b/DbaClientX.Tests/ProviderMappedQueryParityTests.cs
@@ -1,0 +1,317 @@
+using System;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+using MySqlConnector;
+using Npgsql;
+using Oracle.ManagedDataAccess.Client;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class ProviderMappedQueryParityTests
+{
+    private sealed class OpenFailureSqlServer : DBAClientX.SqlServer
+    {
+        public int AsyncDisposeCalls { get; private set; }
+        public int DisposeCalls { get; private set; }
+
+        protected override void OpenConnection(SqlConnection connection)
+            => throw new InvalidOperationException("boom");
+
+        protected override void DisposeConnection(SqlConnection connection)
+            => DisposeCalls++;
+
+        protected override Task OpenConnectionAsync(SqlConnection connection, CancellationToken cancellationToken)
+            => Task.FromException(new InvalidOperationException("boom"));
+
+        protected override ValueTask DisposeConnectionAsync(SqlConnection connection)
+        {
+            AsyncDisposeCalls++;
+            return default;
+        }
+    }
+
+    private sealed class OpenFailureMySql : DBAClientX.MySql
+    {
+        public int AsyncDisposeCalls { get; private set; }
+        public int DisposeCalls { get; private set; }
+
+        protected override void OpenConnection(MySqlConnection connection)
+            => throw new InvalidOperationException("boom");
+
+        protected override void DisposeConnection(MySqlConnection connection)
+            => DisposeCalls++;
+
+        protected override Task OpenConnectionAsync(MySqlConnection connection, CancellationToken cancellationToken)
+            => Task.FromException(new InvalidOperationException("boom"));
+
+        protected override ValueTask DisposeConnectionAsync(MySqlConnection connection)
+        {
+            AsyncDisposeCalls++;
+            return default;
+        }
+    }
+
+    private sealed class OpenFailurePostgreSql : DBAClientX.PostgreSql
+    {
+        public int AsyncDisposeCalls { get; private set; }
+        public int DisposeCalls { get; private set; }
+
+        protected override void OpenConnection(NpgsqlConnection connection)
+            => throw new InvalidOperationException("boom");
+
+        protected override void DisposeConnection(NpgsqlConnection connection)
+            => DisposeCalls++;
+
+        protected override Task OpenConnectionAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+            => Task.FromException(new InvalidOperationException("boom"));
+
+        protected override ValueTask DisposeConnectionAsync(NpgsqlConnection connection)
+        {
+            AsyncDisposeCalls++;
+            return default;
+        }
+    }
+
+    private sealed class OpenFailureOracle : DBAClientX.Oracle
+    {
+        public int AsyncDisposeCalls { get; private set; }
+        public int DisposeCalls { get; private set; }
+
+        protected override void OpenConnection(OracleConnection connection)
+            => throw new InvalidOperationException("boom");
+
+        protected override void DisposeConnection(OracleConnection connection)
+            => DisposeCalls++;
+
+        protected override Task OpenConnectionAsync(OracleConnection connection, CancellationToken cancellationToken)
+            => Task.FromException(new InvalidOperationException("boom"));
+
+        protected override ValueTask DisposeConnectionAsync(OracleConnection connection)
+        {
+            AsyncDisposeCalls++;
+            return default;
+        }
+    }
+
+    [Fact]
+    public async Task SqlServerQueryAsListAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
+    {
+        using var sql = new OpenFailureSqlServer();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            sql.QueryAsListAsync<int>("Server=.;Database=app;", "SELECT 1", null!));
+
+        Assert.Equal(0, sql.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task MySqlQueryAsListAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
+    {
+        using var mysql = new OpenFailureMySql();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            mysql.QueryAsListAsync<int>("Server=dbhost;Database=app;User ID=user;Password=password;SslMode=Required", "SELECT 1", null!));
+
+        Assert.Equal(0, mysql.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task OracleQueryAsListAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
+    {
+        using var oracle = new OpenFailureOracle();
+        var connectionString = DBAClientX.Oracle.BuildConnectionString("dbhost", "svc", "user", "password");
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            oracle.QueryAsListAsync<int>(connectionString, "SELECT 1 FROM dual", null!));
+
+        Assert.Equal(0, oracle.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task SqliteQueryAsListAsync_WithNullMapper_ThrowsBeforeBuildingConnection()
+    {
+        using var sqlite = new DBAClientX.SQLite();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            sqlite.QueryAsListAsync<int>(" ", "SELECT 1", null!));
+    }
+
+    [Fact]
+    public void SqlServerQueryStreamAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
+    {
+        using var sql = new OpenFailureSqlServer();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            sql.QueryStreamAsync<int>("Server=.;Database=app;", "SELECT 1", null!));
+
+        Assert.Equal(0, sql.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public void MySqlQueryStreamAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
+    {
+        using var mysql = new OpenFailureMySql();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            mysql.QueryStreamAsync<int>("Server=dbhost;Database=app;User ID=user;Password=password;SslMode=Required", "SELECT 1", null!));
+
+        Assert.Equal(0, mysql.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public void OracleQueryStreamAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
+    {
+        using var oracle = new OpenFailureOracle();
+        var connectionString = DBAClientX.Oracle.BuildConnectionString("dbhost", "svc", "user", "password");
+
+        Assert.Throws<ArgumentNullException>(() =>
+            oracle.QueryStreamAsync<int>(connectionString, "SELECT 1 FROM dual", null!));
+
+        Assert.Equal(0, oracle.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public void SqliteQueryStreamAsync_WithNullMapper_ThrowsBeforeBuildingConnection()
+    {
+        using var sqlite = new DBAClientX.SQLite();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            sqlite.QueryStreamAsync<int>(" ", "SELECT 1", null!));
+    }
+
+    [Fact]
+    public async Task ConnectionStringQueryAsync_RejectsInvalidSettingsBeforeOpeningConnection()
+    {
+        using var sql = new OpenFailureSqlServer();
+        using var mysql = new OpenFailureMySql();
+        using var postgreSql = new OpenFailurePostgreSql();
+        using var oracle = new OpenFailureOracle();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sql.QueryAsync("Server=.;", "SELECT 1"));
+        await Assert.ThrowsAsync<ArgumentException>(() => mysql.QueryAsync("Server=dbhost;Database=app;User ID=user;Password=password", "SELECT 1"));
+        await Assert.ThrowsAsync<ArgumentException>(() => postgreSql.QueryAsync("Host=dbhost;Database=app;Username=user;Password=password", "SELECT 1"));
+        await Assert.ThrowsAsync<ArgumentException>(() => oracle.QueryAsync("Data Source=dbhost/svc;User Id=user", "SELECT 1 FROM dual"));
+
+        Assert.Equal(0, sql.AsyncDisposeCalls);
+        Assert.Equal(0, mysql.AsyncDisposeCalls);
+        Assert.Equal(0, postgreSql.AsyncDisposeCalls);
+        Assert.Equal(0, oracle.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task ConnectionStringExecuteScalarAsync_RejectsInvalidSettingsBeforeOpeningConnection()
+    {
+        using var sql = new OpenFailureSqlServer();
+        using var mysql = new OpenFailureMySql();
+        using var postgreSql = new OpenFailurePostgreSql();
+        using var oracle = new OpenFailureOracle();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sql.ExecuteScalarAsync("Server=.;Database=app;Encrypt=False", "SELECT 1"));
+        await Assert.ThrowsAsync<ArgumentException>(() => mysql.ExecuteScalarAsync("Server=dbhost;Database=app;User ID=user;Password=password", "SELECT 1"));
+        await Assert.ThrowsAsync<ArgumentException>(() => postgreSql.ExecuteScalarAsync("Host=dbhost;Database=app;Username=user;Password=password", "SELECT 1"));
+        await Assert.ThrowsAsync<ArgumentException>(() => oracle.ExecuteScalarAsync("Data Source=dbhost/svc;User Id=user", "SELECT 1 FROM dual"));
+
+        Assert.Equal(0, sql.AsyncDisposeCalls);
+        Assert.Equal(0, mysql.AsyncDisposeCalls);
+        Assert.Equal(0, postgreSql.AsyncDisposeCalls);
+        Assert.Equal(0, oracle.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task ConnectionStringExecuteNonQueryAsync_RejectsInvalidSettingsBeforeOpeningConnection()
+    {
+        using var sql = new OpenFailureSqlServer();
+        using var mysql = new OpenFailureMySql();
+        using var postgreSql = new OpenFailurePostgreSql();
+        using var oracle = new OpenFailureOracle();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sql.ExecuteNonQueryAsync("Server=.;Database=app;Encrypt=False", "UPDATE t SET c = 1"));
+        await Assert.ThrowsAsync<ArgumentException>(() => mysql.ExecuteNonQueryAsync("Server=dbhost;Database=app;User ID=user;Password=password", "UPDATE t SET c = 1"));
+        await Assert.ThrowsAsync<ArgumentException>(() => postgreSql.ExecuteNonQueryAsync("Host=dbhost;Database=app;Username=user;Password=password", "UPDATE t SET c = 1"));
+        await Assert.ThrowsAsync<ArgumentException>(() => oracle.ExecuteNonQueryAsync("Data Source=dbhost/svc;User Id=user", "UPDATE t SET c = 1"));
+
+        Assert.Equal(0, sql.AsyncDisposeCalls);
+        Assert.Equal(0, mysql.AsyncDisposeCalls);
+        Assert.Equal(0, postgreSql.AsyncDisposeCalls);
+        Assert.Equal(0, oracle.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public void ConnectionStringExecuteNonQuery_RejectsInvalidSettingsBeforeOpeningConnection()
+    {
+        using var sql = new OpenFailureSqlServer();
+        using var mysql = new OpenFailureMySql();
+        using var postgreSql = new OpenFailurePostgreSql();
+        using var oracle = new OpenFailureOracle();
+
+        Assert.Throws<ArgumentException>(() => sql.ExecuteNonQuery("Server=.;Database=app;Encrypt=False", "UPDATE t SET c = 1"));
+        Assert.Throws<ArgumentException>(() => mysql.ExecuteNonQuery("Server=dbhost;Database=app;User ID=user;Password=password", "UPDATE t SET c = 1"));
+        Assert.Throws<ArgumentException>(() => postgreSql.ExecuteNonQuery("Host=dbhost;Database=app;Username=user;Password=password", "UPDATE t SET c = 1"));
+        Assert.Throws<ArgumentException>(() => oracle.ExecuteNonQuery("Data Source=dbhost/svc;User Id=user", "UPDATE t SET c = 1"));
+
+        Assert.Equal(0, sql.DisposeCalls);
+        Assert.Equal(0, mysql.DisposeCalls);
+        Assert.Equal(0, postgreSql.DisposeCalls);
+        Assert.Equal(0, oracle.DisposeCalls);
+    }
+
+    [Fact]
+    public void ConnectionStringQuery_RejectsInvalidSettingsBeforeOpeningConnection()
+    {
+        using var sql = new OpenFailureSqlServer();
+        using var mysql = new OpenFailureMySql();
+        using var postgreSql = new OpenFailurePostgreSql();
+        using var oracle = new OpenFailureOracle();
+
+        Assert.Throws<ArgumentException>(() => sql.Query("Server=.;Database=app;Encrypt=False", "SELECT 1"));
+        Assert.Throws<ArgumentException>(() => mysql.Query("Server=dbhost;Database=app;User ID=user;Password=password", "SELECT 1"));
+        Assert.Throws<ArgumentException>(() => postgreSql.Query("Host=dbhost;Database=app;Username=user;Password=password", "SELECT 1"));
+        Assert.Throws<ArgumentException>(() => oracle.Query("Data Source=dbhost/svc;User Id=user", "SELECT 1 FROM dual"));
+
+        Assert.Equal(0, sql.DisposeCalls);
+        Assert.Equal(0, mysql.DisposeCalls);
+        Assert.Equal(0, postgreSql.DisposeCalls);
+        Assert.Equal(0, oracle.DisposeCalls);
+    }
+
+    [Fact]
+    public void ConnectionStringExecuteScalar_RejectsInvalidSettingsBeforeOpeningConnection()
+    {
+        using var sql = new OpenFailureSqlServer();
+        using var mysql = new OpenFailureMySql();
+        using var postgreSql = new OpenFailurePostgreSql();
+        using var oracle = new OpenFailureOracle();
+
+        Assert.Throws<ArgumentException>(() => sql.ExecuteScalar("Server=.;Database=app;Encrypt=False", "SELECT 1"));
+        Assert.Throws<ArgumentException>(() => mysql.ExecuteScalar("Server=dbhost;Database=app;User ID=user;Password=password", "SELECT 1"));
+        Assert.Throws<ArgumentException>(() => postgreSql.ExecuteScalar("Host=dbhost;Database=app;Username=user;Password=password", "SELECT 1"));
+        Assert.Throws<ArgumentException>(() => oracle.ExecuteScalar("Data Source=dbhost/svc;User Id=user", "SELECT 1 FROM dual"));
+
+        Assert.Equal(0, sql.DisposeCalls);
+        Assert.Equal(0, mysql.DisposeCalls);
+        Assert.Equal(0, postgreSql.DisposeCalls);
+        Assert.Equal(0, oracle.DisposeCalls);
+    }
+
+    [Fact]
+    public async Task ConnectionStringExecuteStoredProcedureAsync_RejectsInvalidSettingsBeforeOpeningConnection()
+    {
+        using var sql = new OpenFailureSqlServer();
+        using var mysql = new OpenFailureMySql();
+        using var postgreSql = new OpenFailurePostgreSql();
+        using var oracle = new OpenFailureOracle();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => sql.ExecuteStoredProcedureAsync("Server=.;Database=app;Encrypt=False", "sp_test"));
+        await Assert.ThrowsAsync<ArgumentException>(() => mysql.ExecuteStoredProcedureAsync("Server=dbhost;Database=app;User ID=user;Password=password", "sp_test"));
+        await Assert.ThrowsAsync<ArgumentException>(() => postgreSql.ExecuteStoredProcedureAsync("Host=dbhost;Database=app;Username=user;Password=password", "sp_test"));
+        await Assert.ThrowsAsync<ArgumentException>(() => oracle.ExecuteStoredProcedureAsync("Data Source=dbhost/svc;User Id=user", "sp_test"));
+
+        Assert.Equal(0, sql.AsyncDisposeCalls);
+        Assert.Equal(0, mysql.AsyncDisposeCalls);
+        Assert.Equal(0, postgreSql.AsyncDisposeCalls);
+        Assert.Equal(0, oracle.AsyncDisposeCalls);
+    }
+}

--- a/DbaClientX.Tests/ProviderParameterLookupParityTests.cs
+++ b/DbaClientX.Tests/ProviderParameterLookupParityTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Data;
+using DBAClientX;
+using Microsoft.Data.SqlClient;
+using MySqlConnector;
+using Npgsql;
+using NpgsqlTypes;
+using Oracle.ManagedDataAccess.Client;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class ProviderParameterLookupParityTests
+{
+    private sealed class SqlServerParameterProbe : DBAClientX.SqlServer
+    {
+        public SqlParameter Capture()
+        {
+            using var command = new SqlCommand();
+            AddParameters(
+                command,
+                new Dictionary<string, object?> { ["@ID"] = 1 },
+                ConvertParameterTypes(new Dictionary<string, SqlDbType> { ["@id"] = SqlDbType.Int }),
+                new Dictionary<string, ParameterDirection> { ["@id"] = ParameterDirection.InputOutput });
+            return (SqlParameter)command.Parameters[0];
+        }
+    }
+
+    private sealed class MySqlParameterProbe : DBAClientX.MySql
+    {
+        public MySqlParameter Capture()
+        {
+            using var command = new MySqlCommand();
+            AddParameters(
+                command,
+                new Dictionary<string, object?> { ["@ID"] = 1 },
+                ConvertParameterTypes(new Dictionary<string, MySqlDbType> { ["@id"] = MySqlDbType.Int32 }),
+                new Dictionary<string, ParameterDirection> { ["@id"] = ParameterDirection.InputOutput });
+            return (MySqlParameter)command.Parameters[0];
+        }
+    }
+
+    private sealed class PostgreSqlParameterProbe : DBAClientX.PostgreSql
+    {
+        public NpgsqlParameter Capture()
+        {
+            using var command = new NpgsqlCommand();
+            AddParameters(
+                command,
+                new Dictionary<string, object?> { ["@ID"] = 1 },
+                ConvertParameterTypes(new Dictionary<string, NpgsqlDbType> { ["@id"] = NpgsqlDbType.Integer }),
+                new Dictionary<string, ParameterDirection> { ["@id"] = ParameterDirection.InputOutput });
+            return (NpgsqlParameter)command.Parameters[0];
+        }
+    }
+
+    private sealed class OracleParameterProbe : DBAClientX.Oracle
+    {
+        public OracleParameter Capture()
+        {
+            using var command = new OracleCommand();
+            AddParameters(
+                command,
+                new Dictionary<string, object?> { [":ID"] = 1 },
+                ConvertParameterTypes(new Dictionary<string, OracleDbType> { [":id"] = OracleDbType.Int32 }),
+                new Dictionary<string, ParameterDirection> { [":id"] = ParameterDirection.InputOutput });
+            return (OracleParameter)command.Parameters[0];
+        }
+    }
+
+    [Fact]
+    public void ProviderSpecificParameterTypes_MatchKeysCaseInsensitively()
+    {
+        var sql = new SqlServerParameterProbe().Capture();
+        var mysql = new MySqlParameterProbe().Capture();
+        var postgreSql = new PostgreSqlParameterProbe().Capture();
+        var oracle = new OracleParameterProbe().Capture();
+
+        Assert.Equal(SqlDbType.Int, sql.SqlDbType);
+        Assert.Equal(ParameterDirection.InputOutput, sql.Direction);
+
+        Assert.Equal(MySqlDbType.Int32, mysql.MySqlDbType);
+        Assert.Equal(ParameterDirection.InputOutput, mysql.Direction);
+
+        Assert.Equal(NpgsqlDbType.Integer, postgreSql.NpgsqlDbType);
+        Assert.Equal(ParameterDirection.InputOutput, postgreSql.Direction);
+
+        Assert.Equal(OracleDbType.Int32, oracle.OracleDbType);
+        Assert.Equal(ParameterDirection.InputOutput, oracle.Direction);
+    }
+}


### PR DESCRIPTION
## Summary
- Extend connection-string query, non-query, scalar, and stored-procedure parity across providers.
- Add typed mapped query/stream parity and exact connection-string preservation in generic executors.
- Harden SQL Server, MySQL, and PostgreSQL connection validation plus case-insensitive provider parameter lookup.
- Use SequentialAccess for reader materialization/streaming and update provider READMEs.

## Tests
- `dotnet build DbaClientX.sln --no-restore`
- `dotnet test DbaClientX.Tests/DbaClientX.Tests.csproj --no-build`
- `git diff --check`
