### PR TITLE
feat(sqlserver): add monitoring primitives

### DIFF
--- a/DbaClientX.SqlServer/Monitoring/SqlServerAgentJobHealth.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerAgentJobHealth.cs
@@ -1,0 +1,39 @@
+using System;
+
+namespace DBAClientX.SqlServerMonitoring;
+
+/// <summary>
+/// SQL Server Agent job health and recent execution state.
+/// </summary>
+public sealed class SqlServerAgentJobHealth
+{
+    /// <summary>SQL Agent job identifier.</summary>
+    public Guid JobId { get; set; }
+
+    /// <summary>SQL Agent job name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Job category name.</summary>
+    public string? Category { get; set; }
+
+    /// <summary>Job owner login name.</summary>
+    public string? OwnerLoginName { get; set; }
+
+    /// <summary>True when the job is enabled.</summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>True when SQL Agent currently reports the job as running.</summary>
+    public bool IsRunning { get; set; }
+
+    /// <summary>Timestamp when the current execution started, if running.</summary>
+    public DateTime? CurrentStartDate { get; set; }
+
+    /// <summary>Most recent job run timestamp.</summary>
+    public DateTime? LastRunDate { get; set; }
+
+    /// <summary>Most recent job outcome such as Succeeded or Failed.</summary>
+    public string? LastRunOutcome { get; set; }
+
+    /// <summary>Last run duration in SQL Agent history when available.</summary>
+    public TimeSpan? LastRunDuration { get; set; }
+}

--- a/DbaClientX.SqlServer/Monitoring/SqlServerAvailabilityGroupHealth.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerAvailabilityGroupHealth.cs
@@ -1,0 +1,47 @@
+namespace DBAClientX.SqlServerMonitoring;
+
+/// <summary>
+/// Availability Group replica and database health row.
+/// </summary>
+public sealed class SqlServerAvailabilityGroupHealth
+{
+    /// <summary>Availability Group name.</summary>
+    public string AvailabilityGroupName { get; set; } = string.Empty;
+
+    /// <summary>Replica server name.</summary>
+    public string ReplicaServerName { get; set; } = string.Empty;
+
+    /// <summary>Replica role such as PRIMARY or SECONDARY.</summary>
+    public string? Role { get; set; }
+
+    /// <summary>Replica operational state.</summary>
+    public string? OperationalState { get; set; }
+
+    /// <summary>Replica connection state.</summary>
+    public string? ConnectedState { get; set; }
+
+    /// <summary>Replica synchronization health.</summary>
+    public string? SynchronizationHealth { get; set; }
+
+    /// <summary>Database name when the row is database-scoped.</summary>
+    public string? DatabaseName { get; set; }
+
+    /// <summary>Database synchronization state.</summary>
+    public string? DatabaseSynchronizationState { get; set; }
+
+    /// <summary>Database synchronization health.</summary>
+    public string? DatabaseSynchronizationHealth { get; set; }
+
+    /// <summary>True when the database replica is suspended.</summary>
+    public bool IsSuspended { get; set; }
+
+    /// <summary>Database replica suspend reason.</summary>
+    public string? SuspendReason { get; set; }
+
+    /// <summary>True when the replica/database row looks healthy.</summary>
+    public bool IsHealthy =>
+        !IsSuspended &&
+        (string.IsNullOrWhiteSpace(ConnectedState) || string.Equals(ConnectedState, "CONNECTED", System.StringComparison.OrdinalIgnoreCase)) &&
+        (string.IsNullOrWhiteSpace(SynchronizationHealth) || string.Equals(SynchronizationHealth, "HEALTHY", System.StringComparison.OrdinalIgnoreCase)) &&
+        (string.IsNullOrWhiteSpace(DatabaseSynchronizationHealth) || string.Equals(DatabaseSynchronizationHealth, "HEALTHY", System.StringComparison.OrdinalIgnoreCase));
+}

--- a/DbaClientX.SqlServer/Monitoring/SqlServerAvailabilityGroupHealth.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerAvailabilityGroupHealth.cs
@@ -41,7 +41,13 @@ public sealed class SqlServerAvailabilityGroupHealth
     /// <summary>True when the replica/database row looks healthy.</summary>
     public bool IsHealthy =>
         !IsSuspended &&
-        (string.IsNullOrWhiteSpace(ConnectedState) || string.Equals(ConnectedState, "CONNECTED", System.StringComparison.OrdinalIgnoreCase)) &&
-        (string.IsNullOrWhiteSpace(SynchronizationHealth) || string.Equals(SynchronizationHealth, "HEALTHY", System.StringComparison.OrdinalIgnoreCase)) &&
-        (string.IsNullOrWhiteSpace(DatabaseSynchronizationHealth) || string.Equals(DatabaseSynchronizationHealth, "HEALTHY", System.StringComparison.OrdinalIgnoreCase));
+        HasState(ConnectedState, "CONNECTED") &&
+        HasState(SynchronizationHealth, "HEALTHY") &&
+        (string.IsNullOrWhiteSpace(DatabaseName) || HasState(DatabaseSynchronizationHealth, "HEALTHY"));
+
+    private static bool HasState(string? actual, string expected)
+    {
+        return !string.IsNullOrWhiteSpace(actual) &&
+               string.Equals(actual, expected, System.StringComparison.OrdinalIgnoreCase);
+    }
 }

--- a/DbaClientX.SqlServer/Monitoring/SqlServerBackupFreshness.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerBackupFreshness.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace DBAClientX.SqlServerMonitoring;
+
+/// <summary>
+/// Backup recency information for one database.
+/// </summary>
+public sealed class SqlServerBackupFreshness
+{
+    /// <summary>Database name.</summary>
+    public string DatabaseName { get; set; } = string.Empty;
+
+    /// <summary>Database recovery model.</summary>
+    public string RecoveryModel { get; set; } = string.Empty;
+
+    /// <summary>Database creation timestamp.</summary>
+    public DateTime? DatabaseCreated { get; set; }
+
+    /// <summary>Most recent full backup completion time.</summary>
+    public DateTime? LastFullBackup { get; set; }
+
+    /// <summary>Most recent differential backup completion time.</summary>
+    public DateTime? LastDifferentialBackup { get; set; }
+
+    /// <summary>Most recent log backup completion time.</summary>
+    public DateTime? LastLogBackup { get; set; }
+
+    /// <summary>Elapsed time since the most recent full backup.</summary>
+    public TimeSpan? SinceFullBackup { get; set; }
+
+    /// <summary>Elapsed time since the most recent differential backup.</summary>
+    public TimeSpan? SinceDifferentialBackup { get; set; }
+
+    /// <summary>Elapsed time since the most recent log backup.</summary>
+    public TimeSpan? SinceLogBackup { get; set; }
+
+    /// <summary>True when the database uses full or bulk-logged recovery and should normally have log backups.</summary>
+    public bool RequiresLogBackups { get; set; }
+
+    /// <summary>Provider-level status computed from configured thresholds.</summary>
+    public string Status { get; set; } = "Unknown";
+}

--- a/DbaClientX.SqlServer/Monitoring/SqlServerCheckDbFreshness.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerCheckDbFreshness.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace DBAClientX.SqlServerMonitoring;
+
+/// <summary>
+/// Last known good DBCC CHECKDB information for one database.
+/// </summary>
+public sealed class SqlServerCheckDbFreshness
+{
+    /// <summary>Database name.</summary>
+    public string DatabaseName { get; set; } = string.Empty;
+
+    /// <summary>Database creation timestamp.</summary>
+    public DateTime? DatabaseCreated { get; set; }
+
+    /// <summary>Last known good CHECKDB timestamp when it could be collected.</summary>
+    public DateTime? LastGoodCheckDb { get; set; }
+
+    /// <summary>Elapsed time since the last known good CHECKDB.</summary>
+    public TimeSpan? SinceLastGoodCheckDb { get; set; }
+
+    /// <summary>Provider-level status computed from configured thresholds.</summary>
+    public string Status { get; set; } = "Unknown";
+
+    /// <summary>Error message for this database when CHECKDB metadata could not be collected.</summary>
+    public string? ErrorMessage { get; set; }
+}

