### PR TITLE
Improve bulk provider parity and AOT readiness

### DIFF
--- a/DbaClientX.Core/Compatibility/DynamicallyAccessedMembers.cs
+++ b/DbaClientX.Core/Compatibility/DynamicallyAccessedMembers.cs
@@ -1,0 +1,74 @@
+#if NET472
+namespace System.Diagnostics.CodeAnalysis;
+
+[System.Flags]
+internal enum DynamicallyAccessedMemberTypes
+{
+    None = 0,
+    PublicParameterlessConstructor = 0x0001,
+    PublicConstructors = 0x0002 | PublicParameterlessConstructor,
+    NonPublicConstructors = 0x0004,
+    PublicMethods = 0x0008,
+    NonPublicMethods = 0x0010,
+    PublicFields = 0x0020,
+    NonPublicFields = 0x0040,
+    PublicNestedTypes = 0x0080,
+    NonPublicNestedTypes = 0x0100,
+    PublicProperties = 0x0200,
+    NonPublicProperties = 0x0400,
+    PublicEvents = 0x0800,
+    NonPublicEvents = 0x1000,
+    Interfaces = 0x2000,
+    All = ~None
+}
+
+[System.AttributeUsage(
+    System.AttributeTargets.Field |
+    System.AttributeTargets.ReturnValue |
+    System.AttributeTargets.GenericParameter |
+    System.AttributeTargets.Parameter |
+    System.AttributeTargets.Property |
+    System.AttributeTargets.Method |
+    System.AttributeTargets.Class |
+    System.AttributeTargets.Struct)]
+internal sealed class DynamicallyAccessedMembersAttribute : System.Attribute
+{
+    public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        => MemberTypes = memberTypes;
+
+    public DynamicallyAccessedMemberTypes MemberTypes { get; }
+}
+
+[System.AttributeUsage(System.AttributeTargets.Method | System.AttributeTargets.Constructor | System.AttributeTargets.Class | System.AttributeTargets.Struct)]
+internal sealed class RequiresUnreferencedCodeAttribute : System.Attribute
+{
+    public RequiresUnreferencedCodeAttribute(string message)
+        => Message = message;
+
+    public string Message { get; }
+
+    public string? Url { get; set; }
+}
+
+[System.AttributeUsage(System.AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+internal sealed class UnconditionalSuppressMessageAttribute : System.Attribute
+{
+    public UnconditionalSuppressMessageAttribute(string category, string checkId)
+    {
+        Category = category;
+        CheckId = checkId;
+    }
+
+    public string Category { get; }
+
+    public string CheckId { get; }
+
+    public string? Scope { get; set; }
+
+    public string? Target { get; set; }
+
+    public string? MessageId { get; set; }
+
+    public string? Justification { get; set; }
+}
+#endif

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -585,9 +585,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
                 }
                 else if (returnType == ReturnType.DataTable || returnType == ReturnType.PSObject)
                 {
-                    var table = new DataTable("Table0");
-                    table.Load(reader);
-                    result = table;
+                    result = ReadDataTable(reader, "Table0");
                 }
                 else
                 {
@@ -595,8 +593,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
                     var tableIndex = 0;
                     do
                     {
-                        var table = new DataTable($"Table{tableIndex}");
-                        table.Load(reader);
+                        var table = ReadDataTable(reader, $"Table{tableIndex}");
                         dataSet.Tables.Add(table);
                         tableIndex++;
                     } while (!reader.IsClosed && reader.NextResult());
@@ -728,9 +725,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
                 }
                 else if (returnType == ReturnType.DataTable || returnType == ReturnType.PSObject)
                 {
-                    var table = new DataTable("Table0");
-                    table.Load(reader);
-                    result = table;
+                    result = await ReadDataTableAsync(reader, "Table0", cancellationToken).ConfigureAwait(false);
                 }
                 else
                 {
@@ -738,8 +733,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
                     var tableIndex = 0;
                     do
                     {
-                        var table = new DataTable($"Table{tableIndex}");
-                        table.Load(reader);
+                        var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
                         dataSet.Tables.Add(table);
                         tableIndex++;
                     } while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
@@ -1095,6 +1089,65 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             return dataSet;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Materializes the current result set from a data reader without relying on <see cref="DataTable.Load(IDataReader)"/>.
+    /// </summary>
+    /// <param name="reader">Reader positioned before the first row of the current result set.</param>
+    /// <param name="tableName">Name assigned to the created data table.</param>
+    /// <returns>A data table containing every row in the current result set.</returns>
+    protected static DataTable ReadDataTable(DbDataReader reader, string tableName)
+    {
+        var table = new DataTable(tableName);
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            table.Columns.Add(reader.GetName(i), reader.GetFieldType(i));
+        }
+
+        while (reader.Read())
+        {
+            var row = table.NewRow();
+            for (var i = 0; i < reader.FieldCount; i++)
+            {
+                row[i] = reader.IsDBNull(i) ? DBNull.Value : reader.GetValue(i);
+            }
+
+            table.Rows.Add(row);
+        }
+
+        return table;
+    }
+
+    /// <summary>
+    /// Asynchronously materializes the current result set from a data reader without relying on <see cref="DataTable.Load(IDataReader)"/>.
+    /// </summary>
+    /// <param name="reader">Reader positioned before the first row of the current result set.</param>
+    /// <param name="tableName">Name assigned to the created data table.</param>
+    /// <param name="cancellationToken">Token used to cancel reader operations.</param>
+    /// <returns>A data table containing every row in the current result set.</returns>
+    protected static async Task<DataTable> ReadDataTableAsync(DbDataReader reader, string tableName, CancellationToken cancellationToken)
+    {
+        var table = new DataTable(tableName);
+        for (var i = 0; i < reader.FieldCount; i++)
+        {
+            table.Columns.Add(reader.GetName(i), reader.GetFieldType(i));
+        }
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var row = table.NewRow();
+            for (var i = 0; i < reader.FieldCount; i++)
+            {
+                row[i] = await reader.IsDBNullAsync(i, cancellationToken).ConfigureAwait(false)
+                    ? DBNull.Value
+                    : reader.GetValue(i);
+            }
+
+            table.Rows.Add(row);
+        }
+
+        return table;
     }
 
     /// <summary>

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -1100,9 +1100,10 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     protected static DataTable ReadDataTable(DbDataReader reader, string tableName)
     {
         var table = new DataTable(tableName);
+        var columnNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < reader.FieldCount; i++)
         {
-            table.Columns.Add(reader.GetName(i), reader.GetFieldType(i));
+            table.Columns.Add(GetUniqueColumnName(reader.GetName(i), i, columnNames), reader.GetFieldType(i));
         }
 
         while (reader.Read())
