### PR TITLE
Add managed SQLite sessions

### DIFF
--- a/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
+++ b/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
@@ -23,6 +23,9 @@
                 <PackageReference Include="System.Formats.Asn1" />
                 <PackageReference Include="System.Text.Json" />
         </ItemGroup>
+        <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+                <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        </PropertyGroup>
         <ItemGroup>
                 <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
                 <ProjectReference Include="..\DbaClientX.SqlServer\DbaClientX.SqlServer.csproj" />

--- a/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
+++ b/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
@@ -25,6 +25,7 @@
         </ItemGroup>
         <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
                 <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+                <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
         </PropertyGroup>
         <ItemGroup>
                 <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />

--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX SQLite provider</Description>
     <AssemblyName>DbaClientX.SQLite</AssemblyName>
     <AssemblyTitle>DbaClientX.SQLite</AssemblyTitle>
-    <VersionPrefix>0.6.0</VersionPrefix>
+    <VersionPrefix>0.7.0</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
@@ -29,11 +29,16 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net10.0'">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" />
+    <PackageReference Include="SQLitePCLRaw.core" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="System.Collections" />

--- a/DbaClientX.SQLite/README.md
+++ b/DbaClientX.SQLite/README.md
@@ -3,7 +3,7 @@
 SQLite provider for DbaClientX (Microsoft.Data.Sqlite). Supports non-query, scalar, queries, streaming, transactions, bulk insert.
 Also includes SQLite maintenance helpers for WAL checkpointing, `PRAGMA optimize`, and graceful shutdown preparation.
 
-- Target Frameworks: `net8.0`, `net472`
+- Target Frameworks: `net472` (win-x64), `net8.0`, `net10.0`
 - NuGet: `DBAClientX.SQLite`
 
 ## Install

--- a/DbaClientX.SQLite/SQLite.Session.cs
+++ b/DbaClientX.SQLite/SQLite.Session.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using Microsoft.Data.Sqlite;
+
+namespace DBAClientX;
+
+public partial class SQLite
+{
+    /// <summary>
+    /// Opens a managed SQLite session that reuses one connection for a sequence of commands.
+    /// </summary>
+    /// <param name="database">Absolute or relative path of the SQLite database file.</param>
+    /// <returns>A session that owns the underlying provider connection.</returns>
+    /// <remarks>
+    /// Use this for workflows that require connection-local state such as attached databases,
+    /// temporary tables, or explicit transaction blocks without exposing provider objects.
+    /// </remarks>
+    public virtual SQLiteSession OpenSession(string database)
+    {
+        var connectionString = BuildOperationalConnectionString(database);
+        SqliteConnection? connection = null;
+        try
+        {
+            (connection, _, _) = ResolveConnection(connectionString, useTransaction: false);
+            return new SQLiteSession(this, connection);
+        }
+        catch
+        {
+            connection?.Dispose();
+            throw;
+        }
+    }
+
+    internal int ExecuteSessionNonQuery(
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        string query,
+        IDictionary<string, object?>? parameters)
+    {
+        ValidateCommandText(query);
+        try
+        {
+            return ExecuteNonQuery(connection, transaction, query, parameters);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+        }
+    }
+
+    internal object? ExecuteSessionScalar(
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        string query,
+        IDictionary<string, object?>? parameters)
+    {
+        ValidateCommandText(query);
+        try
+        {
+            return ExecuteScalar(connection, transaction, query, parameters);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
+        }
+    }
+
+    internal IReadOnlyList<T> ExecuteSessionQueryAsList<T>(
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters,
+        Action<IDataRecord>? initialize)
+    {
+        ValidateCommandText(query);
+        if (map == null)
+        {
+            throw new ArgumentNullException(nameof(map));
+        }
+
+        try
+        {
+            return ExecuteWithRetry(() =>
+            {
+                using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = query;
+                AddParameters(command, parameters);
+                var commandTimeout = CommandTimeout;
+                if (commandTimeout > 0)
+                {
+                    command.CommandTimeout = commandTimeout;
+                }
+
+                using var reader = command.ExecuteReader(CommandBehavior.Default);
+                initialize?.Invoke(reader);
+
+                List<T> results = new();
+                while (reader.Read())
+                {
+                    results.Add(map(reader));
+                }
+
+                UpdateOutputParameters(command, parameters);
+                return (IReadOnlyList<T>)results;
+            });
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
+        }
+    }
+
+    internal TResult ExecuteSessionTransaction<TResult>(
+        SqliteConnection connection,
+        Func<SQLiteSession, TResult> operation)
+    {
+        if (operation == null)
+        {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+        using SqliteTransaction transaction = connection.BeginTransaction();
+        SQLiteSession transactionSession = new(this, connection, transaction);
+        try
+        {
+            TResult result = operation(transactionSession);
+            transaction.Commit();
+            return result;
+        }
+        catch
+        {
+            transaction.Rollback();
+            throw;
+        }
+    }
+}

--- a/DbaClientX.SQLite/SQLite.Session.cs
+++ b/DbaClientX.SQLite/SQLite.Session.cs
@@ -43,7 +43,7 @@ public partial class SQLite
         {
             return ExecuteNonQuery(connection, transaction, query, parameters);
         }
-        catch (Exception ex)
+        catch (SqliteException ex)
         {
             throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
         }
@@ -60,7 +60,7 @@ public partial class SQLite
         {
             return ExecuteScalar(connection, transaction, query, parameters);
         }
-        catch (Exception ex)
+        catch (SqliteException ex)
         {
             throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
         }
@@ -107,7 +107,7 @@ public partial class SQLite
                 return (IReadOnlyList<T>)results;
             });
         }
