### PR TITLE
Add bulk table data cmdlet

### DIFF
--- a/DbaClientX.PowerShell/CmdletWriteDbaXTableData.cs
+++ b/DbaClientX.PowerShell/CmdletWriteDbaXTableData.cs
@@ -1,0 +1,189 @@
+using System.Data;
+using System.Management.Automation;
+
+namespace DBAClientX.PowerShell;
+
+/// <summary>Writes tabular pipeline input to a database table using provider-native bulk insert APIs.</summary>
+/// <para>Accepts a DataTable, DataView, IDataReader, DataRow pipeline, or regular PowerShell objects and routes the resulting table to the selected DbaClientX provider.</para>
+/// <example>
+/// <summary>Write an Excel-imported DataTable to SQL Server.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Import-OfficeExcel .\Data.xlsx -AsDataTable | Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=.;Database=App;Encrypt=True;TrustServerCertificate=True;Integrated Security=True' -DestinationTable dbo.Import</code>
+/// <para>Loads the workbook rows as a DataTable and sends them through the SQL Server bulk-copy provider.</para>
+/// </example>
+/// <example>
+/// <summary>Write object pipeline data to PostgreSQL.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>$rows | Write-DbaXTableData -Provider PostgreSql -ConnectionString 'Host=localhost;Database=app;Username=user;Password=secret' -DestinationTable public.import_data -BatchSize 5000</code>
+/// <para>Converts the objects to a DataTable and writes them with the PostgreSQL COPY-backed provider.</para>
+/// </example>
+[Cmdlet(VerbsCommunications.Write, "DbaXTableData", SupportsShouldProcess = true)]
+[CmdletBinding()]
+public sealed class CmdletWriteDbaXTableData : PSCmdlet
+{
+    internal static ScriptBlock? BulkInsertOverride { get; set; }
+
+    private readonly List<object?> _input = new();
+    private ActionPreference _errorAction;
+
+    /// <summary>Database provider that should receive the bulk insert.</summary>
+    [Parameter(Mandatory = true)]
+    public DbaXBulkProvider Provider { get; set; }
+
+    /// <summary>Provider connection string used for the bulk insert.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string ConnectionString { get; set; } = string.Empty;
+
+    /// <summary>Destination table name. Include schema or owner when required by the provider.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string DestinationTable { get; set; } = string.Empty;
+
+    /// <summary>Tabular input to write. Accepts DataTable, DataView, IDataReader, DataRow, hashtable, and object pipeline input.</summary>
+    [Parameter(ValueFromPipeline = true, Mandatory = true)]
+    public object? InputObject { get; set; }
+
+    /// <summary>Optional number of rows per provider bulk batch.</summary>
+    [Parameter]
+    public int? BatchSize { get; set; }
+
+    /// <summary>Optional provider bulk-copy timeout in seconds. SQLite does not support this option.</summary>
+    [Parameter]
+    public int? BulkCopyTimeout { get; set; }
+
+    /// <summary>Writes a small result object with provider, destination table, and row count.</summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
+    /// <inheritdoc />
+    protected override void BeginProcessing()
+    {
+        _errorAction = this.ResolveErrorAction();
+    }
+
+    /// <inheritdoc />
+    protected override void ProcessRecord()
+    {
+        _input.Add(InputObject);
+    }
+
+    /// <inheritdoc />
+    protected override void EndProcessing()
+    {
+        try
+        {
+            ValidateOptions();
+
+            if (!ShouldProcess(DestinationTable, $"Bulk write {_input.Count} input item(s) using {Provider}"))
+            {
+                return;
+            }
+
+            var table = PowerShellDataTableConverter.ToDataTable(_input, DestinationTable);
+            var providerAlias = GetProviderAlias(Provider);
+            if (!PowerShellHelpers.TryValidateConnection(this, providerAlias, ConnectionString, _errorAction))
+            {
+                return;
+            }
+
+            if (BulkInsertOverride != null)
+            {
+                BulkInsertOverride.InvokeWithContext(
+                    functionsToDefine: null,
+                    variablesToDefine: null,
+                    args: new object?[] { this, table });
+            }
+            else
+            {
+                InvokeProviderBulkInsert(table);
+            }
+
+            if (PassThru.IsPresent)
+            {
+                WriteObject(new PSObject(new
+                {
+                    Provider,
+                    DestinationTable,
+                    Rows = table.Rows.Count
+                }));
+            }
+        }
+        catch (Exception ex)
+        {
+            WriteWarning($"Write-DbaXTableData - Error writing table data: {ex.Message}");
+            if (_errorAction == ActionPreference.Stop)
+            {
+                throw;
+            }
+        }
+    }
+
+    private void ValidateOptions()
+    {
+        if (BatchSize.HasValue && BatchSize.Value <= 0)
+        {
+            throw new PSArgumentException("BatchSize must be greater than zero.", nameof(BatchSize));
+        }
+
+        if (BulkCopyTimeout.HasValue && BulkCopyTimeout.Value <= 0)
+        {
+            throw new PSArgumentException("BulkCopyTimeout must be greater than zero.", nameof(BulkCopyTimeout));
+        }
+
+        if (Provider == DbaXBulkProvider.SQLite && BulkCopyTimeout.HasValue)
+        {
+            throw new PSArgumentException("SQLite bulk inserts do not support BulkCopyTimeout.", nameof(BulkCopyTimeout));
+        }
+    }
+
+    private void InvokeProviderBulkInsert(DataTable table)
+    {
+        switch (Provider)
+        {
+            case DbaXBulkProvider.SqlServer:
+                using (var sqlServer = new DBAClientX.SqlServer())
+                {
+                    sqlServer.BulkInsert(ConnectionString, table, DestinationTable, batchSize: BatchSize, bulkCopyTimeout: BulkCopyTimeout);
+                }
+                break;
+            case DbaXBulkProvider.PostgreSql:
+                using (var postgreSql = new DBAClientX.PostgreSql())
+                {
+                    postgreSql.BulkInsert(ConnectionString, table, DestinationTable, batchSize: BatchSize, bulkCopyTimeout: BulkCopyTimeout);
+                }
+                break;
+            case DbaXBulkProvider.MySql:
+                using (var mySql = new DBAClientX.MySql())
+                {
+                    mySql.BulkInsert(ConnectionString, table, DestinationTable, batchSize: BatchSize, bulkCopyTimeout: BulkCopyTimeout);
+                }
+                break;
+            case DbaXBulkProvider.Oracle:
+                using (var oracle = new DBAClientX.Oracle())
+                {
+                    oracle.BulkInsert(ConnectionString, table, DestinationTable, batchSize: BatchSize, bulkCopyTimeout: BulkCopyTimeout);
+                }
+                break;
+            case DbaXBulkProvider.SQLite:
+                using (var sqlite = new DBAClientX.SQLite())
+                {
+                    sqlite.BulkInsertWithConnectionString(ConnectionString, table, DestinationTable, batchSize: BatchSize);
+                }
+                break;
+            default:
+                throw new PSArgumentException($"Provider '{Provider}' is not supported.", nameof(Provider));
+        }
+    }
+
+    private static string GetProviderAlias(DbaXBulkProvider provider)
+        => provider switch
+        {
+            DbaXBulkProvider.SqlServer => "sqlserver",
+            DbaXBulkProvider.PostgreSql => "postgresql",
+            DbaXBulkProvider.MySql => "mysql",
+            DbaXBulkProvider.Oracle => "oracle",
+            DbaXBulkProvider.SQLite => "sqlite",
+            _ => throw new PSArgumentException($"Provider '{provider}' is not supported.", nameof(provider))
+        };
+}