--- a/DbaClientX.SqlServer/Monitoring/SqlServerConnectionDiagnostics.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerConnectionDiagnostics.cs
@@ -1,0 +1,81 @@
+using System;
+
+namespace DBAClientX.SqlServerMonitoring;
+
+/// <summary>
+/// Connection-level SQL Server diagnostics collected from a live SQL session.
+/// </summary>
+public sealed class SqlServerConnectionDiagnostics
+{
+    /// <summary>SQL target originally requested by the caller.</summary>
+    public string Target { get; set; } = string.Empty;
+
+    /// <summary>True when the SQL connection opened successfully.</summary>
+    public bool Connected { get; set; }
+
+    /// <summary>True when the lightweight query phase completed successfully.</summary>
+    public bool QuerySucceeded { get; set; }
+
+    /// <summary>UTC timestamp when the diagnostic finished.</summary>
+    public DateTimeOffset CompletedUtc { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>Elapsed time spent opening the SQL connection.</summary>
+    public TimeSpan? ConnectDuration { get; set; }
+
+    /// <summary>Elapsed time spent executing the lightweight diagnostic query.</summary>
+    public TimeSpan? QueryDuration { get; set; }
+
+    /// <summary>SQL Server machine name reported by <c>SERVERPROPERTY</c>.</summary>
+    public string? MachineName { get; set; }
+
+    /// <summary>SQL Server name reported by <c>SERVERPROPERTY</c>.</summary>
+    public string? ServerName { get; set; }
+
+    /// <summary>SQL instance name, or null for the default instance.</summary>
+    public string? InstanceName { get; set; }
+
+    /// <summary>Product version reported by SQL Server.</summary>
+    public string? ProductVersion { get; set; }
+
+    /// <summary>Product level reported by SQL Server.</summary>
+    public string? ProductLevel { get; set; }
+
+    /// <summary>Edition reported by SQL Server.</summary>
+    public string? Edition { get; set; }
+
+    /// <summary>Engine edition numeric value reported by SQL Server.</summary>
+    public int? EngineEdition { get; set; }
+
+    /// <summary>Original login used by the session.</summary>
+    public string? OriginalLogin { get; set; }
+
+    /// <summary>Effective login used by the session.</summary>
+    public string? EffectiveLogin { get; set; }
+
+    /// <summary>SQL session id used for the diagnostic query.</summary>
+    public int? SessionId { get; set; }
+
+    /// <summary>Local SQL Server network address for the session.</summary>
+    public string? LocalNetAddress { get; set; }
+
+    /// <summary>Local SQL Server TCP port for the session.</summary>
+    public int? LocalTcpPort { get; set; }
+
+    /// <summary>Client network address observed by SQL Server.</summary>
+    public string? ClientNetAddress { get; set; }
+
+    /// <summary>Connection authentication scheme such as KERBEROS, NTLM, or SQL.</summary>
+    public string? AuthScheme { get; set; }
+
+    /// <summary>SQL Server encryption option reported for the connection.</summary>
+    public string? EncryptOption { get; set; }
+
+    /// <summary>Protocol reported by SQL Server for the connection.</summary>
+    public string? ProtocolType { get; set; }
+
+    /// <summary>Normalized error category for failed diagnostics.</summary>
+    public string? ErrorCategory { get; set; }
+
+    /// <summary>Human-readable error message for failed diagnostics.</summary>
+    public string? ErrorMessage { get; set; }
+}

--- a/DbaClientX.SqlServer/Monitoring/SqlServerDatabaseState.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerDatabaseState.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace DBAClientX.SqlServerMonitoring;
+
+/// <summary>
+/// Database state and accessibility information from <c>sys.databases</c>.
+/// </summary>
+public sealed class SqlServerDatabaseState
+{
+    /// <summary>Database name.</summary>
+    public string DatabaseName { get; set; } = string.Empty;
+
+    /// <summary>Database state such as ONLINE, RESTORING, or SUSPECT.</summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>User access mode such as MULTI_USER or SINGLE_USER.</summary>
+    public string Access { get; set; } = string.Empty;
+
+    /// <summary>Read/write state such as READ_WRITE or READ_ONLY.</summary>
+    public string ReadWrite { get; set; } = string.Empty;
+
+    /// <summary>Database recovery model.</summary>
+    public string RecoveryModel { get; set; } = string.Empty;
+
+    /// <summary>True when the database is a system database.</summary>
+    public bool IsSystemDatabase { get; set; }
+
+    /// <summary>UTC or server-local creation timestamp reported by SQL Server.</summary>
+    public DateTime? CreateDate { get; set; }
+
+    /// <summary>True when the database state is generally healthy for normal monitoring.</summary>
+    public bool IsHealthy => string.Equals(Status, "ONLINE", StringComparison.OrdinalIgnoreCase) &&
+                             string.Equals(Access, "MULTI_USER", StringComparison.OrdinalIgnoreCase);
+}

--- a/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringMappers.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringMappers.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Data;
+
+namespace DBAClientX.SqlServerMonitoring;
+
+internal static class SqlServerMonitoringMappers
+{
+    public static void PopulateConnectionDiagnostics(IDataRecord record, SqlServerConnectionDiagnostics diagnostic)
+    {
+        diagnostic.MachineName = GetString(record, "MachineName");
+        diagnostic.ServerName = GetString(record, "ServerName");
+        diagnostic.InstanceName = GetString(record, "InstanceName");
+        diagnostic.ProductVersion = GetString(record, "ProductVersion");
+        diagnostic.ProductLevel = GetString(record, "ProductLevel");
+        diagnostic.Edition = GetString(record, "Edition");
+        diagnostic.EngineEdition = GetInt32(record, "EngineEdition");
+        diagnostic.OriginalLogin = GetString(record, "OriginalLogin");
+        diagnostic.EffectiveLogin = GetString(record, "EffectiveLogin");
+        diagnostic.SessionId = GetInt32(record, "SessionId");
+        diagnostic.LocalNetAddress = GetString(record, "LocalNetAddress");
+        diagnostic.LocalTcpPort = GetInt32(record, "LocalTcpPort");
+        diagnostic.ClientNetAddress = GetString(record, "ClientNetAddress");
+        diagnostic.AuthScheme = GetString(record, "AuthScheme");
+        diagnostic.EncryptOption = GetString(record, "EncryptOption");
+        diagnostic.ProtocolType = GetString(record, "ProtocolType");
+    }
+
+    public static SqlServerDatabaseState MapDatabaseState(IDataRecord record)
+    {
+        return new SqlServerDatabaseState
+        {
+            DatabaseName = GetString(record, "DatabaseName") ?? string.Empty,
+            Status = GetString(record, "Status") ?? string.Empty,
+            Access = GetString(record, "AccessMode") ?? string.Empty,
+            ReadWrite = GetString(record, "ReadWrite") ?? string.Empty,
+            RecoveryModel = GetString(record, "RecoveryModel") ?? string.Empty,
+            IsSystemDatabase = GetBoolean(record, "IsSystemDatabase"),
+            CreateDate = GetDateTime(record, "CreateDate")
+        };
+    }
+
+    public static SqlServerBackupFreshness MapBackupFreshness(IDataRecord record, SqlServerMonitoringOptions options)
+    {
+        var item = new SqlServerBackupFreshness
+        {
+            DatabaseName = GetString(record, "DatabaseName") ?? string.Empty,
+            RecoveryModel = GetString(record, "RecoveryModel") ?? string.Empty,
+            DatabaseCreated = GetDateTime(record, "DatabaseCreated"),
+            LastFullBackup = GetDateTime(record, "LastFullBackup"),
+            LastDifferentialBackup = GetDateTime(record, "LastDifferentialBackup"),
+            LastLogBackup = GetDateTime(record, "LastLogBackup")
+        };
+        DateTime now = DateTime.UtcNow;
+        item.SinceFullBackup = SinceUtc(now, item.LastFullBackup);
+        item.SinceDifferentialBackup = SinceUtc(now, item.LastDifferentialBackup);
+        item.SinceLogBackup = SinceUtc(now, item.LastLogBackup);
+        item.RequiresLogBackups = string.Equals(item.RecoveryModel, "FULL", StringComparison.OrdinalIgnoreCase) ||
+                                  string.Equals(item.RecoveryModel, "BULK_LOGGED", StringComparison.OrdinalIgnoreCase);
+        item.Status = EvaluateBackupStatus(item, options);
+        return item;
+    }
+
+    public static SqlServerAgentJobHealth MapAgentJobHealth(IDataRecord record)
+    {
+        return new SqlServerAgentJobHealth
+        {
+            JobId = GetGuid(record, "JobId") ?? Guid.Empty,
+            Name = GetString(record, "Name") ?? string.Empty,
+            Category = GetString(record, "Category"),
+            OwnerLoginName = GetString(record, "OwnerLoginName"),
+            Enabled = GetBoolean(record, "Enabled"),
+            IsRunning = GetBoolean(record, "IsRunning"),
+            CurrentStartDate = GetDateTime(record, "CurrentStartDate"),
+            LastRunDate = GetDateTime(record, "LastRunDate"),
+            LastRunOutcome = GetString(record, "LastRunOutcome"),
+            LastRunDuration = ParseAgentDuration(GetInt32(record, "LastRunDuration"))
+        };
+    }
+
+    public static SqlServerWaitStatistic MapWaitStatistic(IDataRecord record)
+    {
+        return new SqlServerWaitStatistic
+        {
+            WaitType = GetString(record, "WaitType") ?? string.Empty,
+            WaitSeconds = GetDecimal(record, "WaitSeconds"),
+            ResourceSeconds = GetDecimal(record, "ResourceSeconds"),
+            SignalSeconds = GetDecimal(record, "SignalSeconds"),
+            WaitCount = GetInt64(record, "WaitCount"),
+            Percentage = GetDecimal(record, "Percentage"),
+            AverageWaitSeconds = GetDecimal(record, "AverageWaitSeconds")
+        };
+    }
+
+    public static SqlServerAvailabilityGroupHealth MapAvailabilityGroupHealth(IDataRecord record)
+    {
+        return new SqlServerAvailabilityGroupHealth
+        {
+            AvailabilityGroupName = GetString(record, "AvailabilityGroupName") ?? string.Empty,
+            ReplicaServerName = GetString(record, "ReplicaServerName") ?? string.Empty,
+            Role = GetString(record, "Role"),
+            OperationalState = GetString(record, "OperationalState"),
+            ConnectedState = GetString(record, "ConnectedState"),
+            SynchronizationHealth = GetString(record, "SynchronizationHealth"),
+            DatabaseName = GetString(record, "DatabaseName"),
+            DatabaseSynchronizationState = GetString(record, "DatabaseSynchronizationState"),
+            DatabaseSynchronizationHealth = GetString(record, "DatabaseSynchronizationHealth"),
+            IsSuspended = GetBoolean(record, "IsSuspended"),
+            SuspendReason = GetString(record, "SuspendReason")
+        };
+    }
+
+    public static string EvaluateCheckDbStatus(SqlServerCheckDbFreshness item, SqlServerMonitoringOptions options)
+    {
+        if (!string.IsNullOrWhiteSpace(item.ErrorMessage))
+        {
+            return "Unknown";
+        }
+
+        if (!item.LastGoodCheckDb.HasValue)
+        {
+            return item.DatabaseCreated.HasValue && DateTime.UtcNow - item.DatabaseCreated.Value.ToUniversalTime() <= options.MaxCheckDbAge
+                ? "New"
+                : "Missing";
+        }
+
+        return item.SinceLastGoodCheckDb.HasValue && item.SinceLastGoodCheckDb.Value > options.MaxCheckDbAge
+            ? "Overdue"
+            : "Ok";
+    }
+
+    public static string? GetString(IDataRecord record, string name)
+    {
+        int ordinal = record.GetOrdinal(name);
+        return record.IsDBNull(ordinal) ? null : Convert.ToString(record.GetValue(ordinal));
+    }
+
+    public static DateTime? GetDateTime(IDataRecord record, string name)
+    {
+        int ordinal = record.GetOrdinal(name);
+        if (record.IsDBNull(ordinal)) return null;
+        object value = record.GetValue(ordinal);
+        if (value is DateTime dt) return dt;
+        return DateTime.TryParse(Convert.ToString(value), out DateTime parsed) ? parsed : null;
+    }
+
+    private static string EvaluateBackupStatus(SqlServerBackupFreshness item, SqlServerMonitoringOptions options)
+    {
+        if (!item.LastFullBackup.HasValue)
+        {
+            return item.DatabaseCreated.HasValue && DateTime.UtcNow - item.DatabaseCreated.Value.ToUniversalTime() <= options.MaxFullBackupAge
+                ? "New"
+                : "MissingFull";
+        }
+
+        if (item.SinceFullBackup.HasValue && item.SinceFullBackup.Value > options.MaxFullBackupAge)
+        {
+            return "FullOverdue";
+        }
+
+        if (item.RequiresLogBackups && (!item.SinceLogBackup.HasValue || item.SinceLogBackup.Value > options.MaxLogBackupAge))
+        {
+            return "LogOverdue";
+        }
+
+        if (item.SinceDifferentialBackup.HasValue && item.SinceDifferentialBackup.Value > options.MaxDifferentialBackupAge)
+        {
+            return "DifferentialOld";
+        }
+
+        return "Ok";
+    }
+
+    private static TimeSpan? SinceUtc(DateTime nowUtc, DateTime? value)
+    {
+        return value.HasValue ? nowUtc - value.Value.ToUniversalTime() : null;
+    }
+
+    private static int? GetInt32(IDataRecord record, string name)
+    {
+        int ordinal = record.GetOrdinal(name);
+        return record.IsDBNull(ordinal) ? null : Convert.ToInt32(record.GetValue(ordinal));
+    }
+
+    private static long GetInt64(IDataRecord record, string name)
+    {
+        int ordinal = record.GetOrdinal(name);
+        return record.IsDBNull(ordinal) ? 0L : Convert.ToInt64(record.GetValue(ordinal));
+    }
+
+    private static decimal GetDecimal(IDataRecord record, string name)
+    {
+        int ordinal = record.GetOrdinal(name);
+        return record.IsDBNull(ordinal) ? 0m : Convert.ToDecimal(record.GetValue(ordinal));
+    }
+
+    private static bool GetBoolean(IDataRecord record, string name)
+    {
+        int ordinal = record.GetOrdinal(name);
+        return !record.IsDBNull(ordinal) && Convert.ToBoolean(record.GetValue(ordinal));
+    }
+
+    private static Guid? GetGuid(IDataRecord record, string name)
+    {
+        int ordinal = record.GetOrdinal(name);
+        if (record.IsDBNull(ordinal)) return null;
+        object value = record.GetValue(ordinal);
+        if (value is Guid guid) return guid;
+        return Guid.TryParse(Convert.ToString(value), out Guid parsed) ? parsed : null;
+    }
+
+    private static TimeSpan? ParseAgentDuration(int? value)
+    {
+        if (!value.HasValue) return null;
+        int raw = value.Value;
+        int seconds = raw % 100;
+        int minutes = (raw / 100) % 100;
+        int hours = raw / 10000;
+        return new TimeSpan(hours, minutes, seconds);
+    }
+}

--- a/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringMappers.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringMappers.cs
@@ -118,7 +118,7 @@ internal static class SqlServerMonitoringMappers
 
         if (!item.LastGoodCheckDb.HasValue)
         {
-            return item.DatabaseCreated.HasValue && DateTime.UtcNow - item.DatabaseCreated.Value.ToUniversalTime() <= options.MaxCheckDbAge
+            return item.DatabaseCreated.HasValue && DateTime.UtcNow - NormalizeSqlDateTimeUtc(item.DatabaseCreated.Value) <= options.MaxCheckDbAge
                 ? "New"
                 : "Missing";
         }
@@ -147,7 +147,7 @@ internal static class SqlServerMonitoringMappers
     {
         if (!item.LastFullBackup.HasValue)
         {
-            return item.DatabaseCreated.HasValue && DateTime.UtcNow - item.DatabaseCreated.Value.ToUniversalTime() <= options.MaxFullBackupAge
+            return item.DatabaseCreated.HasValue && DateTime.UtcNow - NormalizeSqlDateTimeUtc(item.DatabaseCreated.Value) <= options.MaxFullBackupAge
                 ? "New"
                 : "MissingFull";
         }
@@ -172,7 +172,17 @@ internal static class SqlServerMonitoringMappers
 
     private static TimeSpan? SinceUtc(DateTime nowUtc, DateTime? value)
     {
-        return value.HasValue ? nowUtc - value.Value.ToUniversalTime() : null;
+        return value.HasValue ? nowUtc - NormalizeSqlDateTimeUtc(value.Value) : null;
+    }
+
+    internal static DateTime NormalizeSqlDateTimeUtc(DateTime value)
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
     }
 
     private static int? GetInt32(IDataRecord record, string name)

--- a/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringOptions.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringOptions.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace DBAClientX.SqlServerMonitoring;
+
+/// <summary>
+/// Controls how SQL Server monitoring data is collected and evaluated by the provider.
+/// </summary>
+public sealed class SqlServerMonitoringOptions
+{
+    /// <summary>Monitoring areas to collect.</summary>
+    public SqlServerMonitoringScope Scope { get; set; } = SqlServerMonitoringScope.Baseline;
+
+    /// <summary>Maximum age for full database backups before consumers should consider them overdue.</summary>
+    public TimeSpan MaxFullBackupAge { get; set; } = TimeSpan.FromDays(1);
+
+    /// <summary>Maximum age for differential backups before consumers should consider them overdue.</summary>
+    public TimeSpan MaxDifferentialBackupAge { get; set; } = TimeSpan.FromDays(1);
+
+    /// <summary>Maximum age for log backups on full or bulk-logged recovery databases.</summary>
+    public TimeSpan MaxLogBackupAge { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>Maximum age for last known good CHECKDB before consumers should consider it overdue.</summary>
+    public TimeSpan MaxCheckDbAge { get; set; } = TimeSpan.FromDays(7);
+
+    /// <summary>When true, system databases are included in database-level collectors.</summary>
+    public bool IncludeSystemDatabases { get; set; }
+
+    /// <summary>When true, disabled SQL Agent jobs are included in job health output.</summary>
+    public bool IncludeDisabledAgentJobs { get; set; }
+
+    /// <summary>Maximum cumulative wait percentage to include in wait-stat output.</summary>
+    public decimal WaitStatisticThresholdPercent { get; set; } = 95m;
+
+    /// <summary>Returns true when the requested scope includes the supplied flag.</summary>
+    /// <param name="scope">Scope flag to test.</param>
+    /// <returns><see langword="true"/> when <see cref="Scope"/> contains <paramref name="scope"/>.</returns>
+    public bool Includes(SqlServerMonitoringScope scope) => (Scope & scope) == scope;
+}

--- a/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringScope.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringScope.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace DBAClientX.SqlServerMonitoring;
+
+/// <summary>
+/// SQL Server monitoring areas that can be collected for a target instance.
+/// </summary>
+[Flags]
+public enum SqlServerMonitoringScope
+{
+    /// <summary>No monitoring data beyond connectivity should be collected.</summary>
+    None = 0,
+
+    /// <summary>Collect connection, server identity, TCP, encryption, and authentication diagnostics.</summary>
+    Connectivity = 1 << 0,
+
+    /// <summary>Collect user database state, access mode, recovery model, and read/write state.</summary>
+    DatabaseState = 1 << 1,
+
+    /// <summary>Collect backup freshness from <c>msdb</c> backup history.</summary>
+    BackupFreshness = 1 << 2,
+
+    /// <summary>Collect last known good DBCC CHECKDB timestamps where permissions allow it.</summary>
+    CheckDbFreshness = 1 << 3,
+
+    /// <summary>Collect SQL Server Agent job state and recent outcome information.</summary>
+    AgentJobs = 1 << 4,
+
+    /// <summary>Collect wait statistics for performance diagnostics.</summary>
+    WaitStatistics = 1 << 5,
+
+    /// <summary>Collect Availability Group replica and database synchronization health.</summary>
+    AvailabilityGroups = 1 << 6,
+
+    /// <summary>Recommended baseline monitoring for continuous health checks.</summary>
+    Baseline = Connectivity | DatabaseState | BackupFreshness | CheckDbFreshness | AgentJobs,
+
+    /// <summary>All monitoring areas currently implemented by this provider.</summary>
+    All = Baseline | WaitStatistics | AvailabilityGroups
+}

--- a/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringSnapshot.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringSnapshot.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace DBAClientX.SqlServerMonitoring;
+
+/// <summary>
+/// Aggregated SQL Server monitoring snapshot collected for one target.
+/// </summary>
+public sealed class SqlServerMonitoringSnapshot
+{
+    /// <summary>Requested SQL Server target.</summary>
+    public string Target { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp when collection finished.</summary>
+    public DateTimeOffset CompletedUtc { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>Scopes requested for this snapshot.</summary>
+    public SqlServerMonitoringScope RequestedScope { get; set; }
+
+    /// <summary>Connection diagnostics. This is always populated when connectivity was requested.</summary>
+    public SqlServerConnectionDiagnostics? Connectivity { get; set; }
+
+    /// <summary>Database state rows.</summary>
+    public List<SqlServerDatabaseState> Databases { get; set; } = new();
+
+    /// <summary>Backup freshness rows.</summary>
+    public List<SqlServerBackupFreshness> Backups { get; set; } = new();
+
+    /// <summary>CHECKDB freshness rows.</summary>
+    public List<SqlServerCheckDbFreshness> CheckDb { get; set; } = new();
+
+    /// <summary>SQL Agent job health rows.</summary>
+    public List<SqlServerAgentJobHealth> AgentJobs { get; set; } = new();
+
+    /// <summary>SQL wait statistic rows.</summary>
+    public List<SqlServerWaitStatistic> WaitStatistics { get; set; } = new();
+
+    /// <summary>Availability Group health rows.</summary>
+    public List<SqlServerAvailabilityGroupHealth> AvailabilityGroups { get; set; } = new();
+
+    /// <summary>Collector errors for optional sections that could not be read.</summary>
+    public List<string> Errors { get; set; } = new();
+}

--- a/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringTarget.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerMonitoringTarget.cs
@@ -1,0 +1,34 @@
+namespace DBAClientX.SqlServerMonitoring;
+
+/// <summary>
+/// Describes a SQL Server instance and authentication settings used by monitoring collectors.
+/// </summary>
+public sealed class SqlServerMonitoringTarget
+{
+    /// <summary>Server name, address, or <c>Server\Instance</c> identifier.</summary>
+    public string ServerOrInstance { get; set; } = string.Empty;
+
+    /// <summary>Database used for connection-level checks.</summary>
+    public string Database { get; set; } = "master";
+
+    /// <summary>When true, uses Windows authentication.</summary>
+    public bool IntegratedSecurity { get; set; } = true;
+
+    /// <summary>SQL login name when <see cref="IntegratedSecurity"/> is false.</summary>
+    public string? Username { get; set; }
+
+    /// <summary>SQL login password when <see cref="IntegratedSecurity"/> is false.</summary>
+    public string? Password { get; set; }
+
+    /// <summary>Optional TCP port to append to the server address.</summary>
+    public int? Port { get; set; }
+
+    /// <summary>Trusts the server certificate while still requiring encrypted SQL connections.</summary>
+    public bool TrustServerCertificate { get; set; }
+
+    /// <summary>Optional connection timeout in seconds.</summary>
+    public int? ConnectTimeoutSeconds { get; set; }
+
+    /// <summary>Application name placed in the SQL connection string for observability.</summary>
+    public string? ApplicationName { get; set; } = "DbaClientX.Monitoring";
+}

--- a/DbaClientX.SqlServer/Monitoring/SqlServerWaitStatistic.cs
+++ b/DbaClientX.SqlServer/Monitoring/SqlServerWaitStatistic.cs
@@ -1,0 +1,28 @@
+namespace DBAClientX.SqlServerMonitoring;
+
+/// <summary>
+/// SQL Server wait statistic row collected from <c>sys.dm_os_wait_stats</c>.
+/// </summary>
+public sealed class SqlServerWaitStatistic
+{
+    /// <summary>Wait type name.</summary>
+    public string WaitType { get; set; } = string.Empty;
+
+    /// <summary>Total wait time in seconds.</summary>
+    public decimal WaitSeconds { get; set; }
+
+    /// <summary>Resource wait time in seconds.</summary>
+    public decimal ResourceSeconds { get; set; }
+
+    /// <summary>Signal wait time in seconds.</summary>
+    public decimal SignalSeconds { get; set; }
+
+    /// <summary>Total wait count.</summary>
+    public long WaitCount { get; set; }
+
+    /// <summary>Percentage of total non-ignored wait time represented by this wait.</summary>
+    public decimal Percentage { get; set; }
+
+    /// <summary>Average wait time in seconds.</summary>
+    public decimal AverageWaitSeconds { get; set; }
+}

--- a/DbaClientX.SqlServer/SqlServer.Monitoring.Queries.cs
+++ b/DbaClientX.SqlServer/SqlServer.Monitoring.Queries.cs
@@ -74,6 +74,11 @@ WITH last_history AS
     FROM msdb.dbo.sysjobhistory AS h
     WHERE h.step_id = 0
 ),
+current_agent_session AS
+(
+    SELECT session_id = MAX(s.session_id)
+    FROM msdb.dbo.syssessions AS s
+),
 active_jobs AS
 (
     SELECT
@@ -82,6 +87,7 @@ active_jobs AS
         ja.stop_execution_date,
         rn = ROW_NUMBER() OVER (PARTITION BY ja.job_id ORDER BY ja.start_execution_date DESC)
     FROM msdb.dbo.sysjobactivity AS ja
+    INNER JOIN current_agent_session AS s ON s.session_id = ja.session_id
     WHERE ja.start_execution_date IS NOT NULL
 )
 SELECT

--- a/DbaClientX.SqlServer/SqlServer.Monitoring.Queries.cs
+++ b/DbaClientX.SqlServer/SqlServer.Monitoring.Queries.cs
@@ -1,0 +1,181 @@
+namespace DBAClientX;
+
+public partial class SqlServer
+{
+    private const string ConnectionDiagnosticsQuery = @"
+SELECT
+    MachineName = CONVERT(nvarchar(128), SERVERPROPERTY('MachineName')),
+    ServerName = CONVERT(nvarchar(256), SERVERPROPERTY('ServerName')),
+    InstanceName = CONVERT(nvarchar(128), SERVERPROPERTY('InstanceName')),
+    ProductVersion = CONVERT(nvarchar(128), SERVERPROPERTY('ProductVersion')),
+    ProductLevel = CONVERT(nvarchar(128), SERVERPROPERTY('ProductLevel')),
+    Edition = CONVERT(nvarchar(256), SERVERPROPERTY('Edition')),
+    EngineEdition = TRY_CONVERT(int, SERVERPROPERTY('EngineEdition')),
+    OriginalLogin = ORIGINAL_LOGIN(),
+    EffectiveLogin = SUSER_SNAME(),
+    SessionId = @@SPID,
+    LocalNetAddress = c.local_net_address,
+    LocalTcpPort = c.local_tcp_port,
+    ClientNetAddress = c.client_net_address,
+    AuthScheme = c.auth_scheme,
+    EncryptOption = c.encrypt_option,
+    ProtocolType = c.protocol_type
+FROM sys.dm_exec_connections AS c
+WHERE c.session_id = @@SPID;";
+
+    private const string DatabaseStateQuery = @"
+SELECT
+    DatabaseName = d.name,
+    Status = d.state_desc,
+    AccessMode = d.user_access_desc,
+    ReadWrite = CASE WHEN d.is_read_only = 1 THEN N'READ_ONLY' ELSE N'READ_WRITE' END,
+    RecoveryModel = d.recovery_model_desc,
+    IsSystemDatabase = CASE WHEN d.name IN (N'master', N'model', N'msdb', N'tempdb', N'distribution') THEN 1 ELSE 0 END,
+    CreateDate = d.create_date
+FROM sys.databases AS d
+WHERE @includeFilteredRows = 1
+   OR d.name NOT IN (N'master', N'model', N'msdb', N'tempdb', N'distribution')
+ORDER BY d.name;";
+
+    private const string BackupFreshnessQuery = @"
+WITH last_backup AS
+(
+    SELECT
+        bs.database_name,
+        LastFullBackup = MAX(CASE WHEN bs.type = 'D' THEN bs.backup_finish_date END),
+        LastDifferentialBackup = MAX(CASE WHEN bs.type = 'I' THEN bs.backup_finish_date END),
+        LastLogBackup = MAX(CASE WHEN bs.type = 'L' THEN bs.backup_finish_date END)
+    FROM msdb.dbo.backupset AS bs
+    GROUP BY bs.database_name
+)
+SELECT
+    DatabaseName = d.name,
+    RecoveryModel = d.recovery_model_desc,
+    DatabaseCreated = d.create_date,
+    lb.LastFullBackup,
+    lb.LastDifferentialBackup,
+    lb.LastLogBackup
+FROM sys.databases AS d
+LEFT JOIN last_backup AS lb ON lb.database_name = d.name
+WHERE @includeFilteredRows = 1
+   OR d.name NOT IN (N'master', N'model', N'msdb', N'tempdb', N'distribution')
+ORDER BY d.name;";
+
+    private const string AgentJobsQuery = @"
+WITH last_history AS
+(
+    SELECT
+        h.job_id,
+        h.run_status,
+        h.run_date,
+        h.run_time,
+        h.run_duration,
+        rn = ROW_NUMBER() OVER (PARTITION BY h.job_id ORDER BY h.instance_id DESC)
+    FROM msdb.dbo.sysjobhistory AS h
+    WHERE h.step_id = 0
+),
+active_jobs AS
+(
+    SELECT
+        ja.job_id,
+        ja.start_execution_date,
+        ja.stop_execution_date,
+        rn = ROW_NUMBER() OVER (PARTITION BY ja.job_id ORDER BY ja.start_execution_date DESC)
+    FROM msdb.dbo.sysjobactivity AS ja
+    WHERE ja.start_execution_date IS NOT NULL
+)
+SELECT
+    JobId = j.job_id,
+    Name = j.name,
+    Category = c.name,
+    OwnerLoginName = SUSER_SNAME(j.owner_sid),
+    Enabled = CONVERT(bit, j.enabled),
+    IsRunning = CONVERT(bit, CASE WHEN a.start_execution_date IS NOT NULL AND a.stop_execution_date IS NULL THEN 1 ELSE 0 END),
+    CurrentStartDate = CASE WHEN a.start_execution_date IS NOT NULL AND a.stop_execution_date IS NULL THEN a.start_execution_date ELSE NULL END,
+    LastRunDate = msdb.dbo.agent_datetime(h.run_date, h.run_time),
+    LastRunOutcome = CASE h.run_status
+        WHEN 0 THEN N'Failed'
+        WHEN 1 THEN N'Succeeded'
+        WHEN 2 THEN N'Retry'
+        WHEN 3 THEN N'Cancelled'
+        WHEN 4 THEN N'InProgress'
+        ELSE NULL
+    END,
+    LastRunDuration = h.run_duration
+FROM msdb.dbo.sysjobs AS j
+LEFT JOIN msdb.dbo.syscategories AS c ON c.category_id = j.category_id
+LEFT JOIN last_history AS h ON h.job_id = j.job_id AND h.rn = 1
+LEFT JOIN active_jobs AS a ON a.job_id = j.job_id AND a.rn = 1
+WHERE @includeFilteredRows = 1 OR j.enabled = 1
+ORDER BY j.name;";
+
+    private const string WaitStatisticsQuery = @"
+WITH waits AS
+(
+    SELECT
+        wait_type,
+        wait_time_ms,
+        signal_wait_time_ms,
+        waiting_tasks_count
+    FROM sys.dm_os_wait_stats
+    WHERE wait_time_ms > 0
+      AND wait_type NOT LIKE N'SLEEP%'
+      AND wait_type NOT IN
+      (
+          N'BROKER_EVENTHANDLER', N'BROKER_RECEIVE_WAITFOR', N'BROKER_TASK_STOP',
+          N'BROKER_TO_FLUSH', N'BROKER_TRANSMITTER', N'CHECKPOINT_QUEUE',
+          N'CLR_AUTO_EVENT', N'CLR_MANUAL_EVENT', N'CLR_SEMAPHORE',
+          N'DBMIRROR_DBM_EVENT', N'DBMIRROR_EVENTS_QUEUE', N'DBMIRROR_WORKER_QUEUE',
+          N'FT_IFTS_SCHEDULER_IDLE_WAIT', N'HADR_FILESTREAM_IOMGR_IOCOMPLETION',
+          N'LAZYWRITER_SLEEP', N'LOGMGR_QUEUE', N'ONDEMAND_TASK_QUEUE',
+          N'QDS_PERSIST_TASK_MAIN_LOOP_SLEEP', N'REQUEST_FOR_DEADLOCK_SEARCH',
+          N'RESOURCE_QUEUE', N'SERVER_IDLE_CHECK', N'SP_SERVER_DIAGNOSTICS_SLEEP',
+          N'SQLTRACE_BUFFER_FLUSH', N'SQLTRACE_INCREMENTAL_FLUSH_SLEEP',
+          N'WAITFOR', N'XE_DISPATCHER_WAIT', N'XE_TIMER_EVENT'
+      )
+),
+ranked AS
+(
+    SELECT
+        wait_type,
+        wait_time_ms,
+        signal_wait_time_ms,
+        waiting_tasks_count,
+        pct = CONVERT(decimal(18, 4), 100.0 * wait_time_ms / NULLIF(SUM(wait_time_ms) OVER (), 0)),
+        running_pct = CONVERT(decimal(18, 4), 100.0 * SUM(wait_time_ms) OVER (ORDER BY wait_time_ms DESC ROWS UNBOUNDED PRECEDING) / NULLIF(SUM(wait_time_ms) OVER (), 0))
+    FROM waits
+)
+SELECT
+    WaitType = wait_type,
+    WaitSeconds = CONVERT(decimal(18, 4), wait_time_ms / 1000.0),
+    ResourceSeconds = CONVERT(decimal(18, 4), (wait_time_ms - signal_wait_time_ms) / 1000.0),
+    SignalSeconds = CONVERT(decimal(18, 4), signal_wait_time_ms / 1000.0),
+    WaitCount = waiting_tasks_count,
+    Percentage = pct,
+    AverageWaitSeconds = CONVERT(decimal(18, 6), wait_time_ms / 1000.0 / NULLIF(waiting_tasks_count, 0))
+FROM ranked
+WHERE running_pct <= @threshold OR pct >= 1.0
+ORDER BY WaitSeconds DESC;";
+
+    private const string AvailabilityGroupsQuery = @"
+IF CONVERT(int, SERVERPROPERTY('IsHadrEnabled')) = 1
+BEGIN
+    SELECT
+        AvailabilityGroupName = ag.name,
+        ReplicaServerName = ar.replica_server_name,
+        Role = ars.role_desc,
+        OperationalState = ars.operational_state_desc,
+        ConnectedState = ars.connected_state_desc,
+        SynchronizationHealth = ars.synchronization_health_desc,
+        DatabaseName = DB_NAME(drs.database_id),
+        DatabaseSynchronizationState = drs.synchronization_state_desc,
+        DatabaseSynchronizationHealth = drs.synchronization_health_desc,
+        IsSuspended = CONVERT(bit, ISNULL(drs.is_suspended, 0)),
+        SuspendReason = drs.suspend_reason_desc
+    FROM sys.availability_groups AS ag
+    INNER JOIN sys.availability_replicas AS ar ON ag.group_id = ar.group_id
+    LEFT JOIN sys.dm_hadr_availability_replica_states AS ars ON ar.replica_id = ars.replica_id
+    LEFT JOIN sys.dm_hadr_database_replica_states AS drs ON ar.replica_id = drs.replica_id
+    ORDER BY ag.name, ar.replica_server_name, DatabaseName;
+END;";
+}

--- a/DbaClientX.SqlServer/SqlServer.Monitoring.cs
+++ b/DbaClientX.SqlServer/SqlServer.Monitoring.cs
@@ -1,0 +1,360 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using DBAClientX.SqlServerMonitoring;
+using Microsoft.Data.SqlClient;
+
+namespace DBAClientX;
+
+public partial class SqlServer
+{
+    /// <summary>
+    /// Collects a SQL Server monitoring snapshot for the supplied target.
+    /// </summary>
+    /// <param name="target">SQL Server target and authentication settings.</param>
+    /// <param name="options">Collection options. Defaults to <see cref="SqlServerMonitoringScope.Baseline"/>.</param>
+    /// <param name="cancellationToken">Token used to cancel SQL calls.</param>
+    /// <returns>A typed monitoring snapshot containing the requested sections.</returns>
+    public virtual async Task<SqlServerMonitoringSnapshot> GetMonitoringSnapshotAsync(
+        SqlServerMonitoringTarget target,
+        SqlServerMonitoringOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateMonitoringTarget(target);
+        options ??= new SqlServerMonitoringOptions();
+
+        var snapshot = new SqlServerMonitoringSnapshot
+        {
+            Target = target.ServerOrInstance,
+            RequestedScope = options.Scope
+        };
+
+        if (options.Includes(SqlServerMonitoringScope.Connectivity))
+        {
+            snapshot.Connectivity = await GetConnectionDiagnosticsAsync(target, cancellationToken).ConfigureAwait(false);
+            if (snapshot.Connectivity.Connected == false)
+            {
+                snapshot.CompletedUtc = DateTimeOffset.UtcNow;
+                return snapshot;
+            }
+        }
+
+        if (options.Includes(SqlServerMonitoringScope.DatabaseState))
+        {
+            await AddSectionAsync(snapshot.Errors, "database state", async () =>
+                snapshot.Databases.AddRange(await GetDatabaseStatesAsync(target, options.IncludeSystemDatabases, cancellationToken).ConfigureAwait(false))).ConfigureAwait(false);
+        }
+
+        if (options.Includes(SqlServerMonitoringScope.BackupFreshness))
+        {
+            await AddSectionAsync(snapshot.Errors, "backup freshness", async () =>
+                snapshot.Backups.AddRange(await GetBackupFreshnessAsync(target, options, cancellationToken).ConfigureAwait(false))).ConfigureAwait(false);
+        }
+
+        if (options.Includes(SqlServerMonitoringScope.CheckDbFreshness))
+        {
+            await AddSectionAsync(snapshot.Errors, "CHECKDB freshness", async () =>
+                snapshot.CheckDb.AddRange(await GetCheckDbFreshnessAsync(target, options, cancellationToken).ConfigureAwait(false))).ConfigureAwait(false);
+        }
+
+        if (options.Includes(SqlServerMonitoringScope.AgentJobs))
+        {
+            await AddSectionAsync(snapshot.Errors, "SQL Agent jobs", async () =>
+                snapshot.AgentJobs.AddRange(await GetAgentJobsAsync(target, options.IncludeDisabledAgentJobs, cancellationToken).ConfigureAwait(false))).ConfigureAwait(false);
+        }
+
+        if (options.Includes(SqlServerMonitoringScope.WaitStatistics))
+        {
+            await AddSectionAsync(snapshot.Errors, "wait statistics", async () =>
+                snapshot.WaitStatistics.AddRange(await GetWaitStatisticsAsync(target, options.WaitStatisticThresholdPercent, cancellationToken).ConfigureAwait(false))).ConfigureAwait(false);
+        }
+
+        if (options.Includes(SqlServerMonitoringScope.AvailabilityGroups))
+        {
+            await AddSectionAsync(snapshot.Errors, "availability groups", async () =>
+                snapshot.AvailabilityGroups.AddRange(await GetAvailabilityGroupsAsync(target, cancellationToken).ConfigureAwait(false))).ConfigureAwait(false);
+        }
+
+        snapshot.CompletedUtc = DateTimeOffset.UtcNow;
+        return snapshot;
+    }
+
+    /// <summary>
+    /// Collects connection, TCP, encryption, authentication, and server identity diagnostics.
+    /// </summary>
+    /// <param name="target">SQL Server target and authentication settings.</param>
+    /// <param name="cancellationToken">Token used to cancel SQL calls.</param>
+    /// <returns>Connection diagnostic result.</returns>
+    public virtual async Task<SqlServerConnectionDiagnostics> GetConnectionDiagnosticsAsync(
+        SqlServerMonitoringTarget target,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateMonitoringTarget(target);
+        var diagnostic = new SqlServerConnectionDiagnostics { Target = target.ServerOrInstance };
+        var connectionString = BuildMonitoringConnectionString(target);
+        SqlConnection? connection = null;
+        try
+        {
+            connection = CreateConnection(connectionString);
+            var connect = Stopwatch.StartNew();
+            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+            connect.Stop();
+            diagnostic.Connected = true;
+            diagnostic.ConnectDuration = connect.Elapsed;
+
+            var query = Stopwatch.StartNew();
+            using SqlCommand command = connection.CreateCommand();
+            command.CommandText = ConnectionDiagnosticsQuery;
+            command.CommandType = CommandType.Text;
+            using SqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                SqlServerMonitoringMappers.PopulateConnectionDiagnostics(reader, diagnostic);
+            }
+            query.Stop();
+            diagnostic.QuerySucceeded = true;
+            diagnostic.QueryDuration = query.Elapsed;
+        }
+        catch (Exception ex)
+        {
+            diagnostic.ErrorCategory = ClassifySqlMonitoringError(ex);
+            diagnostic.ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            diagnostic.CompletedUtc = DateTimeOffset.UtcNow;
+            if (connection != null)
+            {
+                await DisposeConnectionAsync(connection).ConfigureAwait(false);
+            }
+        }
+
+        return diagnostic;
+    }
+
+    /// <summary>
+    /// Collects user database state rows from <c>sys.databases</c>.
+    /// </summary>
+    /// <param name="target">SQL Server target and authentication settings.</param>
+    /// <param name="includeSystemDatabases">When true, includes system databases.</param>
+    /// <param name="cancellationToken">Token used to cancel SQL calls.</param>
+    /// <returns>Database state rows.</returns>
+    public virtual Task<IReadOnlyList<SqlServerDatabaseState>> GetDatabaseStatesAsync(
+        SqlServerMonitoringTarget target,
+        bool includeSystemDatabases = false,
+        CancellationToken cancellationToken = default)
+        => ReadRowsAsync(target, DatabaseStateQuery, r => SqlServerMonitoringMappers.MapDatabaseState(r), includeSystemDatabases, cancellationToken);
+
+    /// <summary>
+    /// Collects backup freshness rows from <c>msdb</c>.
+    /// </summary>
+    /// <param name="target">SQL Server target and authentication settings.</param>
+    /// <param name="options">Threshold settings used to compute row status.</param>
+    /// <param name="cancellationToken">Token used to cancel SQL calls.</param>
+    /// <returns>Backup freshness rows.</returns>
+    public virtual Task<IReadOnlyList<SqlServerBackupFreshness>> GetBackupFreshnessAsync(
+        SqlServerMonitoringTarget target,
+        SqlServerMonitoringOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        options ??= new SqlServerMonitoringOptions();
+        return ReadRowsAsync(target, BackupFreshnessQuery, r => SqlServerMonitoringMappers.MapBackupFreshness(r, options), options.IncludeSystemDatabases, cancellationToken);
+    }
+
+    /// <summary>
+    /// Collects last known good DBCC CHECKDB timestamps for databases where SQL Server exposes them.
+    /// </summary>
+    /// <param name="target">SQL Server target and authentication settings.</param>
+    /// <param name="options">Threshold settings used to compute row status.</param>
+    /// <param name="cancellationToken">Token used to cancel SQL calls.</param>
+    /// <returns>CHECKDB freshness rows.</returns>
+    public virtual async Task<IReadOnlyList<SqlServerCheckDbFreshness>> GetCheckDbFreshnessAsync(
+        SqlServerMonitoringTarget target,
+        SqlServerMonitoringOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        options ??= new SqlServerMonitoringOptions();
+        IReadOnlyList<SqlServerDatabaseState> databases = await GetDatabaseStatesAsync(target, options.IncludeSystemDatabases, cancellationToken).ConfigureAwait(false);
+        var results = new List<SqlServerCheckDbFreshness>(databases.Count);
+        var connectionString = BuildMonitoringConnectionString(target);
+
+        using SqlConnection connection = CreateConnection(connectionString);
+        await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+
+        foreach (SqlServerDatabaseState database in databases)
+        {
+            var freshness = new SqlServerCheckDbFreshness
+            {
+                DatabaseName = database.DatabaseName,
+                DatabaseCreated = database.CreateDate
+            };
+
+            try
+            {
+                using SqlCommand command = connection.CreateCommand();
+                command.CommandText = $"DBCC DBINFO({QuoteSqlIdentifier(database.DatabaseName)}) WITH TABLERESULTS";
+                using SqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    string? field = SqlServerMonitoringMappers.GetString(reader, "Field");
+                    if (string.Equals(field, "dbi_dbccLastKnownGood", StringComparison.OrdinalIgnoreCase))
+                    {
+                        freshness.LastGoodCheckDb = SqlServerMonitoringMappers.GetDateTime(reader, "Value");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                freshness.ErrorMessage = ex.Message;
+            }
+
+            freshness.SinceLastGoodCheckDb = freshness.LastGoodCheckDb.HasValue
+                ? DateTime.UtcNow - freshness.LastGoodCheckDb.Value.ToUniversalTime()
+                : null;
+            freshness.Status = SqlServerMonitoringMappers.EvaluateCheckDbStatus(freshness, options);
+            results.Add(freshness);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Collects SQL Server Agent job status and recent outcome information.
+    /// </summary>
+    /// <param name="target">SQL Server target and authentication settings.</param>
+    /// <param name="includeDisabledJobs">When true, includes disabled jobs.</param>
+    /// <param name="cancellationToken">Token used to cancel SQL calls.</param>
+    /// <returns>SQL Agent job health rows.</returns>
+    public virtual Task<IReadOnlyList<SqlServerAgentJobHealth>> GetAgentJobsAsync(
+        SqlServerMonitoringTarget target,
+        bool includeDisabledJobs = false,
+        CancellationToken cancellationToken = default)
+        => ReadRowsAsync(target, AgentJobsQuery, r => SqlServerMonitoringMappers.MapAgentJobHealth(r), includeDisabledJobs, cancellationToken);
+
+    /// <summary>
+    /// Collects top SQL wait statistics from <c>sys.dm_os_wait_stats</c>.
+    /// </summary>
+    /// <param name="target">SQL Server target and authentication settings.</param>
+    /// <param name="thresholdPercent">Cumulative percentage threshold to include.</param>
+    /// <param name="cancellationToken">Token used to cancel SQL calls.</param>
+    /// <returns>Wait statistic rows.</returns>
+    public virtual Task<IReadOnlyList<SqlServerWaitStatistic>> GetWaitStatisticsAsync(
+        SqlServerMonitoringTarget target,
+        decimal thresholdPercent = 95m,
+        CancellationToken cancellationToken = default)
+    {
+        var parameters = new Dictionary<string, object?> { ["@threshold"] = thresholdPercent };
+        return ReadRowsAsync(target, WaitStatisticsQuery, r => SqlServerMonitoringMappers.MapWaitStatistic(r), false, cancellationToken, parameters);
+    }
+
+    /// <summary>
+    /// Collects Availability Group replica and database synchronization health when HADR is enabled.
+    /// </summary>
+    /// <param name="target">SQL Server target and authentication settings.</param>
+    /// <param name="cancellationToken">Token used to cancel SQL calls.</param>
+    /// <returns>Availability Group health rows, or an empty list when HADR is not enabled.</returns>
+    public virtual Task<IReadOnlyList<SqlServerAvailabilityGroupHealth>> GetAvailabilityGroupsAsync(
+        SqlServerMonitoringTarget target,
+        CancellationToken cancellationToken = default)
+        => ReadRowsAsync(target, AvailabilityGroupsQuery, r => SqlServerMonitoringMappers.MapAvailabilityGroupHealth(r), false, cancellationToken);
+
+    private async Task<IReadOnlyList<T>> ReadRowsAsync<T>(
+        SqlServerMonitoringTarget target,
+        string query,
+        Func<IDataRecord, T> map,
+        bool includeFilteredRows,
+        CancellationToken cancellationToken,
+        IDictionary<string, object?>? parameters = null)
+    {
+        ValidateMonitoringTarget(target);
+        var connectionString = BuildMonitoringConnectionString(target);
+        var rows = new List<T>();
+        using SqlConnection connection = CreateConnection(connectionString);
+        await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+        using SqlCommand command = connection.CreateCommand();
+        command.CommandText = query;
+        command.CommandType = CommandType.Text;
+        if (parameters != null)
+        {
+            foreach (KeyValuePair<string, object?> parameter in parameters)
+            {
+                command.Parameters.AddWithValue(parameter.Key, parameter.Value ?? DBNull.Value);
+            }
+        }
+        command.Parameters.AddWithValue("@includeFilteredRows", includeFilteredRows ? 1 : 0);
+
+        using SqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            rows.Add(map(reader));
+        }
+
+        return rows;
+    }
+
+    private static async Task AddSectionAsync(List<string> errors, string section, Func<Task> action)
+    {
+        try
+        {
+            await action().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"{section}: {ClassifySqlMonitoringError(ex)}: {ex.Message}");
+        }
+    }
+
+    private static string BuildMonitoringConnectionString(SqlServerMonitoringTarget target)
+    {
+        return BuildConnectionString(
+            target.ServerOrInstance,
+            target.Database,
+            target.IntegratedSecurity,
+            target.Username,
+            target.Password,
+            target.Port,
+            ssl: true,
+            trustServerCertificate: target.TrustServerCertificate,
+            connectTimeoutSeconds: target.ConnectTimeoutSeconds,
+            applicationName: target.ApplicationName);
+    }
+
+    private static void ValidateMonitoringTarget(SqlServerMonitoringTarget? target)
+    {
+        if (target == null)
+        {
+            throw new ArgumentNullException(nameof(target));
+        }
+
+        ValidateRequiredConnectionValue(target.ServerOrInstance, nameof(target.ServerOrInstance), "Server");
+        ValidateRequiredConnectionValue(target.Database, nameof(target.Database), "Database");
+        if (!target.IntegratedSecurity)
+        {
+            ValidateRequiredConnectionValue(target.Username, nameof(target.Username), "Username");
+        }
+    }
+
+    private static string QuoteSqlIdentifier(string value)
+    {
+        return "[" + value.Replace("]", "]]") + "]";
+    }
+
+    private static string ClassifySqlMonitoringError(Exception ex)
+    {
+        Exception actual = ex is DbaQueryExecutionException && ex.InnerException != null ? ex.InnerException : ex;
+        return actual switch
+        {
+            SqlException sql when sql.Number == 18456 => "authentication",
+            SqlException sql when sql.Number == 4060 => "database-unavailable",
+            SqlException sql when sql.Number == -2 => "timeout",
+            SqlException => "sql",
+            TimeoutException => "timeout",
+            OperationCanceledException => "cancelled",
+            InvalidOperationException => "connection",
+            _ => "unknown"
+        };
+    }
+}

--- a/DbaClientX.SqlServer/SqlServer.Monitoring.cs
+++ b/DbaClientX.SqlServer/SqlServer.Monitoring.cs
@@ -35,7 +35,7 @@ public partial class SqlServer
         if (options.Includes(SqlServerMonitoringScope.Connectivity))
         {
             snapshot.Connectivity = await GetConnectionDiagnosticsAsync(target, cancellationToken).ConfigureAwait(false);
-            if (snapshot.Connectivity.Connected == false)
+            if (!snapshot.Connectivity.Connected)
             {
                 snapshot.CompletedUtc = DateTimeOffset.UtcNow;
                 return snapshot;
@@ -118,7 +118,21 @@ public partial class SqlServer
             diagnostic.QuerySucceeded = true;
             diagnostic.QueryDuration = query.Elapsed;
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (SqlException ex)
+        {
+            diagnostic.ErrorCategory = ClassifySqlMonitoringError(ex);
+            diagnostic.ErrorMessage = ex.Message;
+        }
+        catch (TimeoutException ex)
+        {
+            diagnostic.ErrorCategory = ClassifySqlMonitoringError(ex);
+            diagnostic.ErrorMessage = ex.Message;
+        }
+        catch (InvalidOperationException ex)
         {
             diagnostic.ErrorCategory = ClassifySqlMonitoringError(ex);
             diagnostic.ErrorMessage = ex.Message;
@@ -206,7 +220,11 @@ public partial class SqlServer
                     }
                 }
             }
-            catch (Exception ex)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (SqlException ex)
             {
                 freshness.ErrorMessage = ex.Message;
             }
@@ -301,10 +319,31 @@ public partial class SqlServer
         {
             await action().ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException)
         {
-            errors.Add($"{section}: {ClassifySqlMonitoringError(ex)}: {ex.Message}");
+            throw;
         }
+        catch (DbaQueryExecutionException ex)
+        {
+            AddSectionError(errors, section, ex);
+        }
+        catch (SqlException ex)
+        {
+            AddSectionError(errors, section, ex);
+        }
+        catch (TimeoutException ex)
+        {
+            AddSectionError(errors, section, ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            AddSectionError(errors, section, ex);
+        }
+    }
+
+    private static void AddSectionError(List<string> errors, string section, Exception ex)
+    {
+        errors.Add($"{section}: {ClassifySqlMonitoringError(ex)}: {ex.Message}");
     }
 
     private static string BuildMonitoringConnectionString(SqlServerMonitoringTarget target)

--- a/DbaClientX.SqlServer/SqlServer.Monitoring.cs
+++ b/DbaClientX.SqlServer/SqlServer.Monitoring.cs
@@ -230,7 +230,7 @@ public partial class SqlServer
             }
 
             freshness.SinceLastGoodCheckDb = freshness.LastGoodCheckDb.HasValue
-                ? DateTime.UtcNow - freshness.LastGoodCheckDb.Value.ToUniversalTime()
+                ? DateTime.UtcNow - SqlServerMonitoringMappers.NormalizeSqlDateTimeUtc(freshness.LastGoodCheckDb.Value)
                 : null;
             freshness.Status = SqlServerMonitoringMappers.EvaluateCheckDbStatus(freshness, options);
             results.Add(freshness);

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -51,13 +51,49 @@ public partial class SqlServer : DatabaseClientBase
     /// <param name="password">SQL login password when <paramref name="integratedSecurity"/> is <see langword="false"/>.</param>
     /// <param name="port">Optional TCP port appended to <paramref name="serverOrInstance"/>.</param>
     /// <param name="ssl">Optional encryption flag routed to <see cref="SqlConnectionStringBuilder.Encrypt"/>.</param>
+    /// <returns>A provider-formatted connection string.</returns>
+    /// <remarks>
+    /// The builder enables pooling by default to keep performance comparable to the MySQL implementation. Additional
+    /// advanced options can be appended by callers if necessary for their environment.
+    /// </remarks>
+    public static string BuildConnectionString(
+        string serverOrInstance,
+        string database,
+        bool integratedSecurity,
+        string? username,
+        string? password,
+        int? port,
+        bool? ssl)
+    {
+        return BuildConnectionString(
+            serverOrInstance,
+            database,
+            integratedSecurity,
+            username,
+            password,
+            port,
+            ssl,
+            trustServerCertificate: false,
+            connectTimeoutSeconds: null,
+            applicationName: null);
+    }
+
+    /// <summary>
+    /// Builds a SQL Server connection string from discrete connection components and diagnostics options.
+    /// </summary>
+    /// <param name="serverOrInstance">Server name, address, or <c>Server\Instance</c> style identifier.</param>
+    /// <param name="database">Database (catalog) to target.</param>
+    /// <param name="integratedSecurity">When <see langword="true"/> configures Windows authentication.</param>
+    /// <param name="username">SQL login identifier when <paramref name="integratedSecurity"/> is <see langword="false"/>.</param>
+    /// <param name="password">SQL login password when <paramref name="integratedSecurity"/> is <see langword="false"/>.</param>
+    /// <param name="port">Optional TCP port appended to <paramref name="serverOrInstance"/>.</param>
+    /// <param name="ssl">Optional encryption flag routed to <see cref="SqlConnectionStringBuilder.Encrypt"/>.</param>
     /// <param name="trustServerCertificate">When true, encrypted connections trust the server certificate without validating the chain.</param>
     /// <param name="connectTimeoutSeconds">Optional connection timeout in seconds.</param>
     /// <param name="applicationName">Optional application name written into the connection string.</param>
     /// <returns>A provider-formatted connection string.</returns>
     /// <remarks>
-    /// The builder enables pooling by default to keep performance comparable to the MySQL implementation. Additional
-    /// advanced options can be appended by callers if necessary for their environment.
+    /// This overload extends the legacy signature while keeping the original overload available for binary-compatible upgrades.
     /// </remarks>
     public static string BuildConnectionString(
         string serverOrInstance,

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -51,6 +51,9 @@ public partial class SqlServer : DatabaseClientBase
     /// <param name="password">SQL login password when <paramref name="integratedSecurity"/> is <see langword="false"/>.</param>
     /// <param name="port">Optional TCP port appended to <paramref name="serverOrInstance"/>.</param>
     /// <param name="ssl">Optional encryption flag routed to <see cref="SqlConnectionStringBuilder.Encrypt"/>.</param>
+    /// <param name="trustServerCertificate">When true, encrypted connections trust the server certificate without validating the chain.</param>
+    /// <param name="connectTimeoutSeconds">Optional connection timeout in seconds.</param>
+    /// <param name="applicationName">Optional application name written into the connection string.</param>
     /// <returns>A provider-formatted connection string.</returns>
     /// <remarks>
     /// The builder enables pooling by default to keep performance comparable to the MySQL implementation. Additional
@@ -63,7 +66,10 @@ public partial class SqlServer : DatabaseClientBase
         string? username = null,
         string? password = null,
         int? port = null,
-        bool? ssl = null)
+        bool? ssl = null,
+        bool trustServerCertificate = false,
+        int? connectTimeoutSeconds = null,
+        string? applicationName = null)
     {
         ValidateRequiredConnectionValue(serverOrInstance, nameof(serverOrInstance), "Server");
         ValidateRequiredConnectionValue(database, nameof(database), "Database");
@@ -84,8 +90,22 @@ public partial class SqlServer : DatabaseClientBase
             InitialCatalog = database,
             IntegratedSecurity = integratedSecurity,
             Encrypt = true,
+            TrustServerCertificate = trustServerCertificate,
             Pooling = true
         };
+        if (connectTimeoutSeconds.HasValue)
+        {
+            if (connectTimeoutSeconds.Value <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(connectTimeoutSeconds), "Connection timeout must be greater than zero.");
+            }
+
+            connectionStringBuilder.ConnectTimeout = connectTimeoutSeconds.Value;
+        }
+        if (!string.IsNullOrWhiteSpace(applicationName))
+        {
+            connectionStringBuilder.ApplicationName = applicationName;
+        }
         if (!integratedSecurity)
         {
             connectionStringBuilder.UserID = username;

--- a/DbaClientX.Tests/DbaClientX.Tests.csproj
+++ b/DbaClientX.Tests/DbaClientX.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.PowerShell.SDK" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" />
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DbaClientX.Tests/SqlServerMonitoringTests.cs
+++ b/DbaClientX.Tests/SqlServerMonitoringTests.cs
@@ -1,0 +1,77 @@
+using DBAClientX;
+using DBAClientX.SqlServerMonitoring;
+using Microsoft.Data.SqlClient;
+using Xunit;
+
+namespace DbaClientX.Tests;
+
+public class SqlServerMonitoringTests
+{
+    [Fact]
+    public void BuildConnectionString_WithMonitoringOptions_KeepsEncryptionAndAppliesDiagnosticsSettings()
+    {
+        string connectionString = SqlServer.BuildConnectionString(
+            "sql01",
+            "master",
+            integratedSecurity: true,
+            port: 14330,
+            ssl: true,
+            trustServerCertificate: true,
+            connectTimeoutSeconds: 7,
+            applicationName: "unit-test");
+
+        var builder = new SqlConnectionStringBuilder(connectionString);
+
+        Assert.Equal("sql01,14330", builder.DataSource);
+        Assert.Equal("master", builder.InitialCatalog);
+        Assert.True(builder.IntegratedSecurity);
+        Assert.True(builder.Encrypt);
+        Assert.True(builder.TrustServerCertificate);
+        Assert.Equal(7, builder.ConnectTimeout);
+        Assert.Equal("unit-test", builder.ApplicationName);
+    }
+
+    [Fact]
+    public void BuildConnectionString_WithInvalidTimeout_ThrowsArgumentOutOfRangeException()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            SqlServer.BuildConnectionString("sql01", "master", true, connectTimeoutSeconds: 0));
+    }
+
+    [Fact]
+    public void MonitoringOptions_Includes_ReturnsTrueOnlyForRequestedScopes()
+    {
+        var options = new SqlServerMonitoringOptions
+        {
+            Scope = SqlServerMonitoringScope.Connectivity | SqlServerMonitoringScope.DatabaseState
+        };
+
+        Assert.True(options.Includes(SqlServerMonitoringScope.Connectivity));
+        Assert.True(options.Includes(SqlServerMonitoringScope.DatabaseState));
+        Assert.False(options.Includes(SqlServerMonitoringScope.AgentJobs));
+    }
+
+    [Fact]
+    public void MonitoringScope_All_IncludesAvailabilityGroups()
+    {
+        var options = new SqlServerMonitoringOptions
+        {
+            Scope = SqlServerMonitoringScope.All
+        };
+
+        Assert.True(options.Includes(SqlServerMonitoringScope.AvailabilityGroups));
+    }
+
+    [Fact]
+    public void MonitoringTarget_DefaultsToIntegratedSecurityAndMaster()
+    {
+        var target = new SqlServerMonitoringTarget
+        {
+            ServerOrInstance = "sql01"
+        };
+
+        Assert.True(target.IntegratedSecurity);
+        Assert.Equal("master", target.Database);
+        Assert.Equal("DbaClientX.Monitoring", target.ApplicationName);
+    }
+}