-        catch (Exception ex)
+        catch (SqliteException ex)
         {
             throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
         }

--- a/DbaClientX.SQLite/SQLiteSession.cs
+++ b/DbaClientX.SQLite/SQLiteSession.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using Microsoft.Data.Sqlite;
+
+namespace DBAClientX;
+
+/// <summary>
+/// Represents a SQLite connection session owned and managed by <see cref="SQLite"/>.
+/// </summary>
+/// <remarks>
+/// The session keeps provider-specific connection and transaction objects inside DBAClientX while
+/// allowing callers to run related commands against the same SQLite connection.
+/// </remarks>
+public sealed class SQLiteSession : IDisposable
+{
+    private readonly SQLite _client;
+    private readonly SqliteConnection _connection;
+    private readonly SqliteTransaction? _transaction;
+    private readonly bool _ownsConnection;
+    private bool _disposed;
+
+    internal SQLiteSession(SQLite client, SqliteConnection connection)
+        : this(client, connection, transaction: null, ownsConnection: true)
+    {
+    }
+
+    internal SQLiteSession(SQLite client, SqliteConnection connection, SqliteTransaction transaction)
+        : this(client, connection, transaction, ownsConnection: false)
+    {
+    }
+
+    private SQLiteSession(
+        SQLite client,
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        bool ownsConnection)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        _transaction = transaction;
+        _ownsConnection = ownsConnection;
+    }
+
+    /// <summary>
+    /// Executes a SQL statement that does not return rows using this session's connection.
+    /// </summary>
+    /// <param name="query">SQL command text.</param>
+    /// <param name="parameters">Optional parameter values.</param>
+    /// <returns>The number of rows affected by the command.</returns>
+    public int ExecuteNonQuery(string query, IDictionary<string, object?>? parameters = null)
+    {
+        ThrowIfDisposed();
+        return _client.ExecuteSessionNonQuery(_connection, _transaction, query, parameters);
+    }
+
+    /// <summary>
+    /// Executes a SQL statement and returns the first column of the first row.
+    /// </summary>
+    /// <param name="query">SQL command text.</param>
+    /// <param name="parameters">Optional parameter values.</param>
+    /// <returns>The scalar value returned by the provider.</returns>
+    public object? ExecuteScalar(string query, IDictionary<string, object?>? parameters = null)
+    {
+        ThrowIfDisposed();
+        return _client.ExecuteSessionScalar(_connection, _transaction, query, parameters);
+    }
+
+    /// <summary>
+    /// Executes a query and maps each row through a provider-neutral <see cref="IDataRecord"/>.
+    /// </summary>
+    /// <typeparam name="T">The row projection type.</typeparam>
+    /// <param name="query">SQL query text.</param>
+    /// <param name="map">Mapping callback invoked for each row.</param>
+    /// <param name="parameters">Optional parameter values.</param>
+    /// <param name="initialize">Optional callback invoked once after the reader opens.</param>
+    /// <returns>The mapped rows.</returns>
+    public IReadOnlyList<T> QueryAsList<T>(
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        Action<IDataRecord>? initialize = null)
+    {
+        ThrowIfDisposed();
+        return _client.ExecuteSessionQueryAsList(_connection, _transaction, query, map, parameters, initialize);
+    }
+
+    /// <summary>
+    /// Runs a group of operations inside one SQLite transaction using this session's connection.
+    /// </summary>
+    /// <typeparam name="TResult">The operation result type.</typeparam>
+    /// <param name="operation">Callback that receives a transaction-bound session.</param>
+    /// <returns>The callback result after the transaction commits.</returns>
+    public TResult RunInTransaction<TResult>(Func<SQLiteSession, TResult> operation)
+    {
+        ThrowIfDisposed();
+        if (_transaction != null)
+        {
+            throw new DbaTransactionException("A session transaction is already active.");
+        }
+
+        return _client.ExecuteSessionTransaction(_connection, operation);
+    }
+
+    /// <summary>
+    /// Runs a group of operations inside one SQLite transaction using this session's connection.
+    /// </summary>
+    /// <param name="operation">Callback that receives a transaction-bound session.</param>
+    public void RunInTransaction(Action<SQLiteSession> operation)
+    {
+        if (operation == null)
+        {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+        RunInTransaction(session =>
+        {
+            operation(session);
+            return true;
+        });
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        if (_ownsConnection)
+        {
+            _connection.Dispose();
+        }
+
+        _disposed = true;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+        {
+            throw new ObjectDisposedException(nameof(SQLiteSession));
+        }
+    }
+}