--- a/DbaClientX.PowerShell/CmdletWriteDbaXTableData.cs
+++ b/DbaClientX.PowerShell/CmdletWriteDbaXTableData.cs
@@ -42,6 +42,7 @@ public sealed class CmdletWriteDbaXTableData : PSCmdlet
 
     /// <summary>Tabular input to write. Accepts DataTable, DataView, IDataReader, DataRow, hashtable, and object pipeline input.</summary>
     [Parameter(ValueFromPipeline = true, Mandatory = true)]
+    [AllowNull]
     public object? InputObject { get; set; }
 
     /// <summary>Optional number of rows per provider bulk batch.</summary>
@@ -74,6 +75,21 @@ public sealed class CmdletWriteDbaXTableData : PSCmdlet
         try
         {
             ValidateOptions();
+
+            if (_input.Count == 0)
+            {
+                if (PassThru.IsPresent)
+                {
+                    WriteObject(new PSObject(new
+                    {
+                        Provider,
+                        DestinationTable,
+                        Rows = 0
+                    }));
+                }
+
+                return;
+            }
 
             if (!ShouldProcess(DestinationTable, $"Bulk write {_input.Count} input item(s) using {Provider}"))
             {

--- a/DbaClientX.PowerShell/DbaXBulkProvider.cs
+++ b/DbaClientX.PowerShell/DbaXBulkProvider.cs
@@ -1,0 +1,22 @@
+namespace DBAClientX.PowerShell;
+
+/// <summary>
+/// Identifies the database provider used by bulk table-data cmdlets.
+/// </summary>
+public enum DbaXBulkProvider
+{
+    /// <summary>SQL Server provider.</summary>
+    SqlServer,
+
+    /// <summary>PostgreSQL provider.</summary>
+    PostgreSql,
+
+    /// <summary>MySQL provider.</summary>
+    MySql,
+
+    /// <summary>Oracle provider.</summary>
+    Oracle,
+
+    /// <summary>SQLite provider.</summary>
+    SQLite
+}

--- a/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
+++ b/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
@@ -1,0 +1,185 @@
+using System.Collections;
+using System.Data;
+using System.Management.Automation;
+
+namespace DBAClientX.PowerShell;
+
+/// <summary>
+/// Converts common PowerShell pipeline inputs into <see cref="DataTable"/> instances for provider bulk APIs.
+/// </summary>
+internal static class PowerShellDataTableConverter
+{
+    internal static DataTable ToDataTable(IReadOnlyList<object?> input, string? tableName = null)
+    {
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        var items = new List<object?>(input.Count);
+        foreach (var item in input)
+        {
+            var value = Unwrap(item);
+            if (value != null)
+            {
+                items.Add(value);
+            }
+        }
+
+        if (items.Count == 0)
+        {
+            throw new PSArgumentException("Provide at least one row or DataTable to write.", nameof(input));
+        }
+
+        if (items.Count == 1)
+        {
+            var single = items[0];
+            if (single is DataTable table)
+            {
+                return table;
+            }
+
+            if (single is DataView view)
+            {
+                return view.ToTable();
+            }
+
+            if (single is IDataReader reader)
+            {
+                var tableFromReader = string.IsNullOrWhiteSpace(tableName)
+                    ? new DataTable()
+                    : new DataTable(tableName);
+                tableFromReader.Load(reader);
+                return tableFromReader;
+            }
+        }
+
+        if (items[0] is DataRow firstRow)
+        {
+            return FromDataRows(items, firstRow.Table);
+        }
+
+        return FromObjects(items, tableName);
+    }
+
+    private static DataTable FromDataRows(IReadOnlyList<object?> items, DataTable source)
+    {
+        var table = source.Clone();
+        foreach (var item in items)
+        {
+            if (item is not DataRow row)
+            {
+                throw new PSArgumentException("DataRow input cannot be mixed with other input types.", nameof(items));
+            }
+
+            if (!ReferenceEquals(row.Table, source))
+            {
+                throw new PSArgumentException("DataRow inputs must come from the same DataTable.", nameof(items));
+            }
+
+            table.ImportRow(row);
+        }
+
+        return table;
+    }
+
+    private static DataTable FromObjects(IReadOnlyList<object?> items, string? tableName)
+    {
+        var rows = new List<IDictionary<string, object?>>(items.Count);
+        var columns = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var item in items)
+        {
+            var row = GetProperties(item);
+            rows.Add(row);
+
+            foreach (var key in row.Keys)
+            {
+                if (seen.Add(key))
+                {
+                    columns.Add(key);
+                }
+            }
+        }
+
+        if (columns.Count == 0)
+        {
+            columns.Add("Value");
+            rows.Clear();
+            foreach (var item in items)
+            {
+                rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Value"] = item
+                });
+            }
+        }
+
+        var table = string.IsNullOrWhiteSpace(tableName)
+            ? new DataTable()
+            : new DataTable(tableName);
+        foreach (var column in columns)
+        {
+            table.Columns.Add(column, typeof(object));
+        }
+
+        foreach (var rowValues in rows)
+        {
+            var row = table.NewRow();
+            foreach (var column in columns)
+            {
+                row[column] = rowValues.TryGetValue(column, out var value) && value != null
+                    ? value
+                    : DBNull.Value;
+            }
+
+            table.Rows.Add(row);
+        }
+
+        return table;
+    }
+
+    private static IDictionary<string, object?> GetProperties(object? item)
+    {
+        if (item is IDictionary dictionary)
+        {
+            var values = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+            foreach (DictionaryEntry entry in dictionary)
+            {
+                if (entry.Key != null)
+                {
+                    values[entry.Key.ToString()!] = entry.Value;
+                }
+            }
+
+            return values;
+        }
+
+        var psObject = PSObject.AsPSObject(item);
+        var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var property in psObject.Properties)
+        {
+            if ((property.MemberType == PSMemberTypes.NoteProperty ||
+                 property.MemberType == PSMemberTypes.Property) &&
+                !string.IsNullOrWhiteSpace(property.Name))
+            {
+                result[property.Name] = property.Value;
+            }
+        }
+
+        return result;
+    }
+
+    private static object? Unwrap(object? item)
+    {
+        if (item is not PSObject psObject)
+        {
+            return item;
+        }
+
+        return psObject.BaseObject is DataTable or DataView or IDataReader or DataRow or IDictionary
+            ? psObject.BaseObject
+            : psObject;
+    }
+}

