### PR TITLE
Retry SQL Server connection opens

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -362,7 +362,12 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         }
     }
 
-    private TimeSpan ComputeBackoffDelay(int attempt)
+    /// <summary>
+    /// Computes the capped exponential backoff delay with jitter for a retry attempt.
+    /// </summary>
+    /// <param name="attempt">The one-based retry attempt number.</param>
+    /// <returns>The delay before the next retry attempt.</returns>
+    protected TimeSpan ComputeBackoffDelay(int attempt)
     {
         var baseDelay = RetryDelay;
         if (baseDelay <= TimeSpan.Zero)

--- a/DbaClientX.SqlServer/SqlServer.Transactions.cs
+++ b/DbaClientX.SqlServer/SqlServer.Transactions.cs
@@ -542,7 +542,8 @@ public partial class SqlServer
     /// <inheritdoc />
     protected override bool IsTransient(Exception ex) =>
         ex is SqlException sqlEx &&
-        sqlEx.Number is 4060 or 10928 or 10929 or 1205 or 40197 or 40501 or 40613 or 49918 or 49919 or 49920;
+        sqlEx.Number is -2 or 64 or 233 or 4060 or 10928 or 10929 or 1205 or 40197 or 40501 or 40613 or 49918 or 49919 or 49920
+            or 10053 or 10054 or 10060;
 
     /// <inheritdoc />
     protected override void Dispose(bool disposing)

--- a/DbaClientX.SqlServer/SqlServer.Transactions.cs
+++ b/DbaClientX.SqlServer/SqlServer.Transactions.cs
@@ -542,8 +542,7 @@ public partial class SqlServer
     /// <inheritdoc />
     protected override bool IsTransient(Exception ex) =>
         ex is SqlException sqlEx &&
-        sqlEx.Number is -2 or 64 or 233 or 4060 or 10928 or 10929 or 1205 or 40197 or 40501 or 40613 or 49918 or 49919 or 49920
-            or 10053 or 10054 or 10060;
+        sqlEx.Number is 4060 or 10928 or 10929 or 1205 or 40197 or 40501 or 40613 or 49918 or 49919 or 49920;
 
     /// <inheritdoc />
     protected override void Dispose(bool disposing)

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -332,9 +332,10 @@ public partial class SqlServer : DatabaseClientBase
                     break;
                 }
 
-                if (RetryDelay > TimeSpan.Zero)
+                var delay = ComputeBackoffDelay(attempts);
+                if (delay > TimeSpan.Zero)
                 {
-                    Thread.Sleep(RetryDelay);
+                    Thread.Sleep(delay);
                 }
             }
         }
@@ -364,9 +365,10 @@ public partial class SqlServer : DatabaseClientBase
                     break;
                 }
 
-                if (RetryDelay > TimeSpan.Zero)
+                var delay = ComputeBackoffDelay(attempts);
+                if (delay > TimeSpan.Zero)
                 {
-                    await Task.Delay(RetryDelay, cancellationToken).ConfigureAwait(false);
+                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                 }
             }
         }

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -254,7 +254,7 @@ public partial class SqlServer : DatabaseClientBase
             }
         }
 
-        SqlConnection connection = ExecuteWithRetry(() =>
+        SqlConnection connection = ExecuteConnectionOpenWithRetry(() =>
         {
             var candidate = CreateConnection(connectionString);
             try
@@ -295,7 +295,7 @@ public partial class SqlServer : DatabaseClientBase
             }
         }
 
-        SqlConnection connection = await ExecuteWithRetryAsync(async () =>
+        SqlConnection connection = await ExecuteConnectionOpenWithRetryAsync(async () =>
         {
             var candidate = CreateConnection(connectionString);
             try
@@ -311,6 +311,78 @@ public partial class SqlServer : DatabaseClientBase
         }, cancellationToken).ConfigureAwait(false);
         return (connection, null, true);
     }
+
+    private T ExecuteConnectionOpenWithRetry<T>(Func<T> operation)
+    {
+        var attempts = 0;
+        Exception? lastException = null;
+        var maxAttempts = MaxRetryAttempts < 1 ? 1 : MaxRetryAttempts;
+        while (attempts < maxAttempts)
+        {
+            try
+            {
+                return operation();
+            }
+            catch (Exception ex) when (IsConnectionOpenTransient(ex))
+            {
+                lastException = ex;
+                attempts++;
+                if (attempts >= maxAttempts)
+                {
+                    break;
+                }
+
+                if (RetryDelay > TimeSpan.Zero)
+                {
+                    Thread.Sleep(RetryDelay);
+                }
+            }
+        }
+
+        throw lastException ?? new Exception("Operation failed.");
+    }
+
+    private async Task<T> ExecuteConnectionOpenWithRetryAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken)
+    {
+        var attempts = 0;
+        Exception? lastException = null;
+        var maxAttempts = MaxRetryAttempts < 1 ? 1 : MaxRetryAttempts;
+        while (attempts < maxAttempts)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                return await operation().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (IsConnectionOpenTransient(ex))
+            {
+                lastException = ex;
+                attempts++;
+                if (attempts >= maxAttempts)
+                {
+                    break;
+                }
+
+                if (RetryDelay > TimeSpan.Zero)
+                {
+                    await Task.Delay(RetryDelay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        throw lastException ?? new Exception("Operation failed.");
+    }
+
+    /// <summary>
+    /// Determines whether a connection-open failure is transient enough to retry.
+    /// </summary>
+    /// <param name="ex">The exception raised while opening the SQL Server connection.</param>
+    /// <returns><see langword="true" /> when opening the connection can be retried.</returns>
+    protected virtual bool IsConnectionOpenTransient(Exception ex) =>
+        IsTransient(ex)
+        || ex is SqlException sqlEx
+            && sqlEx.Number is -2 or 64 or 233 or 10053 or 10054 or 10060;
 
     /// <inheritdoc />
     protected override void AddParameters(DbCommand command, IDictionary<string, object?>? parameters, IDictionary<string, DbType>? parameterTypes = null, IDictionary<string, ParameterDirection>? parameterDirections = null)

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -254,17 +254,21 @@ public partial class SqlServer : DatabaseClientBase
             }
         }
 
-        var connection = CreateConnection(connectionString);
-        try
+        SqlConnection connection = ExecuteWithRetry(() =>
         {
-            OpenConnection(connection);
-            return (connection, null, true);
-        }
-        catch
-        {
-            DisposeConnection(connection);
-            throw;
-        }
+            var candidate = CreateConnection(connectionString);
+            try
+            {
+                OpenConnection(candidate);
+                return candidate;
+            }
+            catch
+            {
+                DisposeConnection(candidate);
+                throw;
+            }
+        });
+        return (connection, null, true);
     }
 
     private async Task<(SqlConnection Connection, SqlTransaction? Transaction, bool Dispose)> ResolveConnectionAsync(
@@ -291,17 +295,21 @@ public partial class SqlServer : DatabaseClientBase
             }
         }
 