@@ -1129,9 +1130,10 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     protected static async Task<DataTable> ReadDataTableAsync(DbDataReader reader, string tableName, CancellationToken cancellationToken)
     {
         var table = new DataTable(tableName);
+        var columnNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < reader.FieldCount; i++)
         {
-            table.Columns.Add(reader.GetName(i), reader.GetFieldType(i));
+            table.Columns.Add(GetUniqueColumnName(reader.GetName(i), i, columnNames), reader.GetFieldType(i));
         }
 
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -1148,6 +1150,20 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         }
 
         return table;
+    }
+
+    private static string GetUniqueColumnName(string? columnName, int ordinal, HashSet<string> usedNames)
+    {
+        var baseName = string.IsNullOrEmpty(columnName) ? $"Column{ordinal + 1}" : columnName!;
+        var name = baseName;
+        var suffix = 1;
+        while (!usedNames.Add(name))
+        {
+            name = baseName + suffix;
+            suffix++;
+        }
+
+        return name;
     }
 
     /// <summary>

--- a/DbaClientX.Core/DbaClientX.Core.csproj
+++ b/DbaClientX.Core/DbaClientX.Core.csproj
@@ -26,6 +26,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net10.0'">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
   </ItemGroup>

--- a/DbaClientX.Core/Invoker/DbInvoker.cs
+++ b/DbaClientX.Core/Invoker/DbInvoker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,6 +44,7 @@ public static class DbInvoker
     /// <param name="ambient">Ambient values available to mapping keys (e.g., RunId, TsUtc).</param>
     /// <returns>Sum of affected rows reported by the provider (0 for providers that don’t return counts).</returns>
     /// <exception cref="InvalidOperationException">Thrown when provider GenericExecutors cannot be resolved.</exception>
+    [RequiresUnreferencedCode("DbInvoker discovers provider executors and maps object properties by reflection. Preserve provider GenericExecutors types and item properties when trimming.")]
     public static async Task<int> ExecuteSqlAsync(
         string providerAlias,
         string connectionString,
@@ -136,6 +138,7 @@ public static class DbInvoker
     /// <param name="ambient">Ambient values available to mappings.</param>
     /// <returns>Sum of affected rows reported by the provider (0 for providers that don’t return counts).</returns>
     /// <exception cref="InvalidOperationException">Thrown when provider GenericExecutors cannot be resolved.</exception>
+    [RequiresUnreferencedCode("DbInvoker discovers provider executors and maps object properties by reflection. Preserve provider GenericExecutors types and item properties when trimming.")]
     public static async Task<int> ExecuteProcedureAsync(
         string providerAlias,
         string connectionString,
@@ -243,6 +246,7 @@ public static class DbInvoker
         return null;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Executor discovery is explicitly marked as reflection-based at the public DbInvoker entry points.")]
     private static MethodInfo? TryGetExec(Assembly asm, string? typeName, string methodName)
     {
         try
@@ -273,6 +277,7 @@ public static class DbInvoker
         return null;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = "Executor discovery reflects provider GenericExecutors methods by design.")]
     private static MethodInfo? FindPreferredOverload(Type? t, string methodName)
     {
         if (t == null) return null;

--- a/DbaClientX.Core/Mapping/DbParameterMapper.cs
+++ b/DbaClientX.Core/Mapping/DbParameterMapper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace DBAClientX.Mapping;
 
@@ -39,11 +40,37 @@ public static class DbParameterMapper
     /// <param name="options">Conversion options (enum handling, DateTimeOffset conversion, custom converters).</param>
     /// <param name="ambient">Optional ambient values available to mappings when the item does not provide a value (e.g., RunId, TsUtc).</param>
     /// <returns>A new dictionary of provider parameters to values.</returns>
+    [RequiresUnreferencedCode("Use the generic MapItem<T> overload when trimming so public properties can be preserved.")]
     public static IDictionary<string, object?> MapItem(
         object? item,
         IReadOnlyDictionary<string, string> map,
         DbParameterMapperOptions? options = null,
         IReadOnlyDictionary<string, object?>? ambient = null)
+        => MapItemRuntime(item, map, options, ambient);
+
+    [RequiresUnreferencedCode("Use the generic MapItem<T> overload when trimming so public properties can be preserved.")]
+    private static IDictionary<string, object?> MapItemRuntime(
+        object? item,
+        IReadOnlyDictionary<string, string> map,
+        DbParameterMapperOptions? options,
+        IReadOnlyDictionary<string, object?>? ambient)
+        => MapItemCore(item, map, options, ambient);
+
+    /// <summary>
+    /// Maps a strongly typed item while preserving public properties for trimmed/AOT builds.
+    /// </summary>
+    public static IDictionary<string, object?> MapItem<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)] T>(
+        T? item,
+        IReadOnlyDictionary<string, string> map,
+        DbParameterMapperOptions? options = null,
+        IReadOnlyDictionary<string, object?>? ambient = null)
+        => MapItemCore(item, map, options, ambient);
+
+    private static IDictionary<string, object?> MapItemCore<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)] T>(
+        T? item,
+        IReadOnlyDictionary<string, string> map,
+        DbParameterMapperOptions? options,
+        IReadOnlyDictionary<string, object?>? ambient)
     {
         options ??= new DbParameterMapperOptions();
         var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);

--- a/DbaClientX.Core/Mapping/DbPropertyAccessor.cs
+++ b/DbaClientX.Core/Mapping/DbPropertyAccessor.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq.Expressions;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace DBAClientX.Mapping;
@@ -24,14 +24,31 @@ public static class DbPropertyAccessor
     /// <param name="path">Dotted, case-insensitive path (e.g., "User.Name" or "Metadata.Tags.0").</param>
     /// <param name="value">When this method returns, contains the resolved value or null.</param>
     /// <returns>True when a value was resolved; otherwise false.</returns>
+    [RequiresUnreferencedCode("Use the generic TryGetValue<T> overload when trimming so public properties can be preserved.")]
     public static bool TryGetValue(object? item, string path, out object? value)