--- a/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
+++ b/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Data;
+using System.Linq;
 using System.Management.Automation;
 
 namespace DBAClientX.PowerShell;
@@ -16,19 +17,15 @@ internal static class PowerShellDataTableConverter
             throw new ArgumentNullException(nameof(input));
         }
 
-        var items = new List<object?>(input.Count);
-        foreach (var item in input)
-        {
-            var value = Unwrap(item);
-            if (value != null)
-            {
-                items.Add(value);
-            }
-        }
+        var items = input
+            .Select(Unwrap)
+            .ToList();
 
         if (items.Count == 0)
         {
-            throw new PSArgumentException("Provide at least one row or DataTable to write.", nameof(input));
+            return string.IsNullOrWhiteSpace(tableName)
+                ? new DataTable()
+                : new DataTable(tableName);
         }
 
         if (items.Count == 1)
@@ -56,15 +53,25 @@ internal static class PowerShellDataTableConverter
 
         if (items[0] is DataRow firstRow)
         {
-            return FromDataRows(items, firstRow.Table);
+            return FromDataRows(items, firstRow.Table, tableName);
+        }
+
+        if (items[0] is DataRowView firstRowView)
+        {
+            return FromDataRowViews(items, firstRowView.Row.Table, tableName);
+        }
+
+        if (items[0] is IDataRecord firstRecord)
+        {
+            return FromDataRecords(items, firstRecord, tableName);
         }
 
         return FromObjects(items, tableName);
     }
 
-    private static DataTable FromDataRows(IReadOnlyList<object?> items, DataTable source)
+    private static DataTable FromDataRows(IReadOnlyList<object?> items, DataTable source, string? tableName)
     {
-        var table = source.Clone();
+        var table = CloneTable(source, tableName);
         foreach (var item in items)
         {
             if (item is not DataRow row)
@@ -72,15 +79,153 @@ internal static class PowerShellDataTableConverter
                 throw new PSArgumentException("DataRow input cannot be mixed with other input types.", nameof(items));
             }
 
-            if (!ReferenceEquals(row.Table, source))
-            {
-                throw new PSArgumentException("DataRow inputs must come from the same DataTable.", nameof(items));
-            }
-
-            table.ImportRow(row);
+            AddCompatibleDataRow(table, row);
         }
 
         return table;