-        var connection = CreateConnection(connectionString);
-        try
+        SqlConnection connection = await ExecuteWithRetryAsync(async () =>
         {
-            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
-            return (connection, null, true);
-        }
-        catch
-        {
-            await DisposeOwnedResourceAsync(connection, ownsResource: true, DisposeConnectionAsync).ConfigureAwait(false);
-            throw;
-        }
+            var candidate = CreateConnection(connectionString);
+            try
+            {
+                await OpenConnectionAsync(candidate, cancellationToken).ConfigureAwait(false);
+                return candidate;
+            }
+            catch
+            {
+                await DisposeOwnedResourceAsync(candidate, ownsResource: true, DisposeConnectionAsync).ConfigureAwait(false);
+                throw;
+            }
+        }, cancellationToken).ConfigureAwait(false);
+        return (connection, null, true);
     }
 
     /// <inheritdoc />

--- a/DbaClientX.Tests/ProviderRetryTests.cs
+++ b/DbaClientX.Tests/ProviderRetryTests.cs
@@ -67,6 +67,8 @@ public class ProviderRetryTests
     private class SqlServerRetryClient : DBAClientX.SqlServer
     {
         public T Run<T>(Func<T> operation) => ExecuteWithRetry(operation);
+        public bool IsConnectionOpenRetryable(Exception exception) => IsConnectionOpenTransient(exception);
+        public bool IsCommandRetryable(Exception exception) => IsTransient(exception);
     }
 
     private static SqlException CreateSqlException(int number)
@@ -105,21 +107,12 @@ public class ProviderRetryTests
     }
 
     [Fact]
-    public void SqlServer_RetriesConnectionTimeouts()
+    public void SqlServer_RetriesConnectionTimeoutsOnlyForConnectionOpen()
     {
-        using var client = new SqlServerRetryClient { MaxRetryAttempts = 3, RetryDelay = TimeSpan.Zero };
+        using var client = new SqlServerRetryClient();
         var exception = CreateSqlException(-2);
-        var attempts = 0;
-        var result = client.Run(() =>
-        {
-            if (++attempts < 3)
-            {
-                throw exception;
-            }
-            return 1;
-        });
-        Assert.Equal(1, result);
-        Assert.Equal(3, attempts);
+        Assert.True(client.IsConnectionOpenRetryable(exception));
+        Assert.False(client.IsCommandRetryable(exception));
     }
 
     private class SqliteRetryClient : DBAClientX.SQLite

--- a/DbaClientX.Tests/ProviderRetryTests.cs
+++ b/DbaClientX.Tests/ProviderRetryTests.cs
@@ -104,6 +104,24 @@ public class ProviderRetryTests
         Assert.Equal(3, attempts);
     }
 
+    [Fact]
+    public void SqlServer_RetriesConnectionTimeouts()
+    {
+        using var client = new SqlServerRetryClient { MaxRetryAttempts = 3, RetryDelay = TimeSpan.Zero };
+        var exception = CreateSqlException(-2);
+        var attempts = 0;
+        var result = client.Run(() =>
+        {
+            if (++attempts < 3)
+            {
+                throw exception;
+            }
+            return 1;
+        });
+        Assert.Equal(1, result);
+        Assert.Equal(3, attempts);
+    }
+
     private class SqliteRetryClient : DBAClientX.SQLite
     {
         public T Run<T>(Func<T> operation) => ExecuteWithRetry(operation);


### PR DESCRIPTION
## Summary
- retry SQL Server connection creation/open operations inside the existing provider retry pipeline
- include common SQL/network transient codes such as timeout, transport, and reset failures
- add retry coverage for SQL Server connection timeout handling

## Validation
- `dotnet test DbaClientX.Tests\DbaClientX.Tests.csproj --filter ProviderRetryTests`