--- a/DbaClientX.Tests/SQLiteSessionTests.cs
+++ b/DbaClientX.Tests/SQLiteSessionTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using DBAClientX;
+
+namespace DbaClientX.Tests;
+
+public class SQLiteSessionTests
+{
+    [Fact]
+    public void OpenSession_ReusesConnectionForAttachedDatabase()
+    {
+        string primary = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.db");
+        string legacy = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.db");
+        try
+        {
+            using var sqlite = new SQLite();
+            sqlite.ExecuteNonQuery(legacy, "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL);");
+            sqlite.ExecuteNonQuery(legacy, "INSERT INTO items (name) VALUES ($name);", new Dictionary<string, object?> { ["$name"] = "legacy" });
+
+            using SQLiteSession session = sqlite.OpenSession(primary);
+            session.ExecuteNonQuery("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL);");
+            session.ExecuteNonQuery("ATTACH DATABASE $path AS legacy;", new Dictionary<string, object?> { ["$path"] = legacy });
+            session.ExecuteNonQuery("INSERT INTO items (name) SELECT name FROM legacy.items;");
+            session.ExecuteNonQuery("DETACH DATABASE legacy;");
+
+            IReadOnlyList<string> rows = session.QueryAsList(
+                "SELECT name FROM items ORDER BY id;",
+                row => row.GetString(0));
+
+            Assert.Equal(["legacy"], rows);
+        }
+        finally
+        {
+            Cleanup(primary);
+            Cleanup(legacy);
+        }
+    }
+
+    [Fact]
+    public void RunInTransaction_RollsBackWhenOperationFails()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.db");
+        try
+        {
+            using var sqlite = new SQLite();
+            using SQLiteSession session = sqlite.OpenSession(path);
+            session.ExecuteNonQuery("CREATE TABLE items (name TEXT NOT NULL);");
+
+            Assert.Throws<InvalidOperationException>(() =>
+                session.RunInTransaction(tx =>
+                {
+                    tx.ExecuteNonQuery("INSERT INTO items (name) VALUES ($name);", new Dictionary<string, object?> { ["$name"] = "temp" });
+                    throw new InvalidOperationException("stop");
+                }));
+
+            object? count = session.ExecuteScalar("SELECT COUNT(*) FROM items;");
+            Assert.Equal(0L, count);
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    private static void Cleanup(string path)
+    {
+        TryDelete(path);
+        TryDelete(path + "-wal");
+        TryDelete(path + "-shm");
+    }
+
+    private static void TryDelete(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/DbaClientX.Tests/SQLiteSessionTests.cs
+++ b/DbaClientX.Tests/SQLiteSessionTests.cs
@@ -10,8 +10,8 @@ public class SQLiteSessionTests
     [Fact]
     public void OpenSession_ReusesConnectionForAttachedDatabase()
     {
-        string primary = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.db");
-        string legacy = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.db");
+        string primary = Path.Join(Path.GetTempPath(), Path.GetFileName($"{Guid.NewGuid():N}.db"));
+        string legacy = Path.Join(Path.GetTempPath(), Path.GetFileName($"{Guid.NewGuid():N}.db"));
         try
         {
             using var sqlite = new SQLite();
@@ -40,7 +40,7 @@ public class SQLiteSessionTests
     [Fact]
     public void RunInTransaction_RollsBackWhenOperationFails()
     {
-        string path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.db");
+        string path = Path.Join(Path.GetTempPath(), Path.GetFileName($"{Guid.NewGuid():N}.db"));
         try
         {
             using var sqlite = new SQLite();

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
@@ -18,6 +18,8 @@
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.26.200" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.8" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.3" />
     <PackageVersion Include="System.Formats.Asn1" Version="10.0.5" />
     <PackageVersion Include="System.Text.Json" Version="10.0.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -91,7 +91,7 @@
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
 
     New-ConfigurationImportModule -ImportSelf -ImportRequiredModules -SkipBinaryDependencyCheck
 

--- a/Module/DbaClientX.psm1
+++ b/Module/DbaClientX.psm1
@@ -143,7 +143,12 @@ $FoundErrors = @(
             continue
         }
 
-        $ImportAssemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($Import.FullName)
+        try {
+            $ImportAssemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($Import.FullName)
+        } catch [System.BadImageFormatException] {
+            continue
+        }
+
         if ($LoadedAssemblyVersions.ContainsKey($ImportAssemblyName.Name) -and
             $LoadedAssemblyVersions[$ImportAssemblyName.Name] -ge $ImportAssemblyName.Version) {
             continue


### PR DESCRIPTION
## Summary
- add managed SQLite sessions so consumers can reuse one connection without touching provider objects
- expose session query, scalar, non-query, and transaction helpers with provider-neutral row mapping
- bump SQLite provider packaging to 0.7.0 and current SQLitePCLRaw/Microsoft.Data.Sqlite dependencies

## Validation
- dotnet pack DbaClientX.SQLite\DbaClientX.SQLite.csproj -c Release -o C:\Support\GitHub\DbaClientX\artifacts\local-packages
- dotnet test DbaClientX.Tests\DbaClientX.Tests.csproj -c Release --filter "SQLiteSessionTests|SqliteTests|SQLiteMappedQueryTests"
- dotnet list DbaClientX.SQLite\DbaClientX.SQLite.csproj package --include-transitive --vulnerable