### PR TITLE
Add packaged ALC support and README refresh

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -117,6 +117,41 @@ jobs:
               shell: pwsh
               run: ./Module/DbaClientX.Tests.ps1
 
+    test-packaged-alc-ps7:
+        name: 'Windows PowerShell 7 Packaged ALC'
+        runs-on: windows-latest
+        timeout-minutes: 15
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+
+            - name: Install PowerShell modules
+              shell: pwsh
+              run: |
+                  Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+                  Install-Module -Name PSPublishModule -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+                  Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+                  Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+
+            - name: Build packaged module
+              shell: pwsh
+              env:
+                  RefreshPSD1Only: 'false'
+              run: ./Module/Build/Build-Module.ps1
+
+            - name: Run packaged ALC smoke test
+              shell: pwsh
+              env:
+                  DBACLIENTX_REQUIRE_ALC_SMOKE: 'true'
+              run: |
+                  Import-Module Pester -Force
+                  Invoke-Pester -Path ./Module/Tests/AssemblyLoadContext.Tests.ps1 -Output Detailed
+
     test-ubuntu:
         needs: refresh-psd1
         name: 'Ubuntu PowerShell 7'

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -150,7 +150,7 @@ jobs:
                   DBACLIENTX_REQUIRE_ALC_SMOKE: 'true'
               run: |
                   Import-Module Pester -Force
-                  Invoke-Pester -Path ./Module/Tests/AssemblyLoadContext.Tests.ps1 -Output Detailed
+                  Invoke-Pester -Path ./Module/Tests/AssemblyLoadContext.Tests.ps1 -Tag PackagedALC -Output Detailed
 
     test-ubuntu:
         needs: refresh-psd1

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -95,23 +95,6 @@
 
     New-ConfigurationImportModule -ImportSelf -ImportRequiredModules -SkipBinaryDependencyCheck
 
-    $refreshPSD1Only = $true
-    if (-not [string]::IsNullOrWhiteSpace($env:RefreshPSD1Only)) {
-        switch -Regex ($env:RefreshPSD1Only.Trim()) {
-            '^(1|true|yes|on)$' {
-                $refreshPSD1Only = $true
-                break
-            }
-            '^(0|false|no|off)$' {
-                $refreshPSD1Only = $false
-                break
-            }
-            default {
-                throw "RefreshPSD1Only must be a boolean value or numeric flag, but received '$env:RefreshPSD1Only'."
-            }
-        }
-    }
-
     $newConfigurationBuildSplat = @{
         Enable                            = $true
         SignModule                        = if ($Env:COMPUTERNAME -eq 'EVOMAGIC') { $true } else { $false }
@@ -143,7 +126,7 @@
         # PSPublishModule 3.x tightened this legacy option to a single string value.
         NETSearchClass                    = $netSearchClasses -join ','
         DotSourceLibraries                = $true
-        RefreshPSD1Only                   = $refreshPSD1Only
+        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $true } else { [bool]::Parse($Env:RefreshPSD1Only) }
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -93,11 +93,28 @@
     # configuration for documentation, at the same time it enables documentation processing
     New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
 
-    New-ConfigurationImportModule -ImportSelf -ImportRequiredModules
+    New-ConfigurationImportModule -ImportSelf -ImportRequiredModules -SkipBinaryDependencyCheck
+
+    $refreshPSD1Only = $true
+    if (-not [string]::IsNullOrWhiteSpace($env:RefreshPSD1Only)) {
+        switch -Regex ($env:RefreshPSD1Only.Trim()) {
+            '^(1|true|yes|on)$' {
+                $refreshPSD1Only = $true
+                break
+            }
+            '^(0|false|no|off)$' {
+                $refreshPSD1Only = $false
+                break
+            }
+            default {
+                throw "RefreshPSD1Only must be a boolean value or numeric flag, but received '$env:RefreshPSD1Only'."
+            }
+        }
+    }
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = $true
+        SignModule                        = if ($Env:COMPUTERNAME -eq 'EVOMAGIC') { $true } else { $false }
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
         CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