+        => TryGetValueCore(item, item?.GetType(), path, out value);
+
+    /// <summary>
+    /// Tries to resolve a value from a strongly typed item while preserving public properties for trimmed/AOT builds.
+    /// </summary>
+    /// <param name="item">The typed source object (POCO or dictionary) to read from.</param>
+    /// <param name="path">Dotted, case-insensitive path (e.g., "User.Name" or "Metadata.Tags.0").</param>
+    /// <param name="value">When this method returns, contains the resolved value or null.</param>
+    /// <returns>True when a value was resolved; otherwise false.</returns>
+    public static bool TryGetValue<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)] T>(T? item, string path, out object? value)
+        => TryGetValueCore(item, typeof(T), path, out value);
+
+    private static bool TryGetValueCore(object? item, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)] Type? type, string path, out object? value)
     {
         value = null;
-        if (item is null || string.IsNullOrWhiteSpace(path)) return false;
+        if (item is null || type is null || string.IsNullOrWhiteSpace(path)) return false;
 
-        var type = item.GetType();
         var key = (type, path);
-        var getter = _getterCache.GetOrAdd(key, k => BuildGetter(k.Item1, k.Item2));
+        if (!_getterCache.TryGetValue(key, out var getter))
+        {
+            getter = _getterCache.GetOrAdd(key, BuildGetter(type, path));
+        }
+
         if (getter is null) return false;
         value = getter(item);
         if (ReferenceEquals(value, MissingValue))
@@ -42,10 +59,13 @@ public static class DbPropertyAccessor
         return true;
     }
 
-    private static Func<object, object?> BuildGetter(Type type, string path)
+    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = "Nested runtime property types are a best-effort reflection fallback; strongly typed entry points annotate the root type.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Nested runtime property types are a best-effort reflection fallback; strongly typed entry points annotate the root type.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "The runtime-property fallback is best-effort for dynamic shapes; strongly typed entry points annotate the root type.")]
+    private static Func<object, object?> BuildGetter([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties | DynamicallyAccessedMemberTypes.Interfaces)] Type type, string path)
     {
         var segments = path.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
-        // Pre-resolve property infos per segment (case-insensitive), but support dictionaries on the fly
+        // Pre-resolve property infos per segment (case-insensitive), but support dictionaries on the fly.
         var props = new PropertyInfo?[segments.Length];
         Type? current = type;
         for (int i = 0; i < segments.Length; i++)
@@ -72,52 +92,6 @@ public static class DbPropertyAccessor
             if (current is null) break;
         }
 
-        // If all segments resolved to properties (no dictionaries), build a compiled expression fast path
-        bool allProps = true;
-        for (int i = 0; i < props.Length; i++) { if (props[i] == null) { allProps = false; break; } }
-        if (allProps && props.Length > 0)
-        {
-            try
-            {
-                var objParam = Expression.Parameter(typeof(object), "obj");
-                // root may be null or not of the expected type
-                var rootAs = Expression.TypeAs(objParam, type);
-
-                Expression BuildChain(Expression curExpr, int index)
-                {
-                    if (index >= props.Length)
-                    {
-                        return Expression.Convert(curExpr, typeof(object));
-                    }
-                    var prop = props[index]!;
-                    var access = Expression.Property(curExpr, prop);
-                    var t = prop.PropertyType;
-                    bool isRef = !t.IsValueType;
-                    bool isNullableValue = Nullable.GetUnderlyingType(t) != null;
-                    if (isRef || isNullableValue)
-                    {
-                        return Expression.Condition(
-                            Expression.Equal(access, Expression.Constant(null, t)),
-                            Expression.Constant(null, typeof(object)),
-                            BuildChain(access, index + 1));
-                    }
-                    return BuildChain(access, index + 1);
-                }
-
-                var body = Expression.Condition(
-                    Expression.Equal(rootAs, Expression.Constant(null, type)),
-                    Expression.Constant(null, typeof(object)),
-                    BuildChain(rootAs, 0));
-                var lambda = Expression.Lambda<Func<object, object?>>(body, objParam);
-                return lambda.Compile();
-            }
-            catch
-            {
-                // fall back to reflective path below
-            }
-        }
-
-        // Fallback: reflective/dictionary-aware path
         return (obj) =>
         {
             object? cur = obj;
@@ -202,6 +176,8 @@ public static class DbPropertyAccessor
         return false;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "Generic dictionary probing is a best-effort fallback for runtime dictionary shapes.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Generic dictionary probing is a best-effort fallback for runtime dictionary shapes.")]
     private static bool TryGetFromGenericDictionary(object obj, string key, out object? value)
     {
         value = null;
@@ -219,10 +195,10 @@ public static class DbPropertyAccessor
         return TryGetFromStringDictionaryEnumeration(obj, dictionaryType, key, out value);
     }
 