+    }
+
+    private static DataTable FromDataRowViews(IReadOnlyList<object?> items, DataTable source, string? tableName)
+    {
+        var table = CloneTable(source, tableName);
+        foreach (var item in items)
+        {
+            if (item is not DataRowView rowView)
+            {
+                throw new PSArgumentException("DataRowView input cannot be mixed with other input types.", nameof(items));
+            }
+
+            AddCompatibleDataRow(table, rowView.Row);
+        }
+
+        return table;
+    }
+
+    private static DataTable FromDataRecords(IReadOnlyList<object?> items, IDataRecord firstRecord, string? tableName)
+    {
+        var table = string.IsNullOrWhiteSpace(tableName)
+            ? new DataTable()
+            : new DataTable(tableName);
+
+        var columns = GetDataRecordColumns(firstRecord);
+        foreach (var column in columns)
+        {
+            table.Columns.Add(column.TableName, typeof(object));
+        }
+
+        foreach (var item in items)
+        {
+            if (item is not IDataRecord record)
+            {
+                throw new PSArgumentException("IDataRecord input cannot be mixed with other input types.", nameof(items));
+            }
+
+            EnsureCompatibleDataRecord(record, columns);
+
+            var row = table.NewRow();
+            for (var index = 0; index < record.FieldCount; index++)
+            {
+                row[columns[index].TableName] = record.IsDBNull(index) ? DBNull.Value : record.GetValue(index);
+            }
+
+            table.Rows.Add(row);
+        }
+
+        return table;
+    }
+
+    private static IReadOnlyList<DataRecordColumn> GetDataRecordColumns(IDataRecord record)
+    {
+        var columns = new List<DataRecordColumn>(record.FieldCount);
+        var tableNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var index = 0; index < record.FieldCount; index++)
+        {
+            var sourceName = record.GetName(index);
+            var baseName = string.IsNullOrWhiteSpace(sourceName)
+                ? $"Column{index + 1}"
+                : sourceName;
+            var tableName = GetUniqueColumnName(baseName, tableNames);
+            columns.Add(new DataRecordColumn(sourceName, tableName, record.GetFieldType(index)));
+        }
+
+        return columns;
+    }
+
+    private static string GetUniqueColumnName(string columnName, HashSet<string> seen)
+    {
+        var candidate = columnName;
+        var suffix = 2;
+        while (!seen.Add(candidate))
+        {
+            candidate = $"{columnName}_{suffix}";
+            suffix++;
+        }
+
+        return candidate;
+    }
+
+    private static void EnsureCompatibleDataRecord(IDataRecord record, IReadOnlyList<DataRecordColumn> expectedColumns)
+    {
+        if (record.FieldCount != expectedColumns.Count)
+        {
+            throw new PSArgumentException("IDataRecord inputs must have the same field count.", nameof(record));
+        }
+
+        for (var index = 0; index < expectedColumns.Count; index++)
+        {
+            var expected = expectedColumns[index];
+            if (!string.Equals(record.GetName(index), expected.SourceName, StringComparison.OrdinalIgnoreCase) ||
+                record.GetFieldType(index) != expected.FieldType)
+            {
+                throw new PSArgumentException("IDataRecord inputs must have compatible column schemas.", nameof(record));
+            }
+        }
+    }
+
+    private static DataTable CloneTable(DataTable source, string? tableName)
+    {
+        var table = source.Clone();
+        if (!string.IsNullOrWhiteSpace(tableName))
+        {
+            table.TableName = tableName;
+        }
+
+        return table;
+    }
+
+    private static void AddCompatibleDataRow(DataTable table, DataRow row)
+    {
+        EnsureCompatibleSchema(table, row.Table);
+
+        var newRow = table.NewRow();
+        foreach (DataColumn column in table.Columns)
+        {
+            newRow[column.ColumnName] = row[column.ColumnName];
+        }
+
+        table.Rows.Add(newRow);
+    }
+
+    private static void EnsureCompatibleSchema(DataTable target, DataTable source)
+    {
+        if (source.Columns.Count != target.Columns.Count)
+        {
+            throw new PSArgumentException("DataRow inputs must have compatible column schemas.", nameof(source));
+        }
+
+        foreach (DataColumn targetColumn in target.Columns)
+        {
+            if (!source.Columns.Contains(targetColumn.ColumnName))
+            {
+                throw new PSArgumentException("DataRow inputs must have compatible column schemas.", nameof(source));
+            }
+
+            var sourceColumn = source.Columns[targetColumn.ColumnName]!;
+            if (sourceColumn.DataType != targetColumn.DataType)
+            {
+                throw new PSArgumentException("DataRow inputs must have compatible column schemas.", nameof(source));
+            }
+        }
     }
 
     private static DataTable FromObjects(IReadOnlyList<object?> items, string? tableName)
@@ -89,17 +234,13 @@ internal static class PowerShellDataTableConverter
         var columns = new List<string>();
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var item in items)
+        foreach (var row in items.Select(GetProperties))
         {
-            var row = GetProperties(item);
             rows.Add(row);
 
-            foreach (var key in row.Keys)
+            foreach (var key in row.Keys.Where(seen.Add))
             {
-                if (seen.Add(key))
-                {
-                    columns.Add(key);
-                }
+                columns.Add(key);
             }
         }
 
@@ -142,6 +283,14 @@ internal static class PowerShellDataTableConverter
 
     private static IDictionary<string, object?> GetProperties(object? item)
     {
+        if (IsScalarValue(item))
+        {
+            return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Value"] = item
+            };
+        }
+
         if (item is IDictionary dictionary)
         {
             var values = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
@@ -158,14 +307,12 @@ internal static class PowerShellDataTableConverter
 
         var psObject = PSObject.AsPSObject(item);
         var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-        foreach (var property in psObject.Properties)
+        foreach (var property in psObject.Properties.Where(static property =>
+                     (property.MemberType == PSMemberTypes.NoteProperty ||
+                      property.MemberType == PSMemberTypes.Property) &&
+                     !string.IsNullOrWhiteSpace(property.Name)))
         {
-            if ((property.MemberType == PSMemberTypes.NoteProperty ||
-                 property.MemberType == PSMemberTypes.Property) &&
-                !string.IsNullOrWhiteSpace(property.Name))
-            {
-                result[property.Name] = property.Value;
-            }
+            result[property.Name] = property.Value;
         }
 
         return result;
@@ -178,8 +325,38 @@ internal static class PowerShellDataTableConverter
             return item;
         }
 
