### PR TITLE
[codex] Add SQLite diagnostics snapshot

### DIFF
--- a/DbaClientX.SQLite/Diagnostics/SqliteDatabaseDiagnostics.cs
+++ b/DbaClientX.SQLite/Diagnostics/SqliteDatabaseDiagnostics.cs
@@ -1,0 +1,145 @@
+using System;
+
+namespace DBAClientX;
+
+/// <summary>
+/// Describes lightweight SQLite database health and file-state diagnostics.
+/// </summary>
+public sealed class SqliteDatabaseDiagnostics
+{
+    /// <summary>
+    /// Gets the database path supplied by the caller.
+    /// </summary>
+    public string Database { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets the normalized database path when the database is file-backed.
+    /// </summary>
+    public string FullPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets a value indicating whether the database file exists.
+    /// </summary>
+    public bool Exists { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether a read-only connection was opened successfully.
+    /// </summary>
+    public bool CanConnect { get; set; }
+
+    /// <summary>
+    /// Gets a connection or diagnostic error message when one was encountered.
+    /// </summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Gets the SQLite engine version.
+    /// </summary>
+    public string? SQLiteVersion { get; set; }
+
+    /// <summary>
+    /// Gets the result of <c>PRAGMA integrity_check</c>.
+    /// </summary>
+    public string? IntegrityCheck { get; set; }
+
+    /// <summary>
+    /// Gets the result of <c>PRAGMA quick_check</c>.
+    /// </summary>
+    public string? QuickCheck { get; set; }
+
+    /// <summary>
+    /// Gets the current journal mode.
+    /// </summary>
+    public string? JournalMode { get; set; }
+
+    /// <summary>
+    /// Gets the configured synchronous mode.
+    /// </summary>
+    public string? SynchronousMode { get; set; }
+
+    /// <summary>
+    /// Gets the current locking mode.
+    /// </summary>
+    public string? LockingMode { get; set; }
+
+    /// <summary>
+    /// Gets the configured auto-vacuum mode.
+    /// </summary>
+    public string? AutoVacuumMode { get; set; }
+
+    /// <summary>
+    /// Gets the number of database pages.
+    /// </summary>
+    public long? PageCount { get; set; }
+
+    /// <summary>
+    /// Gets the database page size in bytes.
+    /// </summary>
+    public long? PageSizeBytes { get; set; }
+
+    /// <summary>
+    /// Gets the number of pages currently on the freelist.
+    /// </summary>
+    public long? FreelistCount { get; set; }
+
+    /// <summary>
+    /// Gets the schema version.
+    /// </summary>
+    public long? SchemaVersion { get; set; }
+
+    /// <summary>
+    /// Gets the user version.
+    /// </summary>
+    public long? UserVersion { get; set; }
+
+    /// <summary>
+    /// Gets the application id.
+    /// </summary>
+    public long? ApplicationId { get; set; }
+
+    /// <summary>
+    /// Gets the WAL autocheckpoint page threshold.
+    /// </summary>
+    public long? WalAutoCheckpointPages { get; set; }
+
+    /// <summary>
+    /// Gets the main database file size in bytes.
+    /// </summary>
+    public long DatabaseFileSizeBytes { get; set; }
+
+    /// <summary>
+    /// Gets the WAL file size in bytes.
+    /// </summary>
+    public long WalFileSizeBytes { get; set; }
+
+    /// <summary>
+    /// Gets the shared-memory file size in bytes.
+    /// </summary>
+    public long SharedMemoryFileSizeBytes { get; set; }
+
+    /// <summary>
+    /// Gets the approximate logical database size from page count and page size.
+    /// </summary>
+    public long? LogicalDatabaseSizeBytes =>
+        PageCount.HasValue && PageSizeBytes.HasValue
+            ? PageCount.Value * PageSizeBytes.Value
+            : null;
+
+    /// <summary>
+    /// Gets the total size of the database, WAL, and shared-memory files.
+    /// </summary>
+    public long TotalFileSizeBytes => DatabaseFileSizeBytes + WalFileSizeBytes + SharedMemoryFileSizeBytes;
+
+    /// <summary>
+    /// Gets the database file last-write time in UTC.
+    /// </summary>
+    public DateTimeOffset? LastWriteTimeUtc { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether both integrity checks report <c>ok</c>.
+    /// </summary>
+    public bool IsHealthy =>
+        CanConnect &&
+        string.Equals(IntegrityCheck, "ok", StringComparison.OrdinalIgnoreCase) &&
+        string.Equals(QuickCheck, "ok", StringComparison.OrdinalIgnoreCase);
+}

--- a/DbaClientX.SQLite/SQLite.Diagnostics.cs
+++ b/DbaClientX.SQLite/SQLite.Diagnostics.cs
@@ -29,15 +29,15 @@ public partial class SQLite
             FullPath = fullPath
         };
 
-        ApplyFileDiagnostics(diagnostics, fullPath);
-        if (!diagnostics.Exists)
-        {
-            diagnostics.ErrorMessage = "SQLite database file does not exist.";
-            return diagnostics;
-        }
-
         try
         {
+            ApplyFileDiagnostics(diagnostics, fullPath);
+            if (!diagnostics.Exists)
+            {
+                diagnostics.ErrorMessage = "SQLite database file does not exist.";
+                return diagnostics;
+            }
+
             using var connection = new SqliteConnection(BuildConnectionString(fullPath, readOnly: true, busyTimeoutMs: busyTimeoutMs));
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
             await ApplyBusyTimeoutAsync(connection, busyTimeoutMs, cancellationToken).ConfigureAwait(false);
@@ -71,6 +71,7 @@ public partial class SQLite
             diagnostics.UserVersion = ConvertToNullableInt64(await ExecuteDiagnosticScalarAsync(connection, "PRAGMA user_version;", cancellationToken).ConfigureAwait(false));
             diagnostics.ApplicationId = ConvertToNullableInt64(await ExecuteDiagnosticScalarAsync(connection, "PRAGMA application_id;", cancellationToken).ConfigureAwait(false));
             diagnostics.WalAutoCheckpointPages = ConvertToNullableInt64(await ExecuteDiagnosticScalarAsync(connection, "PRAGMA wal_autocheckpoint;", cancellationToken).ConfigureAwait(false));
+            ApplyFileDiagnostics(diagnostics, fullPath);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -94,10 +95,13 @@ public partial class SQLite
 
     private static void ApplyFileDiagnostics(SqliteDatabaseDiagnostics diagnostics, string fullPath)
     {
-        var databaseFile = new FileInfo(fullPath);
-        diagnostics.Exists = databaseFile.Exists;
-        if (databaseFile.Exists)
+        diagnostics.Exists = FilePathExists(fullPath);
+        diagnostics.DatabaseFileSizeBytes = 0L;
+        diagnostics.LastWriteTimeUtc = null;
+
+        if (diagnostics.Exists)
         {
+            var databaseFile = new FileInfo(fullPath);
             diagnostics.DatabaseFileSizeBytes = databaseFile.Length;
             diagnostics.LastWriteTimeUtc = new DateTimeOffset(databaseFile.LastWriteTimeUtc, TimeSpan.Zero);
         }
@@ -108,8 +112,35 @@ public partial class SQLite
 
     private static long GetFileSize(string path)
     {
+        if (!FilePathExists(path))
+        {
+            return 0L;
+        }
+
         var file = new FileInfo(path);
-        return file.Exists ? file.Length : 0L;
+        return file.Length;
+    }
+
+    private static bool FilePathExists(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.Directory) == FileAttributes.Directory)
+            {
+                throw new IOException("SQLite file path points to a directory.");
+            }
+
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            return false;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return false;
+        }
     }
 
     private async Task<object?> ExecuteDiagnosticScalarAsync(

--- a/DbaClientX.SQLite/SQLite.Diagnostics.cs
+++ b/DbaClientX.SQLite/SQLite.Diagnostics.cs
@@ -36,10 +36,9 @@ public partial class SQLite
             return diagnostics;
         }
 
-        SqliteConnection? connection = null;
         try
         {
-            connection = new SqliteConnection(BuildConnectionString(fullPath, readOnly: true, busyTimeoutMs: busyTimeoutMs));
+            using var connection = new SqliteConnection(BuildConnectionString(fullPath, readOnly: true, busyTimeoutMs: busyTimeoutMs));
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
             await ApplyBusyTimeoutAsync(connection, busyTimeoutMs, cancellationToken).ConfigureAwait(false);
 
@@ -77,20 +76,17 @@ public partial class SQLite
         {
             throw;
         }
-        catch (Exception ex)
+        catch (SqliteException ex)
         {
             diagnostics.ErrorMessage = ex.Message;
         }
-        finally
+        catch (IOException ex)
         {
-            if (connection != null)
-            {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
-                await connection.DisposeAsync().ConfigureAwait(false);
-#else
-                connection.Dispose();
-#endif
-            }
+            diagnostics.ErrorMessage = ex.Message;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            diagnostics.ErrorMessage = ex.Message;
         }
 
         return diagnostics;

--- a/DbaClientX.SQLite/SQLite.Diagnostics.cs
+++ b/DbaClientX.SQLite/SQLite.Diagnostics.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+
+namespace DBAClientX;
+
+public partial class SQLite
+{
+    /// <summary>
+    /// Collects read-only SQLite health and file-state diagnostics for a database file.
+    /// </summary>
+    /// <param name="database">Absolute or relative path of the SQLite database file.</param>
+    /// <param name="cancellationToken">Token used to cancel command execution.</param>
+    /// <param name="busyTimeoutMs">Optional busy timeout in milliseconds.</param>
+    /// <returns>A typed diagnostics snapshot.</returns>
+    public virtual async Task<SqliteDatabaseDiagnostics> CollectDiagnosticsAsync(
+        string database,
+        CancellationToken cancellationToken = default,
+        int? busyTimeoutMs = null)
+    {
+        ValidateDatabasePath(database);
+        string fullPath = Path.GetFullPath(database);
+        var diagnostics = new SqliteDatabaseDiagnostics
+        {
+            Database = database,
+            FullPath = fullPath
+        };
+
+        ApplyFileDiagnostics(diagnostics, fullPath);
+        if (!diagnostics.Exists)
+        {
+            diagnostics.ErrorMessage = "SQLite database file does not exist.";
+            return diagnostics;
+        }
+
+        SqliteConnection? connection = null;
+        try
+        {
+            connection = new SqliteConnection(BuildConnectionString(fullPath, readOnly: true, busyTimeoutMs: busyTimeoutMs));
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await ApplyBusyTimeoutAsync(connection, busyTimeoutMs, cancellationToken).ConfigureAwait(false);
+
+            diagnostics.CanConnect = true;
+            diagnostics.SQLiteVersion = Convert.ToString(
+                await ExecuteDiagnosticScalarAsync(connection, "SELECT sqlite_version();", cancellationToken).ConfigureAwait(false),
+                CultureInfo.InvariantCulture);
+            diagnostics.IntegrityCheck = Convert.ToString(
+                await ExecuteDiagnosticScalarAsync(connection, "PRAGMA integrity_check;", cancellationToken).ConfigureAwait(false),
+                CultureInfo.InvariantCulture);
+            diagnostics.QuickCheck = Convert.ToString(
+                await ExecuteDiagnosticScalarAsync(connection, "PRAGMA quick_check;", cancellationToken).ConfigureAwait(false),
+                CultureInfo.InvariantCulture);
+            diagnostics.JournalMode = Convert.ToString(
+                await ExecuteDiagnosticScalarAsync(connection, "PRAGMA journal_mode;", cancellationToken).ConfigureAwait(false),
+                CultureInfo.InvariantCulture);
+            diagnostics.SynchronousMode = Convert.ToString(
+                await ExecuteDiagnosticScalarAsync(connection, "PRAGMA synchronous;", cancellationToken).ConfigureAwait(false),
+                CultureInfo.InvariantCulture);
+            diagnostics.LockingMode = Convert.ToString(
+                await ExecuteDiagnosticScalarAsync(connection, "PRAGMA locking_mode;", cancellationToken).ConfigureAwait(false),
+                CultureInfo.InvariantCulture);
+            diagnostics.AutoVacuumMode = Convert.ToString(
+                await ExecuteDiagnosticScalarAsync(connection, "PRAGMA auto_vacuum;", cancellationToken).ConfigureAwait(false),
+                CultureInfo.InvariantCulture);
+            diagnostics.PageCount = ConvertToNullableInt64(await ExecuteDiagnosticScalarAsync(connection, "PRAGMA page_count;", cancellationToken).ConfigureAwait(false));
+            diagnostics.PageSizeBytes = ConvertToNullableInt64(await ExecuteDiagnosticScalarAsync(connection, "PRAGMA page_size;", cancellationToken).ConfigureAwait(false));
+            diagnostics.FreelistCount = ConvertToNullableInt64(await ExecuteDiagnosticScalarAsync(connection, "PRAGMA freelist_count;", cancellationToken).ConfigureAwait(false));
+            diagnostics.SchemaVersion = ConvertToNullableInt64(await ExecuteDiagnosticScalarAsync(connection, "PRAGMA schema_version;", cancellationToken).ConfigureAwait(false));
+            diagnostics.UserVersion = ConvertToNullableInt64(await ExecuteDiagnosticScalarAsync(connection, "PRAGMA user_version;", cancellationToken).ConfigureAwait(false));
+            diagnostics.ApplicationId = ConvertToNullableInt64(await ExecuteDiagnosticScalarAsync(connection, "PRAGMA application_id;", cancellationToken).ConfigureAwait(false));
+            diagnostics.WalAutoCheckpointPages = ConvertToNullableInt64(await ExecuteDiagnosticScalarAsync(connection, "PRAGMA wal_autocheckpoint;", cancellationToken).ConfigureAwait(false));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            diagnostics.ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            if (connection != null)
+            {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+                await connection.DisposeAsync().ConfigureAwait(false);
+#else
+                connection.Dispose();
+#endif
+            }
+        }
+
+        return diagnostics;
+    }
+
+    private static void ApplyFileDiagnostics(SqliteDatabaseDiagnostics diagnostics, string fullPath)
+    {
+        var databaseFile = new FileInfo(fullPath);
+        diagnostics.Exists = databaseFile.Exists;
+        if (databaseFile.Exists)
+        {
+            diagnostics.DatabaseFileSizeBytes = databaseFile.Length;
+            diagnostics.LastWriteTimeUtc = new DateTimeOffset(databaseFile.LastWriteTimeUtc, TimeSpan.Zero);
+        }
+
+        diagnostics.WalFileSizeBytes = GetFileSize(fullPath + "-wal");
+        diagnostics.SharedMemoryFileSizeBytes = GetFileSize(fullPath + "-shm");
+    }
+
+    private static long GetFileSize(string path)
+    {
+        var file = new FileInfo(path);
+        return file.Exists ? file.Length : 0L;
+    }
+
+    private async Task<object?> ExecuteDiagnosticScalarAsync(
+        SqliteConnection connection,
+        string commandText,
+        CancellationToken cancellationToken)
+    {
+        ValidateCommandText(commandText);
+        return await ExecuteWithRetryAsync(async () =>
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = commandText;
+            var commandTimeout = CommandTimeout;
+            if (commandTimeout > 0)
+            {
+                command.CommandTimeout = commandTimeout;
+            }
+
+            return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static long? ConvertToNullableInt64(object? value)
+    {
+        if (value is null || value is DBNull)
+        {
+            return null;
+        }
+
+        return Convert.ToInt64(value, CultureInfo.InvariantCulture);
+    }
+}

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -500,6 +500,59 @@ public class SqliteTests
     }
 
     [Fact]
+    public async Task CollectDiagnosticsAsync_FileDatabase_ReturnsHealthAndFileState()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            using var sqlite = new DBAClientX.SQLite();
+            await sqlite.ExecuteNonQueryAsync(path, "PRAGMA journal_mode=WAL;");
+            await sqlite.ExecuteNonQueryAsync(path, "CREATE TABLE t(id INTEGER PRIMARY KEY, payload TEXT);");
+            await sqlite.ExecuteNonQueryAsync(path, "INSERT INTO t(payload) VALUES ($payload);", new Dictionary<string, object?>
+            {
+                ["$payload"] = new string('x', 2048)
+            });
+
+            var diagnostics = await sqlite.CollectDiagnosticsAsync(path);
+
+            Assert.Equal(Path.GetFullPath(path), diagnostics.FullPath);
+            Assert.True(diagnostics.Exists);
+            Assert.True(diagnostics.CanConnect);
+            Assert.True(diagnostics.IsHealthy);
+            Assert.Equal("ok", diagnostics.IntegrityCheck);
+            Assert.Equal("ok", diagnostics.QuickCheck);
+            Assert.False(string.IsNullOrWhiteSpace(diagnostics.SQLiteVersion));
+            Assert.False(string.IsNullOrWhiteSpace(diagnostics.JournalMode));
+            Assert.True(diagnostics.PageCount > 0);
+            Assert.True(diagnostics.PageSizeBytes > 0);
+            Assert.True(diagnostics.DatabaseFileSizeBytes > 0);
+            Assert.True(diagnostics.TotalFileSizeBytes >= diagnostics.DatabaseFileSizeBytes);
+            Assert.True(diagnostics.LogicalDatabaseSizeBytes > 0);
+            Assert.NotNull(diagnostics.LastWriteTimeUtc);
+            Assert.Null(diagnostics.ErrorMessage);
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    [Fact]
+    public async Task CollectDiagnosticsAsync_MissingDatabase_ReturnsMissingSnapshot()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "dbaclientx-missing-" + Guid.NewGuid().ToString("N") + ".sqlite");
+        using var sqlite = new DBAClientX.SQLite();
+
+        var diagnostics = await sqlite.CollectDiagnosticsAsync(path);
+
+        Assert.Equal(Path.GetFullPath(path), diagnostics.FullPath);
+        Assert.False(diagnostics.Exists);
+        Assert.False(diagnostics.CanConnect);
+        Assert.Equal("SQLite database file does not exist.", diagnostics.ErrorMessage);
+        Assert.False(diagnostics.IsHealthy);
+    }
+
+    [Fact]
     public async Task RunInTransactionAsync_CommitsOnSuccess()
     {
         var path = Path.GetTempFileName();

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -555,6 +555,28 @@ public class SqliteTests
     }
 
     [Fact]
+    public async Task CollectDiagnosticsAsync_DirectoryPath_ReturnsFileDiagnosticError()
+    {
+        var path = Path.GetTempFileName();
+        File.Delete(path);
+        Directory.CreateDirectory(path);
+        try
+        {
+            using var sqlite = new DBAClientX.SQLite();
+
+            var diagnostics = await sqlite.CollectDiagnosticsAsync(path);
+
+            Assert.False(diagnostics.CanConnect);
+            Assert.Equal("SQLite file path points to a directory.", diagnostics.ErrorMessage);
+            Assert.False(diagnostics.IsHealthy);
+        }
+        finally
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task RunInTransactionAsync_CommitsOnSuccess()
     {
         var path = Path.GetTempFileName();

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -540,7 +540,9 @@ public class SqliteTests
     [Fact]
     public async Task CollectDiagnosticsAsync_MissingDatabase_ReturnsMissingSnapshot()
     {
-        var path = Path.Combine(Path.GetTempPath(), "dbaclientx-missing-" + Guid.NewGuid().ToString("N") + ".sqlite");
+        var path = Path.GetTempFileName();
+        File.Delete(path);
+        path += ".sqlite";
         using var sqlite = new DBAClientX.SQLite();
 
         var diagnostics = await sqlite.CollectDiagnosticsAsync(path);


### PR DESCRIPTION
## What changed
- Added a typed `SqliteDatabaseDiagnostics` snapshot for SQLite health and file-state reporting.
- Added `SQLite.CollectDiagnosticsAsync(...)` to gather read-only diagnostics from a database file, including integrity/quick checks, common PRAGMAs, SQLite version, logical size, and DB/WAL/SHM file sizes.
- Covered healthy file databases and missing-file snapshots with focused SQLite tests.

## Why
This gives DbaClientX a reusable SQLite diagnostics primitive that can support future tray/app health checks, including Codex local-state monitoring, without baking that logic into a single consumer app.

## Validation
- `dotnet build .\DbaClientX.SQLite\DbaClientX.SQLite.csproj -c Debug /m:1 /nr:false`
- `dotnet test .\DbaClientX.Tests\DbaClientX.Tests.csproj -c Debug -f net10.0 --filter "FullyQualifiedName~SqliteTests" /m:1 /nr:false`
- `dotnet test .\DbaClientX.Tests\DbaClientX.Tests.csproj -c Debug -f net8.0 --filter "FullyQualifiedName~SqliteTests" /m:1 /nr:false`
- `git diff --check`

## Notes
The SQLite test restores still report existing `System.Security.Cryptography.Xml` NU1903 advisories on current `master`. PR #177 already pins that dependency, so this branch keeps the SQLite diagnostics scope separate.