-    private static bool HasStringDictionaryInterface(Type? type)
+    private static bool HasStringDictionaryInterface([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? type)
         => FindStringDictionaryInterface(type) is not null;
 
-    private static Type? FindStringDictionaryInterface(Type? type)
+    private static Type? FindStringDictionaryInterface([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? type)
     {
         if (type is null) return null;
 
@@ -254,7 +230,7 @@ public static class DbPropertyAccessor
         return null;
     }
 
-    private static bool TryGetFromTypedStringDictionary(object obj, Type dictionaryType, string key, out object? value)
+    private static bool TryGetFromTypedStringDictionary(object obj, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.PublicProperties)] Type dictionaryType, string key, out object? value)
     {
         value = null;
 
@@ -285,6 +261,7 @@ public static class DbPropertyAccessor
         return false;
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Enumeration fallback reflects KeyValuePair-shaped entries after dictionary interface probing.")]
     private static bool TryGetFromStringDictionaryEnumeration(object obj, Type dictionaryType, string key, out object? value)
     {
         value = null;
@@ -293,18 +270,17 @@ public static class DbPropertyAccessor
             return false;
         }
 
-        var valueType = dictionaryType.GetGenericArguments()[1];
-        var expectedPairType = typeof(KeyValuePair<,>).MakeGenericType(typeof(string), valueType);
-        var keyProperty = expectedPairType.GetProperty(nameof(KeyValuePair<string, object>.Key));
-        var valueProperty = expectedPairType.GetProperty(nameof(KeyValuePair<string, object>.Value));
-        if (keyProperty is null || valueProperty is null)
-        {
-            return false;
-        }
-
         foreach (var entry in enumerable)
         {
-            if (entry is null || !expectedPairType.IsInstanceOfType(entry))
+            if (entry is null)
+            {
+                continue;
+            }
+
+            var entryType = entry.GetType();
+            var keyProperty = entryType.GetProperty(nameof(KeyValuePair<string, object>.Key));
+            var valueProperty = entryType.GetProperty(nameof(KeyValuePair<string, object>.Value));
+            if (keyProperty is null || valueProperty is null)
             {
                 continue;
             }
@@ -320,11 +296,17 @@ public static class DbPropertyAccessor
         return false;
     }
 
-    private static PropertyInfo? FindPropertyIgnoreCase(Type? type, string name)
+    private static PropertyInfo? FindPropertyIgnoreCase([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type? type, string name)
     {
         if (type is null) return null;
-        // Prefer case-insensitive name match, public instance properties
-        var p = type.GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase);
-        return p;
+        foreach (var property in type.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+        {
+            if (string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return property;
+            }
+        }
+
+        return null;
     }
 }

--- a/DbaClientX.MySql/DbaClientX.MySql.csproj
+++ b/DbaClientX.MySql/DbaClientX.MySql.csproj
@@ -26,6 +26,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net10.0'">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
   </ItemGroup>

--- a/DbaClientX.MySql/MySql.BulkOperations.cs
+++ b/DbaClientX.MySql/MySql.BulkOperations.cs
@@ -26,6 +26,22 @@ public partial class MySql
         ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         var connectionString = BuildConnectionString(host, database, username, password);
+        BulkInsert(connectionString, table, destinationTable, useTransaction, batchSize, bulkCopyTimeout);
+    }
+
+    /// <summary>
+    /// Performs a bulk insert using <see cref="MySqlBulkCopy"/> and a full MySQL connection string.
+    /// </summary>
+    public virtual void BulkInsert(
+        string connectionString,
+        DataTable table,
+        string destinationTable,
+        bool useTransaction = false,
+        int? batchSize = null,
+        int? bulkCopyTimeout = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         MySqlConnection? connection = null;
         MySqlTransaction? transaction = null;
@@ -35,16 +51,7 @@ public partial class MySql
         {
             (connection, transaction, dispose) = ResolveConnection(connectionString, useTransaction);
             var bulkCopy = CreateBulkCopy(connection!, transaction);
-            bulkCopy.DestinationTableName = destinationTable;
-            if (bulkCopyTimeout.HasValue)
-            {
-                bulkCopy.BulkCopyTimeout = bulkCopyTimeout.Value;
-            }
-
-            foreach (DataColumn column in table.Columns)
-            {
-                bulkCopy.ColumnMappings.Add(new MySqlBulkCopyColumnMapping(column.Ordinal, column.ColumnName, null));
-            }
+            ConfigureBulkCopy(bulkCopy, table, destinationTable, bulkCopyTimeout);
 
             if (batchSize.HasValue && batchSize.Value > 0)
             {
@@ -94,6 +101,23 @@ public partial class MySql
         ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         var connectionString = BuildConnectionString(host, database, username, password);
+        await BulkInsertAsync(connectionString, table, destinationTable, useTransaction, batchSize, bulkCopyTimeout, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Performs a bulk insert asynchronously using <see cref="MySqlBulkCopy"/> and a full MySQL connection string.
+    /// </summary>
+    public virtual async Task BulkInsertAsync(
+        string connectionString,
+        DataTable table,
+        string destinationTable,
+        bool useTransaction = false,
+        int? batchSize = null,
+        int? bulkCopyTimeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         MySqlConnection? connection = null;
         MySqlTransaction? transaction = null;
@@ -103,16 +127,7 @@ public partial class MySql
         {
             (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             var bulkCopy = CreateBulkCopy(connection!, transaction);
-            bulkCopy.DestinationTableName = destinationTable;
-            if (bulkCopyTimeout.HasValue)
-            {
-                bulkCopy.BulkCopyTimeout = bulkCopyTimeout.Value;
-            }
-
-            foreach (DataColumn column in table.Columns)
-            {
-                bulkCopy.ColumnMappings.Add(new MySqlBulkCopyColumnMapping(column.Ordinal, column.ColumnName, null));
-            }
+            ConfigureBulkCopy(bulkCopy, table, destinationTable, bulkCopyTimeout);
 
             if (batchSize.HasValue && batchSize.Value > 0)
             {
@@ -165,6 +180,20 @@ public partial class MySql
     /// Asynchronously writes a row sequence to the server using the provided bulk copy instance.
     /// </summary>
     protected virtual Task WriteToServerAsync(MySqlBulkCopy bulkCopy, IEnumerable<DataRow> rows, int columnCount, CancellationToken cancellationToken) => bulkCopy.WriteToServerAsync(rows, columnCount, cancellationToken).AsTask();
+
+    private static void ConfigureBulkCopy(MySqlBulkCopy bulkCopy, DataTable table, string destinationTable, int? bulkCopyTimeout)
+    {
+        bulkCopy.DestinationTableName = destinationTable;
+        if (bulkCopyTimeout.HasValue)
+        {
+            bulkCopy.BulkCopyTimeout = bulkCopyTimeout.Value;
+        }
+
+        foreach (DataColumn column in table.Columns)
+        {
+            bulkCopy.ColumnMappings.Add(new MySqlBulkCopyColumnMapping(column.Ordinal, column.ColumnName, null));
+        }
+    }
 
     /// <summary>
     /// Creates a new <see cref="MySqlConnection"/> for the supplied connection string.

--- a/DbaClientX.MySql/MySql.StoredProcedures.cs
+++ b/DbaClientX.MySql/MySql.StoredProcedures.cs
@@ -63,8 +63,7 @@ public partial class MySql
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = ReadDataTable(reader, $"Table{tableIndex}");
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }
@@ -142,8 +141,7 @@ public partial class MySql
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }
@@ -197,8 +195,7 @@ public partial class MySql
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = ReadDataTable(reader, $"Table{tableIndex}");
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }
@@ -254,8 +251,7 @@ public partial class MySql
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }

--- a/DbaClientX.Oracle/DbaClientX.Oracle.csproj
+++ b/DbaClientX.Oracle/DbaClientX.Oracle.csproj
@@ -26,6 +26,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net10.0'">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
   </ItemGroup>

--- a/DbaClientX.Oracle/Oracle.BulkOperations.cs
+++ b/DbaClientX.Oracle/Oracle.BulkOperations.cs
@@ -25,6 +25,22 @@ public partial class Oracle
         ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         var connectionString = BuildConnectionString(host, serviceName, username, password);
+        BulkInsert(connectionString, table, destinationTable, useTransaction, batchSize, bulkCopyTimeout);
+    }
+
+    /// <summary>
+    /// Performs a bulk insert into an Oracle table using a full Oracle connection string.
+    /// </summary>
+    public virtual void BulkInsert(
+        string connectionString,
+        DataTable table,
+        string destinationTable,
+        bool useTransaction = false,
+        int? batchSize = null,
+        int? bulkCopyTimeout = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         OracleConnection? connection = null;
         OracleTransaction? transaction = null;
@@ -34,16 +50,7 @@ public partial class Oracle
         {
             (connection, transaction, dispose) = ResolveConnection(connectionString, useTransaction);
             using var bulkCopy = CreateBulkCopy(connection, transaction);
-            bulkCopy.DestinationTableName = destinationTable;
-            if (bulkCopyTimeout.HasValue)
-            {
-                bulkCopy.BulkCopyTimeout = bulkCopyTimeout.Value;
-            }
-
-            foreach (DataColumn column in table.Columns)
-            {
-                bulkCopy.ColumnMappings.Add(column.ColumnName, column.ColumnName);
-            }
+            ConfigureBulkCopy(bulkCopy, table, destinationTable, bulkCopyTimeout);
 
             if (batchSize.HasValue && batchSize.Value > 0)
             {
@@ -100,6 +107,23 @@ public partial class Oracle
         ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         var connectionString = BuildConnectionString(host, serviceName, username, password);
+        await BulkInsertAsync(connectionString, table, destinationTable, useTransaction, batchSize, bulkCopyTimeout, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously performs a bulk insert into an Oracle table using a full Oracle connection string.
+    /// </summary>
+    public virtual async Task BulkInsertAsync(
+        string connectionString,
+        DataTable table,
+        string destinationTable,
+        bool useTransaction = false,
+        int? batchSize = null,
+        int? bulkCopyTimeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         OracleConnection? connection = null;
         OracleTransaction? transaction = null;
@@ -109,16 +133,7 @@ public partial class Oracle
         {
             (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             using var bulkCopy = CreateBulkCopy(connection, transaction);
-            bulkCopy.DestinationTableName = destinationTable;
-            if (bulkCopyTimeout.HasValue)
-            {
-                bulkCopy.BulkCopyTimeout = bulkCopyTimeout.Value;
-            }
-
-            foreach (DataColumn column in table.Columns)
-            {
-                bulkCopy.ColumnMappings.Add(column.ColumnName, column.ColumnName);
-            }
+            ConfigureBulkCopy(bulkCopy, table, destinationTable, bulkCopyTimeout);
 
             if (batchSize.HasValue && batchSize.Value > 0)
             {
@@ -174,6 +189,20 @@ public partial class Oracle
             cancellationToken.ThrowIfCancellationRequested();
             WriteToServer(bulkCopy, table);
         }, cancellationToken);
+
+    private static void ConfigureBulkCopy(OracleBulkCopy bulkCopy, DataTable table, string destinationTable, int? bulkCopyTimeout)
+    {
+        bulkCopy.DestinationTableName = destinationTable;
+        if (bulkCopyTimeout.HasValue)
+        {
+            bulkCopy.BulkCopyTimeout = bulkCopyTimeout.Value;
+        }
+
+        foreach (DataColumn column in table.Columns)
+        {
+            bulkCopy.ColumnMappings.Add(column.ColumnName, column.ColumnName);
+        }
+    }
 
     /// <summary>
     /// Creates an <see cref="OracleConnection"/> for the provided connection string.

--- a/DbaClientX.Oracle/Oracle.StoredProcedures.cs
+++ b/DbaClientX.Oracle/Oracle.StoredProcedures.cs
@@ -63,8 +63,7 @@ public partial class Oracle
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = ReadDataTable(reader, $"Table{tableIndex}");
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }
@@ -122,8 +121,7 @@ public partial class Oracle
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }
@@ -197,8 +195,7 @@ public partial class Oracle
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = ReadDataTable(reader, $"Table{tableIndex}");
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }
@@ -254,8 +251,7 @@ public partial class Oracle
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }

--- a/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
+++ b/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
@@ -26,9 +26,11 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net10.0'">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
-    <PackageReference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net472'">
     <PackageReference Include="Npgsql" />

--- a/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
@@ -26,6 +26,22 @@ public partial class PostgreSql
         ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         var connectionString = BuildConnectionString(host, database, username, password);
+        BulkInsert(connectionString, table, destinationTable, useTransaction, batchSize, bulkCopyTimeout);
+    }
+
+    /// <summary>
+    /// Performs a bulk insert into a PostgreSQL destination table using a full PostgreSQL connection string.
+    /// </summary>
+    public virtual void BulkInsert(
+        string connectionString,
+        DataTable table,
+        string destinationTable,
+        bool useTransaction = false,
+        int? batchSize = null,
+        int? bulkCopyTimeout = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         NpgsqlConnection? connection = null;
         NpgsqlTransaction? transaction = null;
@@ -82,6 +98,23 @@ public partial class PostgreSql
         ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         var connectionString = BuildConnectionString(host, database, username, password);
+        await BulkInsertAsync(connectionString, table, destinationTable, useTransaction, batchSize, bulkCopyTimeout, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously performs a bulk insert into a PostgreSQL destination table using a full PostgreSQL connection string.
+    /// </summary>
+    public virtual async Task BulkInsertAsync(
+        string connectionString,
+        DataTable table,
+        string destinationTable,
+        bool useTransaction = false,
+        int? batchSize = null,
+        int? bulkCopyTimeout = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateBulkInsertInputs(table, destinationTable, batchSize, bulkCopyTimeout);
 
         NpgsqlConnection? connection = null;
         NpgsqlTransaction? transaction = null;
@@ -142,19 +175,7 @@ public partial class PostgreSql
 
         foreach (var row in rows)
         {
-            importer.StartRow();
-            foreach (DataColumn column in columns)
-            {
-                var value = row[column];
-                if (value == null || value == DBNull.Value)
-                {
-                    importer.WriteNull();
-                }
-                else
-                {
-                    importer.Write((dynamic)value!);
-                }
-            }
+            importer.WriteRow(GetRowValues(row, columns));
         }
 
         importer.Complete();
@@ -186,19 +207,7 @@ public partial class PostgreSql
 
         foreach (var row in rows)
         {
-            await importer.StartRowAsync(cancellationToken).ConfigureAwait(false);
-            foreach (DataColumn column in columns)
-            {
-                var value = row[column];
-                if (value == null || value == DBNull.Value)
-                {
-                    await importer.WriteNullAsync(cancellationToken).ConfigureAwait(false);
-                }
-                else
-                {
-                    await importer.WriteAsync((dynamic)value!, cancellationToken: cancellationToken).ConfigureAwait(false);
-                }
-            }
+            await importer.WriteRowAsync(cancellationToken, GetRowValues(row, columns)).ConfigureAwait(false);
         }
 
         await importer.CompleteAsync(cancellationToken).ConfigureAwait(false);
@@ -258,6 +267,18 @@ public partial class PostgreSql
         {
             yield return rows[i];
         }
+    }
+
+    private static object?[] GetRowValues(DataRow row, DataColumnCollection columns)
+    {
+        var values = new object?[columns.Count];
+        for (var i = 0; i < columns.Count; i++)
+        {
+            var value = row[columns[i]];
+            values[i] = value == DBNull.Value ? null : value;
+        }
+
+        return values;
     }
 
     private static string QuoteIdentifier(string identifier)

--- a/DbaClientX.PostgreSql/PostgreSql.StoredProcedures.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.StoredProcedures.cs
@@ -64,8 +64,7 @@ public partial class PostgreSql
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = ReadDataTable(reader, $"Table{tableIndex}");
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }
@@ -123,8 +122,7 @@ public partial class PostgreSql
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }
@@ -198,8 +196,7 @@ public partial class PostgreSql
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = ReadDataTable(reader, $"Table{tableIndex}");
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }
@@ -255,8 +252,7 @@ public partial class PostgreSql
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }

--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -26,6 +26,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net10.0'">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
   </ItemGroup>

--- a/DbaClientX.SQLite/SQLite.BulkOperations.cs
+++ b/DbaClientX.SQLite/SQLite.BulkOperations.cs
@@ -11,19 +11,17 @@ public partial class SQLite
 {
     private const int DefaultBulkInsertBatchSize = 500;
 
-    /// <summary>
-    /// Inserts all rows from the supplied <see cref="DataTable"/> into the specified destination table.
-    /// </summary>
-    public virtual void BulkInsert(
+    private void BulkInsertCore(
         string database,
         DataTable table,
         string destinationTable,
-        bool useTransaction = false,
-        int? batchSize = null)
+        bool useTransaction,
+        int? batchSize,
+        bool useConnectionString)
     {
         ValidateBulkInsertInputs(table, destinationTable, batchSize);
 
-        var connectionString = BuildOperationalConnectionString(database);
+        var connectionString = ResolveBulkInsertConnectionString(database, useConnectionString);
 
         SqliteConnection? connection = null;
         var dispose = false;
@@ -103,19 +101,39 @@ public partial class SQLite
     }
 
     /// <summary>
-    /// Asynchronously inserts all rows from the supplied <see cref="DataTable"/> into the specified destination table.
+    /// Inserts all rows from the supplied <see cref="DataTable"/> into the specified destination table.
     /// </summary>
-    public virtual async Task BulkInsertAsync(
+    public virtual void BulkInsert(
         string database,
         DataTable table,
         string destinationTable,
         bool useTransaction = false,
-        int? batchSize = null,
-        CancellationToken cancellationToken = default)
+        int? batchSize = null)
+        => BulkInsertCore(database, table, destinationTable, useTransaction, batchSize, useConnectionString: false);
+
+    /// <summary>
+    /// Inserts all rows from the supplied <see cref="DataTable"/> into the specified destination table using a SQLite connection string.
+    /// </summary>
+    public virtual void BulkInsertWithConnectionString(
+        string connectionString,
+        DataTable table,
+        string destinationTable,
+        bool useTransaction = false,
+        int? batchSize = null)
+        => BulkInsertCore(connectionString, table, destinationTable, useTransaction, batchSize, useConnectionString: true);
+
+    private async Task BulkInsertCoreAsync(
+        string database,
+        DataTable table,
+        string destinationTable,
+        bool useTransaction,
+        int? batchSize,
+        CancellationToken cancellationToken,
+        bool useConnectionString)
     {
         ValidateBulkInsertInputs(table, destinationTable, batchSize);
 
-        var connectionString = BuildOperationalConnectionString(database);
+        var connectionString = ResolveBulkInsertConnectionString(database, useConnectionString);
 
         SqliteConnection? connection = null;
         var dispose = false;
@@ -242,6 +260,30 @@ public partial class SQLite
         }
     }
 
+    /// <summary>
+    /// Asynchronously inserts all rows from the supplied <see cref="DataTable"/> into the specified destination table.
+    /// </summary>
+    public virtual Task BulkInsertAsync(
+        string database,
+        DataTable table,
+        string destinationTable,
+        bool useTransaction = false,
+        int? batchSize = null,
+        CancellationToken cancellationToken = default)
+        => BulkInsertCoreAsync(database, table, destinationTable, useTransaction, batchSize, cancellationToken, useConnectionString: false);
+
+    /// <summary>
+    /// Asynchronously inserts all rows from the supplied <see cref="DataTable"/> into the specified destination table using a SQLite connection string.
+    /// </summary>
+    public virtual Task BulkInsertWithConnectionStringAsync(
+        string connectionString,
+        DataTable table,
+        string destinationTable,
+        bool useTransaction = false,
+        int? batchSize = null,
+        CancellationToken cancellationToken = default)
+        => BulkInsertCoreAsync(connectionString, table, destinationTable, useTransaction, batchSize, cancellationToken, useConnectionString: true);
+
     private static DataColumn[] GetColumns(DataTable table)
     {
         var columns = new DataColumn[table.Columns.Count];
@@ -251,6 +293,21 @@ public partial class SQLite
         }
 
         return columns;
+    }
+
+    private static string ResolveBulkInsertConnectionString(string database, bool useConnectionString)
+    {
+        if (!useConnectionString)
+        {
+            return BuildOperationalConnectionString(database);
+        }
+
+        if (string.IsNullOrWhiteSpace(database))
+        {
+            throw new ArgumentException("Connection string cannot be null or whitespace.", nameof(database));
+        }
+
+        return NormalizeConnectionString(database);
     }
 
     private static int ResolveRowsPerBatch(int totalRows, int? batchSize)

--- a/DbaClientX.SqlServer/DbaClientX.SqlServer.csproj
+++ b/DbaClientX.SqlServer/DbaClientX.SqlServer.csproj
@@ -26,6 +26,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net10.0'">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
   </ItemGroup>

--- a/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
+++ b/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
@@ -48,8 +48,7 @@ public partial class SqlServer
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = ReadDataTable(reader, $"Table{tableIndex}");
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }
@@ -109,8 +108,7 @@ public partial class SqlServer
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }

--- a/DbaClientX.SqlServer/SqlServer.StoredProcedures.cs
+++ b/DbaClientX.SqlServer/SqlServer.StoredProcedures.cs
@@ -66,8 +66,7 @@ public partial class SqlServer
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = ReadDataTable(reader, $"Table{tableIndex}");
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }
@@ -128,8 +127,7 @@ public partial class SqlServer
             var tableIndex = 0;
             do
             {
-                var table = new DataTable($"Table{tableIndex}");
-                table.Load(reader);
+                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
                 dataSet.Tables.Add(table);
                 tableIndex++;
             }

--- a/DbaClientX.Tests/DatabaseClientBasePerformanceTests.cs
+++ b/DbaClientX.Tests/DatabaseClientBasePerformanceTests.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Linq;
 using DBAClientX;
 using Xunit;
 using Microsoft.Data.SqlClient;
@@ -66,10 +67,21 @@ public class DatabaseClientBasePerformanceTests
     private class FakeDataReader : DbDataReader
     {
         private readonly int[][] _rows;
+        private readonly string[] _columnNames;
         private int _index = -1;
         public bool ThrowOnSecondRead { get; set; }
         public bool ThrowOnNextResult { get; set; }
-        public FakeDataReader(params int[][] rows) => _rows = rows;
+        public FakeDataReader(params int[][] rows)
+            : this(new[] { "id" }, rows)
+        {
+        }
+
+        public FakeDataReader(string[] columnNames, params int[][] rows)
+        {
+            _columnNames = columnNames;
+            _rows = rows;
+        }
+
         public override bool Read()
         {
             if (_index == 0 && ThrowOnSecondRead)
@@ -87,27 +99,35 @@ public class DatabaseClientBasePerformanceTests
             }
             return false;
         }