-        return psObject.BaseObject is DataTable or DataView or IDataReader or DataRow or IDictionary
+        return psObject.BaseObject is DataTable or DataView or IDataReader or DataRow or DataRowView or IDataRecord or IDictionary ||
+               IsScalarValue(psObject.BaseObject)
             ? psObject.BaseObject
             : psObject;
+    }
+
+    private static bool IsScalarValue(object? item)
+    {
+        if (item == null || item == DBNull.Value)
+        {
+            return true;
+        }
+
+        var type = item.GetType();
+        return type.IsPrimitive ||
+               type.IsEnum ||
+               item is string or decimal or DateTime or DateTimeOffset or TimeSpan or Guid;
+    }
+
+    private sealed class DataRecordColumn
+    {
+        internal DataRecordColumn(string sourceName, string tableName, Type fieldType)
+        {
+            SourceName = sourceName;
+            TableName = tableName;
+            FieldType = fieldType;
+        }
+
+        internal string SourceName { get; }
+
+        internal string TableName { get; }
+
+        internal Type FieldType { get; }
     }
 }

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -30,6 +30,7 @@
             'Invoke-DbaXOracleNonQuery'
             'Invoke-DbaXOracleScalar'
             'Invoke-DbaXSQLite'
+            'Write-DbaXTableData'
         )
     }
     New-ConfigurationManifest @Manifest

--- a/Module/DbaClientX.psd1
+++ b/Module/DbaClientX.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Invoke-DbaXQuery', 'Invoke-DbaXNonQuery', 'New-DbaXQuery', 'Invoke-DbaXMySql', 'Invoke-DbaXMySqlNonQuery', 'Invoke-DbaXMySqlScalar', 'Invoke-DbaXPostgreSql', 'Invoke-DbaXPostgreSqlNonQuery', 'Invoke-DbaXOracle', 'Invoke-DbaXOracleNonQuery', 'Invoke-DbaXOracleScalar', 'Invoke-DbaXSQLite')
+    CmdletsToExport      = @('Invoke-DbaXQuery', 'Invoke-DbaXNonQuery', 'New-DbaXQuery', 'Invoke-DbaXMySql', 'Invoke-DbaXMySqlNonQuery', 'Invoke-DbaXMySqlScalar', 'Invoke-DbaXPostgreSql', 'Invoke-DbaXPostgreSqlNonQuery', 'Invoke-DbaXOracle', 'Invoke-DbaXOracleNonQuery', 'Invoke-DbaXOracleScalar', 'Invoke-DbaXSQLite', 'Write-DbaXTableData')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/DbaClientX.psm1
+++ b/Module/DbaClientX.psm1
@@ -103,6 +103,11 @@ if ($Development) {
     )
 }
 