@@ -108,10 +125,25 @@
         NETBinaryModule                   = 'DbaClientX.PowerShell.dll'
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net472', 'net8.0'
+        NETHandleAssemblyWithSameName     = $true
+        NETAssemblyLoadContext            = $true
+        NETHandleRuntimes                 = $true
+        NETExcludeLibraryFilter           = @(
+            'Microsoft.Data.SqlClient.SNI.arm64.dll'
+            'Microsoft.Data.SqlClient.SNI.dll'
+            'Microsoft.Data.SqlClient.SNI.x64.dll'
+            'Microsoft.Data.SqlClient.SNI.x86.dll'
+        )
+        NETIgnoreLibraryOnLoad            = @(
+            'Microsoft.Data.SqlClient.SNI.arm64.dll'
+            'Microsoft.Data.SqlClient.SNI.dll'
+            'Microsoft.Data.SqlClient.SNI.x64.dll'
+            'Microsoft.Data.SqlClient.SNI.x86.dll'
+        )
         # PSPublishModule 3.x tightened this legacy option to a single string value.
         NETSearchClass                    = $netSearchClasses -join ','
         DotSourceLibraries                = $true
-        RefreshPSD1Only                   = $true
+        RefreshPSD1Only                   = $refreshPSD1Only
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -95,12 +95,14 @@
 
     New-ConfigurationImportModule -ImportSelf -ImportRequiredModules -SkipBinaryDependencyCheck
 
+    $certificateThumbprint = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = if ($Env:COMPUTERNAME -eq 'EVOMAGIC') { $true } else { $false }
+        SignModule                        = Test-Path -LiteralPath "Cert:\CurrentUser\My\$certificateThumbprint"
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
-        CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+        CertificateThumbprint             = $certificateThumbprint
         NETProjectPath                    = "$PSScriptRoot\..\..\DbaClientX.PowerShell"
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'DbaClientX.PowerShell'

--- a/Module/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Module/Tests/AssemblyLoadContext.Tests.ps1
@@ -9,3 +9,98 @@ Describe 'Assembly Load Context' {
         $alc.Name | Should -Be 'DbaClientX.PowerShell'
     }
 }