-        public override int FieldCount => 1;
-        public override string GetName(int ordinal) => "id";
+        public override int FieldCount => _columnNames.Length;
+        public override string GetName(int ordinal) => _columnNames[ordinal];
         public override Type GetFieldType(int ordinal) => typeof(int);
         public override object GetValue(int ordinal) => _rows[_index][ordinal];
         public override int GetValues(object[] values)
         {
-            values[0] = GetValue(0);
-            return 1;
+            for (var i = 0; i < FieldCount; i++)
+            {
+                values[i] = GetValue(i);
+            }
+
+            return FieldCount;
         }
-        public override int GetOrdinal(string name) => 0;
+        public override int GetOrdinal(string name) => Array.IndexOf(_columnNames, name);
         public override DataTable GetSchemaTable()
         {
             var schema = new DataTable();
             schema.Columns.Add("ColumnName", typeof(string));
             schema.Columns.Add("ColumnOrdinal", typeof(int));
             schema.Columns.Add("DataType", typeof(Type));
-            var row = schema.NewRow();
-            row["ColumnName"] = "id";
-            row["ColumnOrdinal"] = 0;
-            row["DataType"] = typeof(int);
-            schema.Rows.Add(row);
+            for (var i = 0; i < FieldCount; i++)
+            {
+                var row = schema.NewRow();
+                row["ColumnName"] = _columnNames[i];
+                row["ColumnOrdinal"] = i;
+                row["DataType"] = typeof(int);
+                schema.Rows.Add(row);
+            }
+
             return schema;
         }
         public override bool IsDBNull(int ordinal) => false;