+$LoadedAssemblyNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($LoadedAssembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+    [void] $LoadedAssemblyNames.Add($LoadedAssembly.GetName().Name)
+}
+
 $FoundErrors = @(
     if ($Development) {
         foreach ($BinaryModule in $BinaryDev) {
@@ -129,9 +134,18 @@ $FoundErrors = @(
         }
     }
     Foreach ($Import in @($Assembly)) {
+        if ($Import.BaseName -like 'System.*' -or $Import.BaseName -like 'Microsoft.*') {
+            continue
+        }
+
+        if ($LoadedAssemblyNames.Contains([System.IO.Path]::GetFileNameWithoutExtension($Import.Name))) {
+            continue
+        }
+
         try {
             #Write-Verbose -Message $Import.FullName
             Add-Type -Path $Import.Fullname -ErrorAction Stop
+            [void] $LoadedAssemblyNames.Add([System.IO.Path]::GetFileNameWithoutExtension($Import.Name))
         } catch [System.Reflection.ReflectionTypeLoadException] {
             Write-Warning "Processing $($Import.Name) Exception: $($_.Exception.Message)"
             $LoaderExceptions = $($_.Exception.LoaderExceptions) | Sort-Object -Unique

--- a/Module/DbaClientX.psm1
+++ b/Module/DbaClientX.psm1
@@ -103,9 +103,14 @@ if ($Development) {
     )
 }
 
-$LoadedAssemblyNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$LoadedAssemblyVersions = [System.Collections.Generic.Dictionary[string, System.Version]]::new([System.StringComparer]::OrdinalIgnoreCase)
 foreach ($LoadedAssembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
-    [void] $LoadedAssemblyNames.Add($LoadedAssembly.GetName().Name)
+    $LoadedAssemblyName = $LoadedAssembly.GetName()
+    if ($LoadedAssemblyName.Name -and (
+            -not $LoadedAssemblyVersions.ContainsKey($LoadedAssemblyName.Name) -or
+            $LoadedAssemblyVersions[$LoadedAssemblyName.Name] -lt $LoadedAssemblyName.Version)) {
+        $LoadedAssemblyVersions[$LoadedAssemblyName.Name] = $LoadedAssemblyName.Version
+    }
 }
 
 $FoundErrors = @(
@@ -138,14 +143,16 @@ $FoundErrors = @(
             continue
         }
 
-        if ($LoadedAssemblyNames.Contains([System.IO.Path]::GetFileNameWithoutExtension($Import.Name))) {
+        $ImportAssemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($Import.FullName)
+        if ($LoadedAssemblyVersions.ContainsKey($ImportAssemblyName.Name) -and
+            $LoadedAssemblyVersions[$ImportAssemblyName.Name] -ge $ImportAssemblyName.Version) {
             continue
         }
 
         try {
             #Write-Verbose -Message $Import.FullName
             Add-Type -Path $Import.Fullname -ErrorAction Stop
-            [void] $LoadedAssemblyNames.Add([System.IO.Path]::GetFileNameWithoutExtension($Import.Name))
+            $LoadedAssemblyVersions[$ImportAssemblyName.Name] = $ImportAssemblyName.Version
         } catch [System.Reflection.ReflectionTypeLoadException] {
             Write-Warning "Processing $($Import.Name) Exception: $($_.Exception.Message)"
             $LoaderExceptions = $($_.Exception.LoaderExceptions) | Sort-Object -Unique

--- a/Module/Tests/CmdletWriteDbaXTableData.Tests.ps1
+++ b/Module/Tests/CmdletWriteDbaXTableData.Tests.ps1
@@ -1,0 +1,107 @@
+Import-Module "$PSScriptRoot/../DbaClientX.psd1" -Force
+
+describe 'Write-DbaXTableData cmdlet' {
+    it 'is exported' {
+        Get-Command Write-DbaXTableData | Should -Not -BeNullOrEmpty
+    }
+
+    it 'supports provider routing parameters' {
+        $parameters = (Get-Command Write-DbaXTableData).Parameters.Keys
+        $parameters | Should -Contain 'Provider'
+        $parameters | Should -Contain 'ConnectionString'
+        $parameters | Should -Contain 'DestinationTable'
+        $parameters | Should -Contain 'BatchSize'
+        $parameters | Should -Contain 'BulkCopyTimeout'
+        $parameters | Should -Contain 'PassThru'
+    }
+
+    it 'passes DataTable input to the provider bulk layer' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletWriteDbaXTableData].GetProperty('BulkInsertOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:lastBulkInsert = $null
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $table)
+            $script:lastBulkInsert = [pscustomobject]@{
+                Provider = $cmdlet.Provider.ToString()
+                DestinationTable = $cmdlet.DestinationTable
+                BatchSize = $cmdlet.BatchSize
+                BulkCopyTimeout = $cmdlet.BulkCopyTimeout
+                Rows = $table.Rows.Count
+                FirstValue = $table.Rows[0]['Name']
+            }
+        })
+
+        try {
+            $table = [System.Data.DataTable]::new('Input')
+            $null = $table.Columns.Add('Name', [string])
+            $row = $table.NewRow()
+            $row['Name'] = 'Alpha'
+            $table.Rows.Add($row)
+
+            $result = $table | Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=s;Database=db;Encrypt=True' -DestinationTable dbo.Import -BatchSize 100 -BulkCopyTimeout 30 -PassThru
+
+            $script:lastBulkInsert.Provider | Should -Be 'SqlServer'
+            $script:lastBulkInsert.DestinationTable | Should -Be 'dbo.Import'
+            $script:lastBulkInsert.BatchSize | Should -Be 100
+            $script:lastBulkInsert.BulkCopyTimeout | Should -Be 30
+            $script:lastBulkInsert.Rows | Should -Be 1
+            $script:lastBulkInsert.FirstValue | Should -Be 'Alpha'
+            $result.Rows | Should -Be 1
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:lastBulkInsert = $null
+        }
+    }
+
+    it 'converts object pipeline input to a DataTable' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletWriteDbaXTableData].GetProperty('BulkInsertOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:lastBulkTable = $null
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $table)
+            $script:lastBulkTable = $table
+        })
+
+        try {
+            [pscustomobject]@{ Id = 1; Name = 'Alpha' },
+            [pscustomobject]@{ Id = 2; Name = 'Beta' } |
+                Write-DbaXTableData -Provider SQLite -ConnectionString 'Data Source=C:\Temp\bulk-test.db' -DestinationTable Import | Out-Null
+
+            $script:lastBulkTable.Rows.Count | Should -Be 2
+            $script:lastBulkTable.Columns['Id'] | Should -Not -BeNullOrEmpty
+            $script:lastBulkTable.Columns['Name'] | Should -Not -BeNullOrEmpty
+            $script:lastBulkTable.Rows[1]['Name'] | Should -Be 'Beta'
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:lastBulkTable = $null
+        }
+    }
+
+    it 'honors WhatIf and skips provider execution' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletWriteDbaXTableData].GetProperty('BulkInsertOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:bulkCalls = 0
+        $prop.SetValue($null, [scriptblock]{
+            $script:bulkCalls++
+        })
+
+        try {
+            [pscustomobject]@{ Id = 1 } |
+                Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=s;Database=db;Encrypt=True' -DestinationTable dbo.Import -WhatIf | Out-Null
+            $script:bulkCalls | Should -Be 0
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:bulkCalls = 0
+        }
+    }
+
+    it 'rejects SQLite bulk copy timeout' {
+        {
+            [pscustomobject]@{ Id = 1 } |
+                Write-DbaXTableData -Provider SQLite -ConnectionString 'Data Source=C:\Temp\bulk-test.db' -DestinationTable Import -BulkCopyTimeout 30 -ErrorAction Stop
+        } | Should -Throw
+    }
+}

--- a/Module/Tests/CmdletWriteDbaXTableData.Tests.ps1
+++ b/Module/Tests/CmdletWriteDbaXTableData.Tests.ps1
@@ -1,5 +1,102 @@
 Import-Module "$PSScriptRoot/../DbaClientX.psd1" -Force
 