--- a/DbaClientX.Tests/SqlServerMonitoringTests.cs
+++ b/DbaClientX.Tests/SqlServerMonitoringTests.cs
@@ -39,6 +39,37 @@ public class SqlServerMonitoringTests
     }
 
     [Fact]
+    public void BuildConnectionString_WithLegacySignature_RemainsCallable()
+    {
+        string connectionString = SqlServer.BuildConnectionString(
+            "sql01",
+            "master",
+            true,
+            null,
+            null,
+            1433,
+            true);
+
+        var builder = new SqlConnectionStringBuilder(connectionString);
+
+        Assert.Equal("sql01,1433", builder.DataSource);
+        Assert.Equal("master", builder.InitialCatalog);
+        Assert.True(builder.IntegratedSecurity);
+        Assert.True(builder.Encrypt);
+    }
+
+    [Fact]
+    public void NormalizeSqlDateTimeUtc_WithUnspecifiedKind_TreatsValueAsUtc()
+    {
+        var value = new DateTime(2026, 5, 25, 12, 30, 0, DateTimeKind.Unspecified);
+
+        DateTime normalized = SqlServerMonitoringMappers.NormalizeSqlDateTimeUtc(value);
+
+        Assert.Equal(DateTimeKind.Utc, normalized.Kind);
+        Assert.Equal(value.Ticks, normalized.Ticks);
+    }
+
+    [Fact]
     public void MonitoringOptions_Includes_ReturnsTrueOnlyForRequestedScopes()
     {
         var options = new SqlServerMonitoringOptions

--- a/DbaClientX.Tests/SqlServerMonitoringTests.cs
+++ b/DbaClientX.Tests/SqlServerMonitoringTests.cs
@@ -63,6 +63,18 @@ public class SqlServerMonitoringTests
     }
 
     [Fact]