@@ -160,5 +180,18 @@ public class DatabaseClientBasePerformanceTests
         var result = client.Execute(connection);
         var table = Assert.IsType<DataTable>(result);
         Assert.Equal(1, table.Rows[0][0]);
+    }
+
+    [Fact]
+    public void ExecuteQuery_DataTable_DisambiguatesDuplicateColumnNames()
+    {
+        var reader = new FakeDataReader(new[] { "id", "id" }, new[] { 1, 2 });
+        using var connection = new FakeDbConnection(reader);
+        using var client = new TestClient { ReturnType = ReturnType.DataTable };
+        var result = client.Execute(connection);
+        var table = Assert.IsType<DataTable>(result);
+        Assert.Equal(new[] { "id", "id1" }, table.Columns.Cast<DataColumn>().Select(static column => column.ColumnName).ToArray());
+        Assert.Equal(1, table.Rows[0][0]);
+        Assert.Equal(2, table.Rows[0][1]);
     }
 }

--- a/DbaClientX.Tests/MySqlBulkInsertTests.cs
+++ b/DbaClientX.Tests/MySqlBulkInsertTests.cs
@@ -17,10 +17,15 @@ public class MySqlBulkInsertTests
         public List<(int Ordinal, string Destination)> Mappings { get; } = new();
         public List<int> BatchRowCounts { get; } = new();
         public bool UsedRowEnumeration { get; private set; }
+        public string? ConnectionString { get; private set; }
         public int SyncDisposeCalls { get; private set; }
         public int AsyncDisposeCalls { get; private set; }
 