+
+Describe 'Packaged Assembly Load Context' {
+    It 'loads packaged cmdlets through the module-scoped ALC on CoreCLR' {
+        $packagedModuleRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\Artefacts\Unpacked'))
+        $packagedModule = [IO.Path]::GetFullPath((Join-Path $packagedModuleRoot 'DbaClientX'))
+        $packagedLoader = Join-Path $packagedModule 'Lib\Core\DbaClientX.ModuleLoadContext.dll'
+        $conflictAssemblyPath = Join-Path $packagedModule 'Lib\Core\Microsoft.Data.SqlClient.dll'
+        $requirePackagedSmoke = $env:DBACLIENTX_REQUIRE_ALC_SMOKE -eq 'true'
+
+        if (-not $IsCoreCLR) {
+            Set-ItResult -Skipped -Because 'AssemblyLoadContext isolation is only available in PowerShell Core'
+            return
+        }
+
+        if (-not $requirePackagedSmoke -and (
+                -not (Test-Path -LiteralPath $packagedModule) -or
+                -not (Test-Path -LiteralPath $packagedLoader) -or
+                -not (Test-Path -LiteralPath $conflictAssemblyPath))) {
+            Set-ItResult -Skipped -Because 'packaged Core artifact is required'
+            return
+        }
+
+        Test-Path -LiteralPath $packagedModule | Should -BeTrue -Because 'the packaged module must exist before the ALC smoke test runs'
+        Test-Path -LiteralPath $packagedLoader | Should -BeTrue -Because 'the packaged module must include the PSPublishModule ALC loader'
+        Test-Path -LiteralPath $conflictAssemblyPath | Should -BeTrue -Because 'the conflict assembly must exist before the smoke test runs'
+
+        $moduleRootLiteral = $packagedModuleRoot.Replace("'", "''")
+        $conflictAssemblyLiteral = $conflictAssemblyPath.Replace("'", "''")
+        $script = @"
+`$ErrorActionPreference = 'Stop'
+`$WarningPreference = 'SilentlyContinue'
+`$moduleRoot = '$moduleRootLiteral'
+`$conflictAssemblyPath = '$conflictAssemblyLiteral'
+`$env:PSModulePath = `$moduleRoot + [IO.Path]::PathSeparator + `$env:PSModulePath
+
+Add-Type -Path `$conflictAssemblyPath -ErrorAction Stop
+`$defaultConflictAssembly = [AppDomain]::CurrentDomain.GetAssemblies() |
+    Where-Object { `$_.GetName().Name -eq 'Microsoft.Data.SqlClient' } |
+    Select-Object -First 1
+`$defaultConflictAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$defaultConflictAssembly)
+
+Import-Module DbaClientX -Force
+`$command = Get-Command Invoke-DbaXQuery -ErrorAction Stop
+`$commandAssembly = `$command.ImplementingType.Assembly
+`$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
+`$loadedAssemblies = [System.Runtime.Loader.AssemblyLoadContext]::All |
+    ForEach-Object {
+        `$alc = `$_
+        foreach (`$assembly in `$alc.Assemblies) {
+            if (`$assembly.GetName().Name -in @('DbaClientX.PowerShell', 'DbaClientX', 'Microsoft.Data.SqlClient')) {
+                [pscustomobject]@{
+                    Assembly = `$assembly.GetName().Name
+                    Version = `$assembly.GetName().Version.ToString()
+                    ALC = `$alc.Name
+                    IsDefault = [object]::ReferenceEquals(`$alc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+                    Location = `$assembly.Location
+                }
+            }
+        }
+    }
+
+[pscustomobject]@{
+    DefaultConflictAssembly = `$defaultConflictAssembly.Location
+    DefaultConflictALC = `$defaultConflictAlc.Name
+    DefaultConflictALCIsDefault = [object]::ReferenceEquals(`$defaultConflictAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    InvokeDbaXQueryAssembly = `$commandAssembly.Location
+    InvokeDbaXQueryALC = `$commandAlc.Name
+    InvokeDbaXQueryALCIsDefault = [object]::ReferenceEquals(`$commandAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    LoadedAssemblies = @(`$loadedAssemblies)
+} | ConvertTo-Json -Depth 6 -Compress
+"@
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($script))
+        $output = pwsh -NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded 2>&1
+        $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
+
+        $json = $output | Where-Object { $_ -is [string] -and $_.TrimStart().StartsWith('{') } | Select-Object -Last 1
+        $json | Should -Not -BeNullOrEmpty -Because ($output -join [Environment]::NewLine)
+        $result = $json | ConvertFrom-Json
+
+        $result.DefaultConflictAssembly | Should -Be $conflictAssemblyPath
+        $result.DefaultConflictALCIsDefault | Should -BeTrue
+        $result.InvokeDbaXQueryAssembly | Should -BeLike '*\Module\Artefacts\Unpacked\DbaClientX\Lib\Core\DBAClientX.PowerShell.dll'
+        $result.InvokeDbaXQueryALC | Should -Be 'DbaClientX'
+        $result.InvokeDbaXQueryALCIsDefault | Should -BeFalse
+
+        $loadedAssemblies = @($result.LoadedAssemblies)
+        $dbaClientXPowerShellAssembly = $loadedAssemblies | Where-Object { $_.Assembly -eq 'DbaClientX.PowerShell' -and $_.ALC -eq 'DbaClientX' } | Select-Object -First 1
+        $dbaClientXAssembly = $loadedAssemblies | Where-Object { $_.Assembly -eq 'DbaClientX' -and $_.ALC -eq 'DbaClientX' } | Select-Object -First 1
+        $defaultConflictAssembly = $loadedAssemblies | Where-Object { $_.Assembly -eq 'Microsoft.Data.SqlClient' -and $_.IsDefault } | Select-Object -First 1
+
+        $dbaClientXPowerShellAssembly.IsDefault | Should -BeFalse
+        $dbaClientXAssembly.IsDefault | Should -BeFalse
+        $defaultConflictAssembly.IsDefault | Should -BeTrue
+    }
+}

--- a/Module/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Module/Tests/AssemblyLoadContext.Tests.ps1
@@ -10,7 +10,7 @@ Describe 'Assembly Load Context' {
     }
 }
 
-Describe 'Packaged Assembly Load Context' {
+Describe 'Packaged Assembly Load Context' -Tag 'PackagedALC' {
     It 'loads packaged cmdlets through the module-scoped ALC on CoreCLR' {
         $packagedModuleRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..\Artefacts\Unpacked'))
         $packagedModule = [IO.Path]::GetFullPath((Join-Path $packagedModuleRoot 'DbaClientX'))

--- a/README.md
+++ b/README.md
@@ -1,58 +1,318 @@
-## DbaClientX
+# DbaClientX - Multi-provider database client for .NET and PowerShell
 
-DbaClientX is a lightweight, multi‑provider database client for .NET and PowerShell.
-It offers:
+DbaClientX is a lightweight database client for .NET and PowerShell. It keeps the database-specific work in provider libraries and exposes a small PowerShell surface for pleasant data movement, query execution, transactions, and bulk writes.
 
-- Providers: SQL Server, PostgreSQL, MySQL, SQLite, Oracle
-- Sync/async APIs with cancellation, retries, and transactions
-- Transaction wrapper helpers that commit on success and roll back on failures
-- A small SQL query builder with dialect support and parameterization
-- PowerShell cmdlets for quick scripting
+## NuGet Packages
 
-### Repo structure
+[![DBAClientX.Core](https://img.shields.io/nuget/v/DBAClientX.Core?label=DBAClientX.Core)](https://www.nuget.org/packages/DBAClientX.Core)
+[![DBAClientX.SqlServer](https://img.shields.io/nuget/v/DBAClientX.SqlServer?label=SQL%20Server)](https://www.nuget.org/packages/DBAClientX.SqlServer)
+[![DBAClientX.PostgreSql](https://img.shields.io/nuget/v/DBAClientX.PostgreSql?label=PostgreSQL)](https://www.nuget.org/packages/DBAClientX.PostgreSql)
+[![DBAClientX.MySql](https://img.shields.io/nuget/v/DBAClientX.MySql?label=MySQL)](https://www.nuget.org/packages/DBAClientX.MySql)
+[![DBAClientX.SQLite](https://img.shields.io/nuget/v/DBAClientX.SQLite?label=SQLite)](https://www.nuget.org/packages/DBAClientX.SQLite)
+[![DBAClientX.Oracle](https://img.shields.io/nuget/v/DBAClientX.Oracle?label=Oracle)](https://www.nuget.org/packages/DBAClientX.Oracle)
 
-- `DbaClientX.Core` – shared base (`DatabaseClientBase`), retry logic, query builder
-- `DbaClientX.SqlServer` / `PostgreSql` / `MySql` / `SQLite` / `Oracle` – providers
-- `DbaClientX.PowerShell` – PowerShell cmdlets
-- `DbaClientX.Tests` – xUnit unit tests
-- `Module` – Pester tests and module build script
+## PowerShell Module
 
-### Build & test
+[![PowerShell Gallery version](https://img.shields.io/powershellgallery/v/DbaClientX.svg)](https://www.powershellgallery.com/packages/DbaClientX)
+[![PowerShell Gallery preview](https://img.shields.io/powershellgallery/v/DbaClientX.svg?label=powershell%20gallery%20preview&colorB=yellow&include_prereleases)](https://www.powershellgallery.com/packages/DbaClientX)
+[![PowerShell Gallery platforms](https://img.shields.io/powershellgallery/p/DbaClientX.svg)](https://www.powershellgallery.com/packages/DbaClientX)
+[![PowerShell Gallery downloads](https://img.shields.io/powershellgallery/dt/DbaClientX.svg)](https://www.powershellgallery.com/packages/DbaClientX)
 
+## Project Information
+
+[![Test .NET](https://github.com/EvotecIT/DbaClientX/actions/workflows/test-dotnet.yml/badge.svg)](https://github.com/EvotecIT/DbaClientX/actions/workflows/test-dotnet.yml)
+[![Test PowerShell](https://github.com/EvotecIT/DbaClientX/actions/workflows/test-powershell.yml/badge.svg)](https://github.com/EvotecIT/DbaClientX/actions/workflows/test-powershell.yml)
+[![codecov](https://codecov.io/gh/EvotecIT/DbaClientX/branch/master/graph/badge.svg)](https://codecov.io/gh/EvotecIT/DbaClientX)
+[![license](https://img.shields.io/github/license/EvotecIT/DbaClientX.svg)](https://github.com/EvotecIT/DbaClientX)
+
+## Author and Community
+
+[![Blog](https://img.shields.io/badge/Blog-evotec.xyz-2A6496.svg)](https://evotec.xyz/hub)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-pklys-0077B5.svg?logo=LinkedIn)](https://www.linkedin.com/in/pklys)
+[![Discord](https://img.shields.io/discord/508328927853281280?style=flat-square&label=discord%20chat)](https://evo.yt/discord)
+
+## What it's all about
+
+DbaClientX is meant to be the thin, reusable database layer behind higher-level tooling. For example, PSWriteOffice can focus on fast Excel import/export while DbaClientX handles provider-specific database writes. The PowerShell module stays small and operator-friendly; the heavy database logic remains in C#.
+
+Use it when you need:
+
+- one codebase for SQL Server, PostgreSQL, MySQL, SQLite, and Oracle
+- sync and async query execution
+- parameterized commands and provider-specific parameter type preservation
+- transaction helpers that commit on success and roll back on failure
+- provider-native bulk insert paths for staging tables and direct table writes
+- PowerShell cmdlets for quick scripts, scheduled jobs, and data movement
+
+## Supported Providers
+
+| Provider | NuGet package | PowerShell query cmdlets | Bulk write | Transaction helper |
+| --- | --- | --- | --- | --- |
+| SQL Server | [DBAClientX.SqlServer](https://www.nuget.org/packages/DBAClientX.SqlServer) | `Invoke-DbaXQuery`, `Invoke-DbaXNonQuery` | `Write-DbaXTableData -Provider SqlServer` | `Invoke-DbaXTransaction` |
+| PostgreSQL | [DBAClientX.PostgreSql](https://www.nuget.org/packages/DBAClientX.PostgreSql) | `Invoke-DbaXPostgreSql`, `Invoke-DbaXPostgreSqlNonQuery` | `Write-DbaXTableData -Provider PostgreSql` | `Invoke-DbaXPostgreSqlTransaction` |
+| MySQL | [DBAClientX.MySql](https://www.nuget.org/packages/DBAClientX.MySql) | `Invoke-DbaXMySql`, `Invoke-DbaXMySqlNonQuery`, `Invoke-DbaXMySqlScalar` | `Write-DbaXTableData -Provider MySql` | `Invoke-DbaXMySqlTransaction` |
+| SQLite | [DBAClientX.SQLite](https://www.nuget.org/packages/DBAClientX.SQLite) | `Invoke-DbaXSQLite` | `Write-DbaXTableData -Provider SQLite` | `Invoke-DbaXSQLiteTransaction` |
+| Oracle | [DBAClientX.Oracle](https://www.nuget.org/packages/DBAClientX.Oracle) | `Invoke-DbaXOracle`, `Invoke-DbaXOracleNonQuery`, `Invoke-DbaXOracleScalar` | `Write-DbaXTableData -Provider Oracle` | `Invoke-DbaXOracleTransaction` |
+
+## Install
+
+PowerShell:
+
+```powershell
+Install-Module DbaClientX -Scope CurrentUser
 ```
+
+.NET:
+
+```powershell
+dotnet add package DBAClientX.Core
+dotnet add package DBAClientX.SqlServer
+dotnet add package DBAClientX.PostgreSql
+dotnet add package DBAClientX.MySql
+dotnet add package DBAClientX.SQLite
+dotnet add package DBAClientX.Oracle
+```
+
+Install only the provider packages you need.
+
+## PowerShell Usage
+
+### Query SQL Server
+
+```powershell
+Invoke-DbaXQuery `
+    -Server 'sql01' `
+    -Database 'App' `
+    -Query 'SELECT TOP (10) * FROM dbo.Users' `
+    -Credential $Credential
+```
+
+### Query Other Providers
+
+```powershell
+Invoke-DbaXPostgreSql -Server 'pg01' -Database 'app' -Query 'select * from users limit 10' -Credential $Credential
+Invoke-DbaXMySql -Server 'mysql01' -Database 'app' -Query 'select * from users limit 10' -Credential $Credential
+Invoke-DbaXOracle -Server 'ora01' -Database 'service' -Query 'select * from users fetch first 10 rows only' -Credential $Credential
+Invoke-DbaXSQLite -Database '.\app.db' -Query 'select * from users limit 10'
+```
+
+### Build SQL
+
+```powershell
+New-DbaXQuery -TableName 'dbo.Users' -Limit 50 -Compile
+```
+
+### Write Table Data
+
+`Write-DbaXTableData` accepts `DataTable`, `DataView`, `IDataReader`, `DataRow`, hashtables, and regular PowerShell objects from the pipeline. This makes it useful for staging-table imports and direct table writes.
+
+```powershell
+$rows = @(
+    [pscustomobject]@{ Id = 1; DisplayName = 'Alice' }
+    [pscustomobject]@{ Id = 2; DisplayName = 'Bob' }
+)
+
+$rows | Write-DbaXTableData `
+    -Provider SqlServer `
+    -ConnectionString 'Server=.;Database=App;Encrypt=True;TrustServerCertificate=True;Integrated Security=True' `
+    -DestinationTable 'dbo.ImportUsers' `
+    -BatchSize 5000 `
+    -PassThru
+```
+
+With PSWriteOffice:
+
+```powershell
+Import-OfficeExcel .\Users.xlsx -AsDataTable |
+    Write-DbaXTableData `
+        -Provider PostgreSql `
+        -ConnectionString 'Host=localhost;Database=app;Username=user;Password=secret' `
+        -DestinationTable 'public.import_users' `
+        -BatchSize 5000
+```
+
+### Use Transactions
+
+```powershell
+Invoke-DbaXTransaction -Server 'sql01' -Database 'App' -ScriptBlock {
+    param($client)
+
+    $client.ExecuteNonQuery(
+        'sql01',
+        'App',
+        $true,
+        'UPDATE dbo.Users SET IsActive = 1 WHERE Id = 1',
+        $null,
+        $true
+    )
+}
+```
+
+Transaction helpers honor `-WhatIf` and `-Confirm`, commit when the script block succeeds, roll back on failure, and dispose the provider client in `finally`.
+
+## .NET Usage
+
+### Query Data
+
+```csharp
+using DBAClientX;
+using System.Data;
+
+using var sqlServer = new SqlServer {
+    ReturnType = ReturnType.DataTable
+};
+
+var result = await sqlServer.QueryAsync(
+    "SQL1",
+    "master",
+    integratedSecurity: true,
+    query: "SELECT TOP 1 * FROM sys.databases");
+
+if (result is DataTable table) {
+    foreach (DataRow row in table.Rows) {
+        Console.WriteLine(row["name"]);
+    }
+}
+```
+
+### Bulk Insert
+
+```csharp
+using System.Data;
+using DBAClientX;
+
+using var sqlServer = new SqlServer();
+var table = new DataTable();
+table.Columns.Add("Id", typeof(int));
+table.Columns.Add("Name", typeof(string));
+table.Rows.Add(1, "Example");
+
+sqlServer.BulkInsert(
+    server: "SQL1",
+    database: "App",
+    integratedSecurity: true,
+    table: table,
+    destinationTable: "dbo.ImportUsers",
+    batchSize: 1000,
+    bulkCopyTimeout: 60);
+```
+
+### Build Connection Strings
+
+```csharp
+var sqlServer = DBAClientX.SqlServer.BuildConnectionString("SQL1", "App", integratedSecurity: true, ssl: true);
+var postgres = DBAClientX.PostgreSql.BuildConnectionString("localhost", "app", "user", "password", ssl: true);
+var mysql = DBAClientX.MySql.BuildConnectionString("localhost", "app", "user", "password", ssl: true);
+var sqlite = DBAClientX.SQLite.BuildConnectionString("app.db");
+```
+
+### Query Builder
+
+```csharp
+using DBAClientX.QueryBuilder;
+
+var query = new Query()
+    .Select("*")
+    .From("users")
+    .Where("name", "Alice")
+    .Where("age", ">", 30);
+
+var (sql, parameters) = QueryBuilder.CompileWithParameters(query);
+```
+
+## Supported .NET Versions
+
+| Component | Windows | Linux/macOS |
+| --- | --- | --- |
+| Provider libraries | .NET Framework 4.7.2, .NET 8.0, .NET 10.0 | .NET 8.0, .NET 10.0 |
+| PowerShell binary module | .NET Framework 4.7.2, .NET 8.0 | .NET 8.0 |
+| Examples | .NET 8.0, .NET 10.0 | .NET 8.0, .NET 10.0 |
+| Benchmarks | .NET 8.0, .NET 10.0 | .NET 8.0, .NET 10.0 |
+
+## Repository Structure
+
+| Path | Purpose |
+| --- | --- |
+| [`DbaClientX.Core`](DbaClientX.Core) | Shared base client, retry logic, query builder, connection validation, invoker abstractions |
+| [`DbaClientX.SqlServer`](DbaClientX.SqlServer) | SQL Server provider |
+| [`DbaClientX.PostgreSql`](DbaClientX.PostgreSql) | PostgreSQL provider |
+| [`DbaClientX.MySql`](DbaClientX.MySql) | MySQL provider |
+| [`DbaClientX.SQLite`](DbaClientX.SQLite) | SQLite provider |
+| [`DbaClientX.Oracle`](DbaClientX.Oracle) | Oracle provider |
+| [`DbaClientX.PowerShell`](DbaClientX.PowerShell) | Binary cmdlets and PowerShell-facing helpers |
+| [`Module`](Module) | PowerShell module manifest, script functions, examples, Pester tests, and build script |
+| [`DbaClientX.Examples`](DbaClientX.Examples) | C# usage examples |
+| [`DbaClientX.Tests`](DbaClientX.Tests) | xUnit tests |
+| [`DbaClientX.Benchmarks`](DbaClientX.Benchmarks) | BenchmarkDotNet scenarios |
+| [`Build`](Build) | Project release configuration |
+
+## Examples
+
+- PowerShell examples: [`Module/Examples`](Module/Examples)
+- C# examples: [`DbaClientX.Examples`](DbaClientX.Examples)
+- Benchmarks: [`DbaClientX.Benchmarks`](DbaClientX.Benchmarks)
+
+Useful example files:
+
+- [`Example.QuerySqlServer.ps1`](Module/Examples/Example.QuerySqlServer.ps1)
+- [`Example.QueryPostgreSql.ps1`](Module/Examples/Example.QueryPostgreSql.ps1)
+- [`Example.QueryMySql.ps1`](Module/Examples/Example.QueryMySql.ps1)
+- [`Example.QueryOracle.ps1`](Module/Examples/Example.QueryOracle.ps1)
+- [`Example.QuerySQLite.ps1`](Module/Examples/Example.QuerySQLite.ps1)
+- [`BulkInsertExample.cs`](DbaClientX.Examples/BulkInsertExample.cs)
+- [`TransactionExample.cs`](DbaClientX.Examples/TransactionExample.cs)
+- [`ParameterizedQueryExample.cs`](DbaClientX.Examples/ParameterizedQueryExample.cs)
+
+## Build and Test
+
+```powershell
 dotnet restore DbaClientX.sln
 dotnet build DbaClientX.sln -c Release
 dotnet test DbaClientX.sln -c Release --framework net8.0
 ```
 
-### Release packaging (manual signing)
+PowerShell module tests:
+
+```powershell
+.\Module\DbaClientX.Tests.ps1
+```
+
+Package build:
+
+```powershell
+$env:RefreshPSD1Only = 'false'
+.\Module\Build\Build-Module.ps1
+Remove-Item Env:\RefreshPSD1Only
+```
+
+## Release Packaging
 
 Package publishing is intentionally manual in this repository because releases are signed locally with the USB key certificate.
 
-1. Generate a build plan:
+Generate a build plan:
 
 ```powershell
 pwsh.exe -NoLogo -NoProfile -File .\Build\Build-Project.ps1 -Plan $true
 ```
 
-2. Build signed packages locally:
+Build signed packages locally:
 
 ```powershell
 pwsh.exe -NoLogo -NoProfile -File .\Build\Build-Project.ps1 -Build $true -PublishNuget $false -PublishGitHub $false
 ```
 
-3. Publish NuGet and GitHub together in one versioned run:
+Publish NuGet and GitHub together in one versioned run:
 
 ```powershell
 pwsh.exe -NoLogo -NoProfile -File .\Build\Build-Project.ps1 -PublishNuget $true -PublishGitHub $true
 ```
 
-Build configuration lives in `Build/project.build.json` and artifacts are generated under `Artefacts/ProjectBuild`.
+Build configuration lives in [`Build/project.build.json`](Build/project.build.json), and artifacts are generated under `Artefacts/ProjectBuild`.
 
-### Notes
+## Notes
 
-- The solution enables nullable reference types and .NET analyzers via `Directory.Build.props`.
-- SourceLink is enabled for all projects for better debugging into packages.
-- SQL Server provider uses `Microsoft.Data.SqlClient`.
-- The release wrapper now treats version updates as part of publishing. If you intentionally need a replay-only publish for already-versioned artifacts, pass `-UpdateVersions $false` explicitly.
-
+- The solution enables nullable reference types and .NET analyzers via [`Directory.Build.props`](Directory.Build.props).
+- SourceLink is enabled for provider projects for easier debugging into packages.
+- SQL Server uses `Microsoft.Data.SqlClient`.
+- PowerShell 7 package builds use a module-scoped AssemblyLoadContext so DbaClientX can coexist more safely with other modules that load overlapping assemblies.
+- The release wrapper treats version updates as part of publishing. If you intentionally need a replay-only publish for already-versioned artifacts, pass `-UpdateVersions $false` explicitly.


### PR DESCRIPTION
## Summary
- enable PSPublishModule module-scoped AssemblyLoadContext generation for the packaged DbaClientX build
- keep SqlClient native SNI assets under runtime-specific folders while excluding flat native copies from managed load validation
- add a packaged PowerShell 7 ALC smoke test and CI job that forces the smoke test after building the package
- refresh the root README with DnsClientX-style structure, badges, provider matrix, links, and PowerShell/.NET examples

## Validation
- `git diff --check`
- `./Module/Build/Build-Module.ps1` with `RefreshPSD1Only=false`
- focused `Invoke-Pester -Path ./Module/Tests/AssemblyLoadContext.Tests.ps1 -Tag PackagedALC` with `DBACLIENTX_REQUIRE_ALC_SMOKE=true`
- `dotnet build DbaClientX.sln -c Release`
- `dotnet test DbaClientX.sln -c Release --no-build`
- `./Module/DbaClientX.Tests.ps1`
- README local path/link sanity check

## Notes
- The full build still reports PSPublishModule binary-conflict advisories for locally installed modules, but the build completes and produces the ALC loader.
- The .NET build still reports existing `System.Security.Cryptography.Xml` NU1903 warnings from the test project.