+    public void AvailabilityGroupHealth_WithMissingState_IsNotHealthy()
+    {
+        var health = new SqlServerAvailabilityGroupHealth
+        {
+            AvailabilityGroupName = "ag01",
+            ReplicaServerName = "sql01"
+        };
+
+        Assert.False(health.IsHealthy);
+    }
+
+    [Fact]
     public void MonitoringTarget_DefaultsToIntegratedSecurityAndMaster()
     {
         var target = new SqlServerMonitoringTarget

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Oracle.ManagedDataAccess" Version="23.26.200" />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.26.200" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.5" />
     <PackageVersion Include="System.Text.Json" Version="10.0.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Summary

Adds a reusable, typed SQL Server monitoring foundation to DbaClientX.SqlServer.

- Adds typed models for connectivity, database state, backup freshness, CHECKDB freshness, SQL Agent job health, wait statistics, and Availability Group health.
- Adds async SQL Server monitoring collectors and query definitions behind the existing SqlServer provider.
- Extends connection-string construction with monitoring-friendly diagnostics options while keeping encryption enabled.
- Pins System.Security.Cryptography.Xml to a patched version for warning-free test restore/build output.

## Validation

- dotnet.exe build .\DbaClientX.SqlServer\DbaClientX.SqlServer.csproj -c Debug /m:1 /nr:false
- dotnet.exe test .\DbaClientX.Tests\DbaClientX.Tests.csproj -c Debug -f net10.0 --filter SqlServerMonitoringTests /m:1 /nr:false
- dotnet.exe list .\DbaClientX.Tests\DbaClientX.Tests.csproj package --vulnerable --include-transitive
- git diff --check

All validation completed with 0 warnings/errors; SQL monitoring tests passed 5/5.