-        protected override MySqlConnection CreateConnection(string connectionString) => new();
+        protected override MySqlConnection CreateConnection(string connectionString)
+        {
+            ConnectionString = connectionString;
+            return new();
+        }
 
         protected override void OpenConnection(MySqlConnection connection)
         {
@@ -156,6 +161,38 @@ public class MySqlBulkInsertTests
         Assert.Equal(table.Columns.Count, mySql.Mappings.Count);
         Assert.Equal(new[] { 2 }, mySql.BatchRowCounts);
         Assert.False(mySql.UsedRowEnumeration);
+    }
+
+    [Fact]
+    public void BulkInsert_WithConnectionString_UsesConnectionStringOverload()
+    {
+        using var mySql = new CaptureBulkCopyMySql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Rows.Add(1);
+        var connectionString = DBAClientX.MySql.BuildConnectionString("h", "db", "u", "p");
+
+        mySql.BulkInsert(connectionString, table, "Dest");
+
+        Assert.Equal(connectionString, mySql.ConnectionString);
+        Assert.Equal("Dest", mySql.Destination);
+        Assert.Equal(1, mySql.SyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task BulkInsertAsync_WithConnectionString_UsesConnectionStringOverload()
+    {
+        using var mySql = new CaptureBulkCopyMySql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Rows.Add(1);
+        var connectionString = DBAClientX.MySql.BuildConnectionString("h", "db", "u", "p");
+
+        await mySql.BulkInsertAsync(connectionString, table, "Dest");
+
+        Assert.Equal(connectionString, mySql.ConnectionString);
+        Assert.Equal("Dest", mySql.Destination);
+        Assert.Equal(1, mySql.AsyncDisposeCalls);
     }
 
     [Fact]

--- a/DbaClientX.Tests/OracleBulkInsertTests.cs
+++ b/DbaClientX.Tests/OracleBulkInsertTests.cs
@@ -15,10 +15,15 @@ public class OracleBulkInsertTests
         public string? Destination { get; private set; }
         public List<(string Source, string Destination)> Mappings { get; } = new();
         public List<int> BatchRowCounts { get; } = new();
+        public string? ConnectionString { get; private set; }
         public int SyncDisposeCalls { get; private set; }
         public int AsyncDisposeCalls { get; private set; }
 
-        protected override OracleConnection CreateConnection(string connectionString) => new();
+        protected override OracleConnection CreateConnection(string connectionString)
+        {
+            ConnectionString = connectionString;
+            return new();
+        }
 
         protected override void OpenConnection(OracleConnection connection)
         {
@@ -169,6 +174,38 @@ public class OracleBulkInsertTests
         Assert.Equal("Dest", oracle.Destination);
         Assert.Equal(table.Columns.Count, oracle.Mappings.Count);
         Assert.Equal(new[] { 2 }, oracle.BatchRowCounts);
+    }
+
+    [Fact]
+    public void BulkInsert_WithConnectionString_UsesConnectionStringOverload()
+    {
+        using var oracle = new CaptureBulkCopyOracle();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Rows.Add(1);
+        var connectionString = DBAClientX.Oracle.BuildConnectionString("h", "svc", "u", "p");
+
+        oracle.BulkInsert(connectionString, table, "Dest");
+
+        Assert.Equal(connectionString, oracle.ConnectionString);
+        Assert.Equal("Dest", oracle.Destination);
+        Assert.Equal(1, oracle.SyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task BulkInsertAsync_WithConnectionString_UsesConnectionStringOverload()
+    {
+        using var oracle = new CaptureBulkCopyOracle();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Rows.Add(1);
+        var connectionString = DBAClientX.Oracle.BuildConnectionString("h", "svc", "u", "p");
+
+        await oracle.BulkInsertAsync(connectionString, table, "Dest");
+
+        Assert.Equal(connectionString, oracle.ConnectionString);
+        Assert.Equal("Dest", oracle.Destination);
+        Assert.Equal(1, oracle.AsyncDisposeCalls);
     }
 
     [Fact]

--- a/DbaClientX.Tests/PostgreSqlBulkInsertTests.cs
+++ b/DbaClientX.Tests/PostgreSqlBulkInsertTests.cs
@@ -17,10 +17,15 @@ public class PostgreSqlBulkInsertTests
         public List<(int Ordinal, string Destination)> Mappings { get; } = new();
         public List<int> BatchRowCounts { get; } = new();
         public bool UsedRowEnumeration { get; private set; }
+        public string? ConnectionString { get; private set; }
         public int SyncDisposeCalls { get; private set; }
         public int AsyncDisposeCalls { get; private set; }
 
-        protected override NpgsqlConnection CreateConnection(string connectionString) => new();
+        protected override NpgsqlConnection CreateConnection(string connectionString)
+        {
+            ConnectionString = connectionString;
+            return new();
+        }
 
         protected override void OpenConnection(NpgsqlConnection connection)
         {
@@ -162,6 +167,38 @@ public class PostgreSqlBulkInsertTests
         Assert.Equal(table.Columns.Count, pg.Mappings.Count);
         Assert.Equal(new[] { 2 }, pg.BatchRowCounts);
         Assert.False(pg.UsedRowEnumeration);
+    }
+
+    [Fact]
+    public void BulkInsert_WithConnectionString_UsesConnectionStringOverload()
+    {
+        using var pg = new CapturePostgreSql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Rows.Add(1);
+        var connectionString = DBAClientX.PostgreSql.BuildConnectionString("h", "db", "u", "p");
+
+        pg.BulkInsert(connectionString, table, "Dest");
+
+        Assert.Equal(connectionString, pg.ConnectionString);
+        Assert.Equal("Dest", pg.Destination);
+        Assert.Equal(1, pg.SyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task BulkInsertAsync_WithConnectionString_UsesConnectionStringOverload()
+    {
+        using var pg = new CapturePostgreSql();
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Rows.Add(1);
+        var connectionString = DBAClientX.PostgreSql.BuildConnectionString("h", "db", "u", "p");
+
+        await pg.BulkInsertAsync(connectionString, table, "Dest");
+
+        Assert.Equal(connectionString, pg.ConnectionString);
+        Assert.Equal("Dest", pg.Destination);
+        Assert.Equal(1, pg.AsyncDisposeCalls);
     }
 
     [Fact]

--- a/DbaClientX.Tests/SQLiteBulkInsertTests.cs
+++ b/DbaClientX.Tests/SQLiteBulkInsertTests.cs
@@ -50,6 +50,28 @@ public class SQLiteBulkInsertTests
     }
 
     [Fact]
+    public void BulkInsert_WithConnectionString_InsertsAllRows()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var connectionString = DBAClientX.SQLite.BuildConnectionString(path);
+            using var sqlite = new DBAClientX.SQLite();
+            sqlite.ExecuteNonQuery(path, "CREATE TABLE Dest(Id INTEGER, Name TEXT);");
+
+            var table = CreateTable(2);
+            sqlite.BulkInsertWithConnectionString(connectionString, table, "Dest", batchSize: 1);
+
+            var count = sqlite.ExecuteScalar(path, "SELECT COUNT(*) FROM Dest;");
+            Assert.Equal(2L, count);
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    [Fact]
     public async Task BulkInsertAsync_WithBatchSize_InsertsAllRows()
     {
         var path = Path.GetTempFileName();
@@ -60,6 +82,28 @@ public class SQLiteBulkInsertTests
 
             var table = CreateTable(2);
             await sqlite.BulkInsertAsync(path, table, "Dest", batchSize: 1);
+
+            var count = await sqlite.ExecuteScalarAsync(path, "SELECT COUNT(*) FROM Dest;");
+            Assert.Equal(2L, count);
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    [Fact]
+    public async Task BulkInsertAsync_WithConnectionString_InsertsAllRows()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            var connectionString = DBAClientX.SQLite.BuildConnectionString(path);
+            using var sqlite = new DBAClientX.SQLite();
+            await sqlite.ExecuteNonQueryAsync(path, "CREATE TABLE Dest(Id INTEGER, Name TEXT);");
+
+            var table = CreateTable(2);
+            await sqlite.BulkInsertWithConnectionStringAsync(connectionString, table, "Dest", batchSize: 1);
 
             var count = await sqlite.ExecuteScalarAsync(path, "SELECT COUNT(*) FROM Dest;");
             Assert.Equal(2L, count);


### PR DESCRIPTION
## Summary
- add full-connection-string bulk insert coverage for MySQL, PostgreSQL, and Oracle
- add explicit SQLite connection-string bulk insert methods while preserving the existing path-based API
- improve AOT readiness by removing dynamic/compiled-expression/DataTable.Load paths and adding trim annotations plus modern-target analyzer settings
- add provider tests for the new bulk surfaces

## Validation
- dotnet build .\DbaClientX.sln -c Release
- dotnet test .\DbaClientX.Tests\DbaClientX.Tests.csproj -c Release --no-build
- git diff --check
- searched for remaining DataTable.Load(reader), Microsoft.CSharp, dynamic, lambda.Compile, and Expression usages
- checked TestimoX, TierBridge, DomainDetectiveNext, PasswordSolutionX, DomainDetective, and DomainDetectiveCertificateTransparency for impacted call sites