+if (-not ('DbaXTestDataRecord' -as [type])) {
+    $referencedAssemblies = if ($PSVersionTable.PSEdition -eq 'Core') { @('System.Data.Common') } else { @('System.Data') }
+    Add-Type -ReferencedAssemblies $referencedAssemblies -TypeDefinition @'
+using System;
+using System.Data;
+
+public sealed class DbaXTestDataRecord : IDataRecord
+{
+    private readonly string[] _names;
+    private readonly Type[] _types;
+    private readonly object[] _values;
+
+    public DbaXTestDataRecord(string[] names, object[] values)
+    {
+        _names = names;
+        _values = values;
+        _types = new Type[values.Length];
+        for (int index = 0; index < values.Length; index++)
+        {
+            _types[index] = values[index] == null || values[index] == DBNull.Value
+                ? typeof(object)
+                : values[index].GetType();
+        }
+    }
+
+    public object this[int i] { get { return GetValue(i); } }
+
+    public object this[string name] { get { return GetValue(GetOrdinal(name)); } }
+
+    public int FieldCount { get { return _values.Length; } }
+
+    public bool GetBoolean(int i) { return Convert.ToBoolean(GetValue(i)); }
+
+    public byte GetByte(int i) { return Convert.ToByte(GetValue(i)); }
+
+    public long GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length) { throw new NotSupportedException(); }
+
+    public char GetChar(int i) { return Convert.ToChar(GetValue(i)); }
+
+    public long GetChars(int i, long fieldoffset, char[] buffer, int bufferoffset, int length) { throw new NotSupportedException(); }
+
+    public IDataReader GetData(int i) { throw new NotSupportedException(); }
+
+    public string GetDataTypeName(int i) { return GetFieldType(i).Name; }
+
+    public DateTime GetDateTime(int i) { return Convert.ToDateTime(GetValue(i)); }
+
+    public decimal GetDecimal(int i) { return Convert.ToDecimal(GetValue(i)); }
+
+    public double GetDouble(int i) { return Convert.ToDouble(GetValue(i)); }
+
+    public Type GetFieldType(int i) { return _types[i]; }
+
+    public float GetFloat(int i) { return Convert.ToSingle(GetValue(i)); }
+
+    public Guid GetGuid(int i) { return (Guid)GetValue(i); }
+
+    public short GetInt16(int i) { return Convert.ToInt16(GetValue(i)); }
+
+    public int GetInt32(int i) { return Convert.ToInt32(GetValue(i)); }
+
+    public long GetInt64(int i) { return Convert.ToInt64(GetValue(i)); }
+
+    public string GetName(int i) { return _names[i]; }
+
+    public int GetOrdinal(string name)
+    {
+        for (int index = 0; index < _names.Length; index++)
+        {
+            if (string.Equals(_names[index], name, StringComparison.OrdinalIgnoreCase))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    public string GetString(int i) { return Convert.ToString(GetValue(i)); }
+
+    public object GetValue(int i) { return _values[i]; }
+
+    public int GetValues(object[] values)
+    {
+        var count = Math.Min(values.Length, _values.Length);
+        Array.Copy(_values, values, count);
+        return count;
+    }
+
+    public bool IsDBNull(int i)
+    {
+        return _values[i] == null || _values[i] == DBNull.Value;
+    }
+}
+'@
+}
+
 describe 'Write-DbaXTableData cmdlet' {
     it 'is exported' {
         Get-Command Write-DbaXTableData | Should -Not -BeNullOrEmpty
@@ -73,6 +170,210 @@ describe 'Write-DbaXTableData cmdlet' {
             $script:lastBulkTable.Columns['Id'] | Should -Not -BeNullOrEmpty
             $script:lastBulkTable.Columns['Name'] | Should -Not -BeNullOrEmpty
             $script:lastBulkTable.Rows[1]['Name'] | Should -Be 'Beta'
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:lastBulkTable = $null
+        }
+    }
+
+    it 'treats an empty pipeline as a no-op' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletWriteDbaXTableData].GetProperty('BulkInsertOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:bulkCalls = 0
+        $prop.SetValue($null, [scriptblock]{
+            $script:bulkCalls++
+        })
+
+        try {
+            $table = [System.Data.DataTable]::new('Input')
+            $null = $table.Columns.Add('Name', [string])
+
+            $result = $table | Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=s;Database=db;Encrypt=True' -DestinationTable dbo.Import -PassThru
+
+            $script:bulkCalls | Should -Be 0
+            $result.Rows | Should -Be 0
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:bulkCalls = 0
+        }
+    }
+
+    it 'merges compatible DataRow input from different tables' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletWriteDbaXTableData].GetProperty('BulkInsertOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:lastBulkTable = $null
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $table)
+            $script:lastBulkTable = $table
+        })
+
+        try {
+            $first = [System.Data.DataTable]::new('First')
+            $null = $first.Columns.Add('Name', [string])
+            $firstRow = $first.NewRow()
+            $firstRow['Name'] = 'Alpha'
+            $first.Rows.Add($firstRow)
+
+            $second = [System.Data.DataTable]::new('Second')
+            $null = $second.Columns.Add('Name', [string])
+            $secondRow = $second.NewRow()
+            $secondRow['Name'] = 'Beta'
+            $second.Rows.Add($secondRow)
+
+            @($first.Rows[0], $second.Rows[0]) |
+                Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=s;Database=db;Encrypt=True' -DestinationTable dbo.Import | Out-Null
+
+            $script:lastBulkTable.Rows.Count | Should -Be 2
+            $script:lastBulkTable.Rows[0]['Name'] | Should -Be 'Alpha'
+            $script:lastBulkTable.Rows[1]['Name'] | Should -Be 'Beta'
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:lastBulkTable = $null
+        }
+    }
+
+    it 'converts DataRowView pipeline input as table rows' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletWriteDbaXTableData].GetProperty('BulkInsertOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:lastBulkTable = $null
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $table)
+            $script:lastBulkTable = $table
+        })
+
+        try {
+            $table = [System.Data.DataTable]::new('Input')
+            $null = $table.Columns.Add('Name', [string])
+            $row = $table.NewRow()
+            $row['Name'] = 'Alpha'
+            $table.Rows.Add($row)
+
+            $view = [System.Data.DataView]::new($table)
+            $view | Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=s;Database=db;Encrypt=True' -DestinationTable dbo.Import | Out-Null
+
+            $script:lastBulkTable.Rows.Count | Should -Be 1
+            $script:lastBulkTable.Columns['Name'] | Should -Not -BeNullOrEmpty
+            $script:lastBulkTable.Rows[0]['Name'] | Should -Be 'Alpha'
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:lastBulkTable = $null
+        }
+    }
+
+    it 'converts IDataRecord pipeline input as table rows' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletWriteDbaXTableData].GetProperty('BulkInsertOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:lastBulkTable = $null
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $table)
+            $script:lastBulkTable = $table
+        })
+
+        try {
+            $table = [System.Data.DataTable]::new('Input')
+            $null = $table.Columns.Add('Name', [string])
+            $row = $table.NewRow()
+            $row['Name'] = 'Alpha'
+            $table.Rows.Add($row)
+
+            $reader = $table.CreateDataReader()
+            $reader | Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=s;Database=db;Encrypt=True' -DestinationTable dbo.Import | Out-Null
+
+            $script:lastBulkTable.Rows.Count | Should -Be 1
+            $script:lastBulkTable.Columns['Name'] | Should -Not -BeNullOrEmpty
+            $script:lastBulkTable.Rows[0]['Name'] | Should -Be 'Alpha'
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:lastBulkTable = $null
+        }
+    }
+
+    it 'keeps duplicate IDataRecord field names unique' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletWriteDbaXTableData].GetProperty('BulkInsertOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:lastBulkTable = $null
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $table)
+            $script:lastBulkTable = $table
+        })
+
+        try {
+            $record = [DbaXTestDataRecord]::new(
+                [string[]]@('Id', 'Id'),
+                [object[]]@(1, 2))
+
+            $record | Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=s;Database=db;Encrypt=True' -DestinationTable dbo.Import | Out-Null
+
+            $script:lastBulkTable.Columns['Id'] | Should -Not -BeNullOrEmpty
+            $script:lastBulkTable.Columns['Id_2'] | Should -Not -BeNullOrEmpty
+            $script:lastBulkTable.Rows[0]['Id'] | Should -Be 1
+            $script:lastBulkTable.Rows[0]['Id_2'] | Should -Be 2
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:lastBulkTable = $null
+        }
+    }
+
+    it 'rejects incompatible IDataRecord schemas' {
+        $first = [DbaXTestDataRecord]::new(
+            [string[]]@('Id', 'Name'),
+            [object[]]@(1, 'Alpha'))
+        $second = [DbaXTestDataRecord]::new(
+            [string[]]@('Id', 'DisplayName'),
+            [object[]]@(2, 'Beta'))
+
+        {
+            @($first, $second) |
+                Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=s;Database=db;Encrypt=True' -DestinationTable dbo.Import -ErrorAction Stop
+        } | Should -Throw
+    }
+
+    it 'preserves scalar pipeline input as values' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletWriteDbaXTableData].GetProperty('BulkInsertOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:lastBulkTable = $null
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $table)
+            $script:lastBulkTable = $table
+        })
+
+        try {
+            'Alpha', 'Beta' |
+                Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=s;Database=db;Encrypt=True' -DestinationTable dbo.Import | Out-Null
+
+            $script:lastBulkTable.Columns['Value'] | Should -Not -BeNullOrEmpty
+            $script:lastBulkTable.Rows[0]['Value'] | Should -Be 'Alpha'
+            $script:lastBulkTable.Rows[1]['Value'] | Should -Be 'Beta'
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:lastBulkTable = $null
+        }
+    }
+
+    it 'preserves explicit null pipeline input as values' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletWriteDbaXTableData].GetProperty('BulkInsertOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:lastBulkTable = $null
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $table)
+            $script:lastBulkTable = $table
+        })
+
+        try {
+            $null, 'Beta' |
+                Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=s;Database=db;Encrypt=True' -DestinationTable dbo.Import | Out-Null
+
+            $script:lastBulkTable.Columns['Value'] | Should -Not -BeNullOrEmpty
+            $script:lastBulkTable.Rows.Count | Should -Be 2
+            $script:lastBulkTable.Rows[0]['Value'] | Should -Be ([DBNull]::Value)
+            $script:lastBulkTable.Rows[1]['Value'] | Should -Be 'Beta'
         } finally {
             $prop.SetValue($null, $orig)
             $script:lastBulkTable = $null


### PR DESCRIPTION
## Summary
- add a single provider-routed Write-DbaXTableData cmdlet over existing DbaClientX bulk insert APIs
- convert DataTable, DataView, IDataReader, DataRow, hashtable, and object pipeline input into DataTable payloads for the provider layer
- export the cmdlet and harden development-mode module loading so Pester does not fail on already-loaded framework dependencies

## Validation
- dotnet build DbaClientX.PowerShell\\DbaClientX.PowerShell.csproj -c Release --framework net8.0 --no-restore
- dotnet build DbaClientX.PowerShell\\DbaClientX.PowerShell.csproj -c Debug --framework net8.0 --no-restore
- dotnet build DbaClientX.sln -c Release --no-restore
- dotnet test DbaClientX.sln -c Release --framework net8.0 --no-build
- Invoke-Pester -Path .\\Module\\Tests\\CmdletWriteDbaXTableData.Tests.ps1 -Output Detailed
- git diff --check