### PR TITLE
Fix packaged provider runtime and module build flow

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -69,6 +69,10 @@ jobs:
               shell: powershell
               run: |
                   Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+                  if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+                      Register-PSRepository -Default
+                  }
+                  Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
                   Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
                   Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
 

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXNonQuery.cs
@@ -10,15 +10,27 @@ namespace DBAClientX.PowerShell;
 /// </item>
 /// </list>
 /// <example>
-/// <summary>Delete rows from a table.</summary>
+/// <summary>Create and populate a local temporary table.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>Invoke-DbaXNonQuery -Server 'sqlsrv' -Database 'app' -Query 'DELETE FROM Users WHERE Disabled = 1'</code>
-/// <para>Removes disabled users and outputs the number of rows deleted.</para>
+/// <code>$sql = @'
+/// CREATE TABLE #DbaClientXDemo
+/// (
+///     Id int NOT NULL,
+///     Name nvarchar(50) NOT NULL
+/// );
+///
+/// INSERT INTO #DbaClientXDemo (Id, Name)
+/// VALUES (1, N'Alpha'), (2, N'Beta');
+/// '@
+///
+/// Invoke-DbaXNonQuery -Server 'localhost' -Database 'master' -TrustServerCertificate -Query $sql</code>
+/// <para>Executes a multi-line command and returns the number of affected rows.</para>
 /// </example>
 /// <example>
 /// <summary>Run a command with SQL authentication.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>Invoke-DbaXNonQuery -Server 'sqlsrv' -Database 'app' -Query 'TRUNCATE TABLE Logs' -Username 'user' -Password 'p@ss'</code>
+/// <code>$credential = Get-Credential 'app_writer'
+/// Invoke-DbaXNonQuery -Server 'sql01' -Database 'app' -Query 'UPDATE dbo.Users SET LastSeenUtc = SYSUTCDATETIME() WHERE Id = @Id' -Credential $credential -Parameters @{ Id = 42 }</code>
 /// <para>Executes the statement using the supplied credentials.</para>
 /// </example>
 /// <seealso href="https://learn.microsoft.com/dotnet/framework/data/adonet/using-sqlclient">Using SqlClient</seealso>
@@ -65,6 +77,10 @@ public sealed class CmdletIInvokeDbaXNonQuery : PSCmdlet {
     [Credential]
     public PSCredential? Credential { get; set; }
 
+    /// <summary>Trusts the SQL Server TLS certificate without validating the certificate chain.</summary>
+    [Parameter(Mandatory = false, ParameterSetName = "DefaultCredentials")]
+    public SwitchParameter TrustServerCertificate { get; set; }
+
     private ActionPreference ErrorAction;
 
     /// <summary>
@@ -97,14 +113,20 @@ public sealed class CmdletIInvokeDbaXNonQuery : PSCmdlet {
             }
 
             var (resolvedUsername, resolvedPassword, integratedSecurity) = PowerShellHelpers.ResolveSqlServerCredential(Username, Password, Credential);
-            var connectionString = DBAClientX.SqlServer.BuildConnectionString(Server, Database, integratedSecurity, resolvedUsername, resolvedPassword);
+            var connectionString = DBAClientX.SqlServer.BuildConnectionString(
+                Server,
+                Database,
+                integratedSecurity,
+                resolvedUsername,
+                resolvedPassword,
+                trustServerCertificate: TrustServerCertificate.IsPresent);
             if (!PowerShellHelpers.TryValidateConnection(this, "sqlserver", connectionString, ErrorAction))
             {
                 return;
             }
 
             using var sqlServer = CreateSqlServer();
-            var affected = sqlServer.ExecuteNonQuery(Server, Database, integratedSecurity, Query, parameters, username: resolvedUsername, password: resolvedPassword);
+            var affected = sqlServer.ExecuteNonQuery(connectionString, Query, parameters);
             WriteObject(affected);
         } catch (Exception ex) {
             WriteWarning($"Invoke-DbaXNonQuery - Error querying SqlServer: {ex.Message}");

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -15,13 +15,24 @@ namespace DBAClientX.PowerShell;
 /// <example>
 /// <summary>Run a query with integrated security.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>Invoke-DbaXQuery -Server 'sqlsrv' -Database 'app' -Query 'SELECT * FROM Users'</code>
-/// <para>Executes the query and returns each row as a <see cref="DataRow"/>.</para>
+/// <code>$rows = Invoke-DbaXQuery -Server 'localhost' -Database 'master' -TrustServerCertificate -Query @'
+/// SELECT
+///     name,
+///     database_id,
+///     create_date
+/// FROM sys.databases
+/// WHERE database_id &gt; 4
+/// ORDER BY name;
+/// '@
+///
+/// $rows | Format-Table name, database_id, create_date</code>
+/// <para>Executes a multi-line query against a local SQL Server instance and returns each row as a <see cref="DataRow"/>.</para>
 /// </example>
 /// <example>
 /// <summary>Execute a stored procedure using credentials.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>Invoke-DbaXQuery -Server 'sqlsrv' -Database 'app' -StoredProcedure 'usp_DoWork' -Username 'user' -Password 'p@ss' -ReturnType DataTable</code>
+/// <code>$credential = Get-Credential 'app_reader'
+/// Invoke-DbaXQuery -Server 'sql01' -Database 'app' -StoredProcedure 'dbo.usp_GetActiveUsers' -Credential $credential -ReturnType DataTable</code>
 /// <para>Runs the stored procedure and outputs a <see cref="DataTable"/>.</para>
 /// </example>
 /// <seealso href="https://learn.microsoft.com/dotnet/framework/data/adonet/using-sqlclient">Using SqlClient</seealso>
@@ -94,6 +105,11 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     [Credential]
     public PSCredential? Credential { get; set; }
+
+    /// <summary>Trusts the SQL Server TLS certificate without validating the certificate chain.</summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
+    public SwitchParameter TrustServerCertificate { get; set; }
 
     private ActionPreference ErrorAction;
 
@@ -185,7 +201,13 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
             }
 
             var (resolvedUsername, resolvedPassword, integratedSecurity) = PowerShellHelpers.ResolveSqlServerCredential(Username, Password, Credential);
-            var connectionString = DBAClientX.SqlServer.BuildConnectionString(Server, Database, integratedSecurity, resolvedUsername, resolvedPassword);
+            var connectionString = DBAClientX.SqlServer.BuildConnectionString(
+                Server,
+                Database,
+                integratedSecurity,
+                resolvedUsername,
+                resolvedPassword,
+                trustServerCertificate: TrustServerCertificate.IsPresent);
             if (!PowerShellHelpers.TryValidateConnection(this, "sqlserver", connectionString, ErrorAction))
             {
                 return;
@@ -198,12 +220,12 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
                 {
                     var dbParameters = PowerShellHelpers.ToDbParameters(parameters, static (name, value) => (DbParameter)new SqlParameter(name, value ?? DBNull.Value));
                     using var sqlServer = CreateSqlServer();
-                    await WriteRowsAsync(sqlServer.ExecuteStoredProcedureStreamAsync(Server, Database, integratedSecurity, StoredProcedure, dbParameters, cancellationToken: CancelToken, username: resolvedUsername, password: resolvedPassword)).ConfigureAwait(false);
+                    await WriteRowsAsync(sqlServer.ExecuteStoredProcedureStreamAsync(connectionString, StoredProcedure, dbParameters, cancellationToken: CancelToken)).ConfigureAwait(false);
                     return;
                 }
 
                 using var streamSqlServer = CreateSqlServer();
-                await WriteRowsAsync(streamSqlServer.QueryStreamAsync(Server, Database, integratedSecurity, Query, parameters, cancellationToken: CancelToken, username: resolvedUsername, password: resolvedPassword)).ConfigureAwait(false);
+                await WriteRowsAsync(streamSqlServer.QueryStreamAsync(connectionString, Query, parameters, cancellationToken: CancelToken)).ConfigureAwait(false);
                 return;
             }
 #endif
@@ -211,10 +233,10 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
             if (!string.IsNullOrEmpty(StoredProcedure)) {
                 var dbParameters = PowerShellHelpers.ToDbParameters(parameters, static (name, value) => (DbParameter)new SqlParameter(name, value ?? DBNull.Value));
                 using var sqlServer = CreateSqlServer();
-                result = sqlServer.ExecuteStoredProcedure(Server, Database, integratedSecurity, StoredProcedure, dbParameters, username: resolvedUsername, password: resolvedPassword);
+                result = sqlServer.ExecuteStoredProcedure(connectionString, StoredProcedure, dbParameters);
             } else {
                 using var sqlServer = CreateSqlServer();
-                result = sqlServer.Query(Server, Database, integratedSecurity, Query, parameters, username: resolvedUsername, password: resolvedPassword);
+                result = sqlServer.Query(connectionString, Query, parameters);
             }
             if (result != null) {
                 if (ReturnType == ReturnType.PSObject) {

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
@@ -13,13 +13,29 @@ namespace DBAClientX.PowerShell;
 /// <example>
 /// <summary>Query MySQL with credentials.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>Invoke-DbaXMySql -Server 'mysqlsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'SELECT * FROM Users'</code>
-/// <para>Returns each row as a <see cref="DataRow"/>.</para>
+/// <code>$credential = Get-Credential 'app_reader'
+/// Invoke-DbaXMySql -Server 'mysql01' -Database 'app' -Credential $credential -Query @'
+/// SELECT
+///     id,
+///     email,
+///     created_at
+/// FROM users
+/// WHERE is_active = 1
+/// ORDER BY created_at DESC
+/// LIMIT 25;
+/// '@</code>
+/// <para>Returns recent active users as <see cref="DataRow"/> objects.</para>
 /// </example>
 /// <example>
 /// <summary>Stream results as they arrive.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>Invoke-DbaXMySql -Server 'mysqlsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'SELECT * FROM Logs' -Stream</code>
+/// <code>$credential = Get-Credential 'app_reader'
+/// Invoke-DbaXMySql -Server 'mysql01' -Database 'app' -Credential $credential -Query @'
+/// SELECT id, message, created_at
+/// FROM audit_log
+/// ORDER BY created_at DESC
+/// LIMIT 1000;
+/// '@ -Stream</code>
 /// <para>Streams rows without buffering the entire result.</para>
 /// </example>
 /// <seealso href="https://learn.microsoft.com/ef/core/providers/?tabs=dotnet-core-cli#mysql">MySQL provider on MS Learn</seealso>

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySqlScalar.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySqlScalar.cs
@@ -5,7 +5,12 @@ namespace DBAClientX.PowerShell;
 /// <example>
 /// <summary>Get a single value.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>Invoke-DbaXMySqlScalar -Server 'mysqlsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'SELECT COUNT(*) FROM Users'</code>
+/// <code>$credential = Get-Credential 'app_reader'
+/// Invoke-DbaXMySqlScalar -Server 'mysql01' -Database 'app' -Credential $credential -Query @'
+/// SELECT COUNT(*)
+/// FROM users
+/// WHERE is_active = 1;
+/// '@</code>
 /// <para>Returns the number of users.</para>
 /// </example>
 [Cmdlet(VerbsLifecycle.Invoke, "DbaXMySqlScalar", SupportsShouldProcess = true)]
@@ -94,22 +99,10 @@ public sealed class CmdletInvokeDbaXMySqlScalar : AsyncPSCmdlet {
             }
             switch (ReturnType) {
                 case ReturnType.DataTable:
-                    DataTable table = new DataTable();
-                    table.Columns.Add("Value", result?.GetType() ?? typeof(object));
-                    var tableRow = table.NewRow();
-                    tableRow[0] = result;
-                    table.Rows.Add(tableRow);
-                    WriteObject(table);
+                    WriteObject(CreateScalarTable(result));
                     break;
                 case ReturnType.DataSet:
-                    DataTable dataTable = new DataTable();
-                    dataTable.Columns.Add("Value", result?.GetType() ?? typeof(object));
-                    var dataRow = dataTable.NewRow();
-                    dataRow[0] = result;
-                    dataTable.Rows.Add(dataRow);
-                    DataSet set = new DataSet();
-                    set.Tables.Add(dataTable);
-                    WriteObject(set);
+                    WriteObject(CreateScalarDataSet(result));
                     break;
                 case ReturnType.PSObject:
                     var psObj = new PSObject();
@@ -117,12 +110,7 @@ public sealed class CmdletInvokeDbaXMySqlScalar : AsyncPSCmdlet {
                     WriteObject(psObj);
                     break;
                 default:
-                    DataTable dt = new DataTable();
-                    dt.Columns.Add("Value", result?.GetType() ?? typeof(object));
-                    var row = dt.NewRow();
-                    row[0] = result;
-                    dt.Rows.Add(row);
-                    WriteObject(row);
+                    WriteObject(CreateScalarRow(result));
                     break;
             }
         } catch (Exception ex) {
@@ -132,4 +120,23 @@ public sealed class CmdletInvokeDbaXMySqlScalar : AsyncPSCmdlet {
             }
         }
     }
+
+    private static DataSet CreateScalarDataSet(object? result)
+    {
+        var set = new DataSet();
+        set.Tables.Add(CreateScalarTable(result));
+        return set;
+    }
+
+    private static DataTable CreateScalarTable(object? result)
+    {
+        var table = new DataTable();
+        table.Columns.Add("Value", result?.GetType() ?? typeof(object));
+        var row = table.NewRow();
+        row[0] = result;
+        table.Rows.Add(row);
+        return table;
+    }
+
+    private static DataRow CreateScalarRow(object? result) => CreateScalarTable(result).Rows[0];
 }

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXOracle.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXOracle.cs
@@ -12,13 +12,25 @@ namespace DBAClientX.PowerShell;
 /// <example>
 /// <summary>Query Oracle with credentials.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>Invoke-DbaXOracle -Server 'oraclesrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'SELECT * FROM Users'</code>
-/// <para>Returns each row as a <see cref="DataRow"/>.</para>
+/// <code>$credential = Get-Credential 'app_reader'
+/// Invoke-DbaXOracle -Server 'oracle01' -Database 'ORCLPDB1' -Credential $credential -Query @'
+/// SELECT
+///     USER AS ConnectedUser,
+///     SYS_CONTEXT('USERENV', 'SERVICE_NAME') AS ServiceName
+/// FROM dual
+/// '@</code>
+/// <para>Returns Oracle session context as <see cref="DataRow"/> objects.</para>
 /// </example>
 /// <example>
 /// <summary>Stream results as they arrive.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>Invoke-DbaXOracle -Server 'oraclesrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'SELECT * FROM Logs' -Stream</code>
+/// <code>$credential = Get-Credential 'app_reader'
+/// Invoke-DbaXOracle -Server 'oracle01' -Database 'ORCLPDB1' -Credential $credential -Query @'
+/// SELECT owner, table_name
+/// FROM all_tables
+/// WHERE owner = USER
+/// ORDER BY table_name
+/// '@ -Stream</code>
 /// <para>Streams rows without buffering the entire result.</para>
 /// </example>
 /// <seealso href="https://learn.microsoft.com/dotnet/standard/data/sqlite/?tabs=netcore-cli">Oracle provider documentation</seealso>

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSql.cs
@@ -15,13 +15,20 @@ namespace DBAClientX.PowerShell;
 /// <example>
 /// <summary>Run a query using explicit credentials.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>Invoke-DbaXPostgreSql -Server 'pgsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'SELECT * FROM data'</code>
+/// <code>$credential = Get-Credential 'app_reader'
+/// Invoke-DbaXPostgreSql -Server 'pg01' -Database 'app' -Credential $credential -Query @'
+/// SELECT
+///     current_database() AS database_name,
+///     current_user AS connected_as,
+///     version() AS server_version;
+/// '@</code>
 /// <para>Executes the query and returns each row as a <see cref="DataRow"/>.</para>
 /// </example>
 /// <example>
 /// <summary>Execute a stored procedure and get a DataTable.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>Invoke-DbaXPostgreSql -Server 'pgsrv' -Database 'app' -Username 'user' -Password 'p@ss' -StoredProcedure 'refresh_stats' -ReturnType DataTable</code>
+/// <code>$credential = Get-Credential 'app_writer'
+/// Invoke-DbaXPostgreSql -Server 'pg01' -Database 'app' -Credential $credential -StoredProcedure 'refresh_stats' -ReturnType DataTable</code>
 /// <para>Runs the stored procedure and outputs a <see cref="DataTable"/>.</para>
 /// </example>
 /// <seealso href="https://learn.microsoft.com/ef/core/providers/npgsql/">Npgsql provider on MS Learn</seealso>

--- a/DbaClientX.PowerShell/OnImportAndRemove.cs
+++ b/DbaClientX.PowerShell/OnImportAndRemove.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
 using System.Reflection;
 using System.Threading;
 #if NET5_0_OR_GREATER
+using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using System.Runtime.Versioning;
 #endif
 
 /// <summary>
@@ -27,6 +30,7 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
 #if NET5_0_OR_GREATER
         else {
             RegisterDefaultAlcResolver();
+            PreloadRuntimeManagedAssemblies();
         }
 #endif
     }
@@ -106,6 +110,8 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         typeof(OnModuleImportAndRemove).Assembly.Location)!;
 
     private static readonly ModuleLoadContext _alc = new ModuleLoadContext(_assemblyDir);
+    private static readonly FrameworkName _currentTargetFramework = GetCurrentTargetFramework();
+    private static int _runtimeManagedAssembliesPreloaded;
 
     /// <summary>
     /// Gets the module's dedicated AssemblyLoadContext used for resolving dependent assemblies.
@@ -121,6 +127,236 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
     private static void UnregisterDefaultAlcResolver() {
         if (Interlocked.CompareExchange(ref _defaultAlcResolvingRegistered, 0, 1) == 1) {
             AssemblyLoadContext.Default.Resolving -= ResolveAlc;
+        }
+    }
+
+    private static void PreloadRuntimeManagedAssemblies() {
+        if (Interlocked.CompareExchange(ref _runtimeManagedAssembliesPreloaded, 1, 0) != 0) {
+            return;
+        }
+
+        var moduleAlc = AssemblyLoadContext.GetLoadContext(typeof(OnModuleImportAndRemove).Assembly);
+        if (moduleAlc == null || string.IsNullOrWhiteSpace(_assemblyDir) || !Directory.Exists(_assemblyDir)) {
+            return;
+        }
+
+        var loaded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var assembly in moduleAlc.Assemblies) {
+            var name = assembly.GetName().Name;
+            if (!string.IsNullOrWhiteSpace(name)) {
+                loaded.Add(name);
+            }
+        }
+
+        foreach (var runtimeDirectory in GetRuntimeManagedLibraryDirectories()) {
+            if (!Directory.Exists(runtimeDirectory)) {
+                continue;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(runtimeDirectory, "*.dll", SearchOption.TopDirectoryOnly)) {
+                try {
+                    var assemblyName = AssemblyName.GetAssemblyName(file);
+                    if (string.IsNullOrWhiteSpace(assemblyName.Name) || loaded.Contains(assemblyName.Name)) {
+                        continue;
+                    }
+
+                    var rootAssemblyPath = Path.Combine(_assemblyDir, assemblyName.Name + ".dll");
+                    if (!File.Exists(rootAssemblyPath)) {
+                        continue;
+                    }
+
+                    moduleAlc.LoadFromAssemblyPath(file);
+                    loaded.Add(assemblyName.Name);
+                } catch (Exception ex) when (ex is BadImageFormatException || ex is FileLoadException || ex is FileNotFoundException) {
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetRuntimeManagedLibraryDirectories() {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var rid in GetRuntimeIdentifiers()) {
+            var ridRoot = Path.Combine(_assemblyDir, "runtimes", rid, "lib");
+            if (!Directory.Exists(ridRoot)) {
+                continue;
+            }
+
+            foreach (var directory in GetCompatibleRuntimeLibraryDirectories(ridRoot)) {
+                if (seen.Add(directory)) {
+                    yield return directory;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetCompatibleRuntimeLibraryDirectories(string ridRoot) {
+        return Directory.EnumerateDirectories(ridRoot)
+            .Select(directory => new
+            {
+                Directory = directory,
+                Score = GetFrameworkCompatibilityScore(Path.GetFileName(directory))
+            })
+            .Where(candidate => candidate.Score >= 0)
+            .OrderByDescending(candidate => candidate.Score)
+            .ThenBy(candidate => candidate.Directory, StringComparer.OrdinalIgnoreCase)
+            .Select(candidate => candidate.Directory);
+    }
+
+    private static int GetFrameworkCompatibilityScore(string? targetFrameworkMoniker) {
+        var candidate = ParseTargetFrameworkMoniker(targetFrameworkMoniker);
+        if (candidate == null) {
+            return -1;
+        }
+
+        if (string.Equals(candidate.Identifier, _currentTargetFramework.Identifier, StringComparison.OrdinalIgnoreCase) &&
+            candidate.Version.CompareTo(_currentTargetFramework.Version) <= 0) {
+            return 300_000 + GetVersionScore(candidate.Version);
+        }
+
+        if (string.Equals(candidate.Identifier, ".NETStandard", StringComparison.OrdinalIgnoreCase) &&
+            IsNetStandardSupported(candidate.Version)) {
+            return 100_000 + GetVersionScore(candidate.Version);
+        }
+
+        return -1;
+    }
+
+    private static FrameworkName GetCurrentTargetFramework() {
+        var frameworkName = typeof(OnModuleImportAndRemove)
+            .Assembly
+            .GetCustomAttribute<TargetFrameworkAttribute>()?
+            .FrameworkName;
+
+        if (!string.IsNullOrWhiteSpace(frameworkName)) {
+            return new FrameworkName(frameworkName);
+        }
+
+        return new FrameworkName($".NETCoreApp,Version=v{Environment.Version.Major}.{Environment.Version.Minor}");
+    }
+
+    private static FrameworkName? ParseTargetFrameworkMoniker(string? targetFrameworkMoniker) {
+        if (string.IsNullOrWhiteSpace(targetFrameworkMoniker)) {
+            return null;
+        }
+
+        var tfm = targetFrameworkMoniker.Split('-')[0];
+        if (tfm.StartsWith("netstandard", StringComparison.OrdinalIgnoreCase) &&
+            TryParseVersion(tfm.Substring("netstandard".Length), out var netStandardVersion)) {
+            return new FrameworkName(".NETStandard", netStandardVersion);
+        }
+
+        if (tfm.StartsWith("netcoreapp", StringComparison.OrdinalIgnoreCase) &&
+            TryParseVersion(tfm.Substring("netcoreapp".Length), out var netCoreVersion)) {
+            return new FrameworkName(".NETCoreApp", netCoreVersion);
+        }
+
+        if (tfm.StartsWith("net", StringComparison.OrdinalIgnoreCase)) {
+            var versionText = tfm.Substring("net".Length);
+            if (TryParseVersion(versionText, out var netVersion)) {
+                return netVersion.Major >= 5
+                    ? new FrameworkName(".NETCoreApp", netVersion)
+                    : new FrameworkName(".NETFramework", netVersion);
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryParseVersion(string versionText, out Version version) {
+        version = new Version(0, 0);
+        if (string.IsNullOrWhiteSpace(versionText)) {
+            return false;
+        }
+
+        if (versionText.IndexOf('.') >= 0) {
+            return Version.TryParse(versionText, out version!);
+        }
+
+        if (versionText.Length == 2 &&
+            char.IsDigit(versionText[0]) &&
+            char.IsDigit(versionText[1])) {
+            version = new Version(versionText[0] - '0', versionText[1] - '0');
+            return true;
+        }
+
+        if (versionText.Length == 3 &&
+            char.IsDigit(versionText[0]) &&
+            char.IsDigit(versionText[1]) &&
+            char.IsDigit(versionText[2])) {
+            version = new Version(versionText[0] - '0', versionText[1] - '0', versionText[2] - '0');
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsNetStandardSupported(Version version) {
+        return string.Equals(_currentTargetFramework.Identifier, ".NETCoreApp", StringComparison.OrdinalIgnoreCase) &&
+            _currentTargetFramework.Version.Major >= 5 &&
+            version.CompareTo(new Version(2, 1)) <= 0;
+    }
+
+    private static int GetVersionScore(Version version) {
+        return (version.Major * 10_000) + (version.Minor * 100) + Math.Max(version.Build, 0);
+    }
+
+    private static IEnumerable<string> GetRuntimeIdentifiers() {
+        return GetRuntimeIdentifiers(
+            RuntimeInformation.RuntimeIdentifier ?? string.Empty,
+            RuntimeInformation.ProcessArchitecture,
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows),
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX),
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
+    }
+
+    private static IEnumerable<string> GetRuntimeIdentifiers(
+        string runtimeIdentifier,
+        Architecture architecture,
+        bool isWindows,
+        bool isOsx,
+        bool isLinux) {
+        if (!string.IsNullOrWhiteSpace(runtimeIdentifier)) {
+            yield return runtimeIdentifier;
+        }
+
+        var arch = architecture switch
+        {
+            Architecture.X64 => "x64",
+            Architecture.X86 => "x86",
+            Architecture.Arm64 => "arm64",
+            Architecture.Arm => "arm",
+            _ => null
+        };
+
+        if (isWindows) {
+            if (arch is not null) {
+                yield return "win-" + arch;
+            }
+
+            yield return "win";
+        } else if (isOsx) {
+            if (arch is not null) {
+                yield return "osx-" + arch;
+            }
+
+            yield return "osx";
+            yield return "unix";
+        } else if (isLinux) {
+            var isMusl = runtimeIdentifier.Contains("musl", StringComparison.OrdinalIgnoreCase);
+            if (arch is not null) {
+                if (isMusl) {
+                    yield return "linux-musl-" + arch;
+                    yield return "linux-musl";
+                    yield return "linux-" + arch;
+                } else {
+                    yield return "linux-" + arch;
+                    yield return "linux-musl-" + arch;
+                    yield return "linux-musl";
+                }
+            }
+
+            yield return "linux";
+            yield return "unix";
         }
     }
 

--- a/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
+++ b/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
@@ -25,6 +25,20 @@ public partial class SqlServer
     {
         ValidateCommandText(procedure, CommandType.StoredProcedure);
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return ExecuteStoredProcedure(connectionString, procedure, parameters, useTransaction);
+    }
+
+    /// <summary>
+    /// Executes a stored procedure using a full SQL Server connection string and existing <see cref="DbParameter"/> instances.
+    /// </summary>
+    public virtual object? ExecuteStoredProcedure(
+        string connectionString,
+        string procedure,
+        IEnumerable<DbParameter>? parameters,
+        bool useTransaction = false)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
 
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;
@@ -56,7 +70,11 @@ public partial class SqlServer
 
             return BuildResult(dataSet);
         }
-        catch (Exception ex)
+        catch (SqlException ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
+        }
+        catch (InvalidOperationException ex)
         {
             throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
         }
@@ -85,6 +103,21 @@ public partial class SqlServer
     {
         ValidateCommandText(procedure, CommandType.StoredProcedure);
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        return await ExecuteStoredProcedureAsync(connectionString, procedure, parameters, useTransaction, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asynchronously executes a stored procedure using a full SQL Server connection string and existing <see cref="DbParameter"/> instances.
+    /// </summary>
+    public virtual async Task<object?> ExecuteStoredProcedureAsync(
+        string connectionString,
+        string procedure,
+        IEnumerable<DbParameter>? parameters,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
 
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;
@@ -116,7 +149,15 @@ public partial class SqlServer
 
             return BuildResult(dataSet);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (SqlException ex)
+        {
+            throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
+        }
+        catch (InvalidOperationException ex)
         {
             throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
         }

--- a/DbaClientX.SqlServer/SqlServer.Streaming.cs
+++ b/DbaClientX.SqlServer/SqlServer.Streaming.cs
@@ -176,6 +176,43 @@ public partial class SqlServer
     }
 
     /// <summary>
+    /// Asynchronously executes a stored procedure using a full SQL Server connection string and streams the resulting rows.
+    /// </summary>
+    public virtual IAsyncEnumerable<DataRow> ExecuteStoredProcedureStreamAsync(
+        string connectionString,
+        string procedure,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqlDbType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
+        return Stream();
+
+        async IAsyncEnumerable<DataRow> Stream()
+        {
+            SqlConnection? connection = null;
+            SqlTransaction? transaction = null;
+            var dispose = false;
+            try
+            {
+                (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+                var dbTypes = ConvertParameterTypes(parameterTypes);
+                await foreach (var row in ExecuteQueryStreamAsync(connection, transaction, procedure, parameters, cancellationToken, dbTypes, parameterDirections, commandType: CommandType.StoredProcedure).ConfigureAwait(false))
+                {
+                    yield return row;
+                }
+            }
+            finally
+            {
+                await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
     /// Asynchronously executes a stored procedure using <see cref="DbParameter"/> instances and streams the resulting rows.
     /// </summary>
     public virtual IAsyncEnumerable<DataRow> ExecuteStoredProcedureStreamAsync(
@@ -196,6 +233,40 @@ public partial class SqlServer
         {
             var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
 
+            SqlConnection? connection = null;
+            SqlTransaction? transaction = null;
+            var dispose = false;
+            try
+            {
+                (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
+                await foreach (var row in ExecuteQueryStreamAsync(connection, transaction, procedure, cancellationToken: cancellationToken, dbParameters: parameters, commandType: CommandType.StoredProcedure).ConfigureAwait(false))
+                {
+                    yield return row;
+                }
+            }
+            finally
+            {
+                await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Asynchronously executes a stored procedure using a full SQL Server connection string and <see cref="DbParameter"/> instances.
+    /// </summary>
+    public virtual IAsyncEnumerable<DataRow> ExecuteStoredProcedureStreamAsync(
+        string connectionString,
+        string procedure,
+        IEnumerable<DbParameter>? parameters,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateConnectionString(connectionString);
+        ValidateCommandText(procedure, CommandType.StoredProcedure);
+        return Stream();
+
+        async IAsyncEnumerable<DataRow> Stream()
+        {
             SqlConnection? connection = null;
             SqlTransaction? transaction = null;
             var dispose = false;

--- a/DbaClientX.Tests/OnImportAndRemoveTests.cs
+++ b/DbaClientX.Tests/OnImportAndRemoveTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Management.Automation;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using DBAClientX.PowerShell;
 using Xunit;
 
@@ -58,6 +59,54 @@ public class OnImportAndRemoveTests
 
         sut.OnRemove(null!);
         Assert.Equal(0, stateField.GetValue(null));
+    }
+
+    [Fact]
+    public void GetRuntimeIdentifiers_IncludesUnixFallbackForUnixLikePlatforms()
+    {
+        var method = typeof(OnModuleImportAndRemove).GetMethod(
+            "GetRuntimeIdentifiers",
+            BindingFlags.NonPublic | BindingFlags.Static,
+            binder: null,
+            new[] { typeof(string), typeof(Architecture), typeof(bool), typeof(bool), typeof(bool) },
+            modifiers: null);
+
+        var result = ((IEnumerable<string>)method!.Invoke(null, new object[] { "linux-x64", Architecture.X64, false, false, true })!).ToArray();
+
+        Assert.Contains("linux-x64", result);
+        Assert.Contains("linux", result);
+        Assert.Contains("unix", result);
+    }
+
+    [Fact]
+    public void GetCompatibleRuntimeLibraryDirectories_UsesCompatibleTargetFramework()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "DbaClientX-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "net8.0"));
+            Directory.CreateDirectory(Path.Combine(root, "net9.0"));
+            Directory.CreateDirectory(Path.Combine(root, "netstandard2.0"));
+
+            var method = typeof(OnModuleImportAndRemove).GetMethod(
+                "GetCompatibleRuntimeLibraryDirectories",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            var result = ((IEnumerable<string>)method!.Invoke(null, new object[] { root })!)
+                .Select(Path.GetFileName)
+                .ToArray();
+
+            Assert.Equal("net8.0", result[0]);
+            Assert.DoesNotContain("net9.0", result);
+            Assert.Contains("netstandard2.0", result);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
     }
 #endif
 }

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -1,12 +1,9 @@
-﻿Build-Module -ModuleName 'DbaClientX' {
-    $netSearchClasses = @(
-        'DbaClientX.PowerShell.CmdletIInvokeDbaXQuery'
-        'DbaClientX.PowerShell.CmdletIInvokeDbaXNonQuery'
-    )
+﻿Import-Module PSPublishModule -Force -ErrorAction Stop
 
+Build-Module -ModuleName 'DbaClientX' {
     # Usual defaults as per standard module
     $Manifest = [ordered] @{
-        ModuleVersion        = '0.1.0'
+        ModuleVersion        = '0.1.X'
         CompatiblePSEditions = @('Desktop', 'Core')
         GUID                 = 'c22cc272-c829-49e2-aaa1-58d3c36edb94'
         Author               = 'Przemyslaw Klys'
@@ -16,22 +13,6 @@
         PowerShellVersion    = '5.1'
         Tags                 = @('Windows', 'MacOS', 'Linux')
         ProjectUri           = 'https://github.com/EvotecIT/DbaClientX'
-        #AliasesToExport      = @('')
-        CmdletsToExport      = @(
-            'Invoke-DbaXQuery'
-            'Invoke-DbaXNonQuery'
-            'New-DbaXQuery'
-            'Invoke-DbaXMySql'
-            'Invoke-DbaXMySqlNonQuery'
-            'Invoke-DbaXMySqlScalar'
-            'Invoke-DbaXPostgreSql'
-            'Invoke-DbaXPostgreSqlNonQuery'
-            'Invoke-DbaXOracle'
-            'Invoke-DbaXOracleNonQuery'
-            'Invoke-DbaXOracleScalar'
-            'Invoke-DbaXSQLite'
-            'Write-DbaXTableData'
-        )
     }
     New-ConfigurationManifest @Manifest
 
@@ -99,15 +80,17 @@
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = Test-Path -LiteralPath "Cert:\CurrentUser\My\$certificateThumbprint"
+        SignModule                        = if ([string]::IsNullOrWhiteSpace($Env:SignModule)) { $false } else { [bool]::Parse($Env:SignModule) }
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
         CertificateThumbprint             = $certificateThumbprint
+        DeleteTargetModuleBeforeBuild     = $true
         NETProjectPath                    = "$PSScriptRoot\..\..\DbaClientX.PowerShell"
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'DbaClientX.PowerShell'
         NETProjectName                    = 'DbaClientX.PowerShell'
         NETBinaryModule                   = 'DbaClientX.PowerShell.dll'
+        NETBinaryModuleDocumentation      = $true
         NETConfiguration                  = 'Release'
         NETFramework                      = 'net472', 'net8.0'
         NETHandleAssemblyWithSameName     = $true
@@ -125,9 +108,8 @@
             'Microsoft.Data.SqlClient.SNI.x64.dll'
             'Microsoft.Data.SqlClient.SNI.x86.dll'
         )
-        # PSPublishModule 3.x tightened this legacy option to a single string value.
-        NETSearchClass                    = $netSearchClasses -join ','
         DotSourceLibraries                = $true
+        DotSourceClasses                  = $true
         RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $true } else { [bool]::Parse($Env:RefreshPSD1Only) }
     }
 
@@ -139,4 +121,4 @@
     # global options for publishing to github/psgallery
     #New-ConfigurationPublish -Type PowerShellGallery -FilePath 'C:\Support\Important\PowerShellGalleryAPI.txt' -Enabled:$true
     #New-ConfigurationPublish -Type GitHub -FilePath 'C:\Support\Important\GitHubAPI.txt' -UserName 'EvotecIT' -Enabled:$true -ID 'ToGitHub' -OverwriteTagName 'DnsClientX-PowerShellModule.<TagModuleVersionWithPreRelease>'
-}
+} -ExitCode

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module PSPublishModule -Force -ErrorAction Stop
+Import-Module PSPublishModule -Force -ErrorAction Stop
 
 Build-Module -ModuleName 'DbaClientX' {
     # Usual defaults as per standard module
@@ -74,16 +74,17 @@ Build-Module -ModuleName 'DbaClientX' {
     # configuration for documentation, at the same time it enables documentation processing
     New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
 
-    New-ConfigurationImportModule -ImportSelf -ImportRequiredModules -SkipBinaryDependencyCheck
-
-    $certificateThumbprint = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+    $defaultRefreshPSD1Only = $false
+    if ((Get-Variable -Name IsWindows -ErrorAction SilentlyContinue) -and -not $IsWindows) {
+        $defaultRefreshPSD1Only = $true
+    }
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
         SignModule                        = if ([string]::IsNullOrWhiteSpace($Env:SignModule)) { $false } else { [bool]::Parse($Env:SignModule) }
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
-        CertificateThumbprint             = $certificateThumbprint
+        CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
         DeleteTargetModuleBeforeBuild     = $true
         NETProjectPath                    = "$PSScriptRoot\..\..\DbaClientX.PowerShell"
         ResolveBinaryConflicts            = $true
@@ -96,12 +97,6 @@ Build-Module -ModuleName 'DbaClientX' {
         NETHandleAssemblyWithSameName     = $true
         NETAssemblyLoadContext            = $true
         NETHandleRuntimes                 = $true
-        NETExcludeLibraryFilter           = @(
-            'Microsoft.Data.SqlClient.SNI.arm64.dll'
-            'Microsoft.Data.SqlClient.SNI.dll'
-            'Microsoft.Data.SqlClient.SNI.x64.dll'
-            'Microsoft.Data.SqlClient.SNI.x86.dll'
-        )
         NETIgnoreLibraryOnLoad            = @(
             'Microsoft.Data.SqlClient.SNI.arm64.dll'
             'Microsoft.Data.SqlClient.SNI.dll'
@@ -110,7 +105,11 @@ Build-Module -ModuleName 'DbaClientX' {
         )
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
-        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $true } else { [bool]::Parse($Env:RefreshPSD1Only) }
+        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) {
+            $defaultRefreshPSD1Only
+        } else {
+            [bool]::Parse($Env:RefreshPSD1Only)
+        }
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Module/Examples/Example.InvokeNonQuery.ps1
+++ b/Module/Examples/Example.InvokeNonQuery.ps1
@@ -1,1 +1,31 @@
-Invoke-DbaXNonQuery -Query "CREATE TABLE #Test (Id INT)" -Server "SQL1" -Database "master"
+Clear-Host
+Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force
+
+$server = $env:DBACLIENTX_SQLSERVER
+if ([string]::IsNullOrWhiteSpace($server)) {
+    $server = 'localhost'
+}
+
+$database = $env:DBACLIENTX_SQLDATABASE
+if ([string]::IsNullOrWhiteSpace($database)) {
+    $database = 'master'
+}
+
+$sql = @'
+CREATE TABLE #DbaClientXDemo
+(
+    Id int NOT NULL,
+    Name nvarchar(50) NOT NULL
+);
+
+INSERT INTO #DbaClientXDemo (Id, Name)
+VALUES (1, N'Alpha'), (2, N'Beta');
+'@
+
+$affectedRows = Invoke-DbaXNonQuery `
+    -Server $server `
+    -Database $database `
+    -TrustServerCertificate `
+    -Query $sql
+
+"Rows affected: $affectedRows"

--- a/Module/Examples/Example.MySqlScalar.ps1
+++ b/Module/Examples/Example.MySqlScalar.ps1
@@ -1,1 +1,19 @@
-Invoke-DbaXMySqlScalar -Server 'mysqlsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query "SELECT COUNT(*) FROM Users"
+Clear-Host
+Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force
+
+$server = $env:DBACLIENTX_MYSQL_SERVER
+$database = $env:DBACLIENTX_MYSQL_DATABASE
+if ([string]::IsNullOrWhiteSpace($server) -or [string]::IsNullOrWhiteSpace($database)) {
+    throw 'Set DBACLIENTX_MYSQL_SERVER and DBACLIENTX_MYSQL_DATABASE before running this example.'
+}
+
+$credential = Get-Credential -Message 'MySQL credentials'
+$tableName = 'Users'
+
+$count = Invoke-DbaXMySqlScalar `
+    -Server $server `
+    -Database $database `
+    -Credential $credential `
+    -Query "SELECT COUNT(*) FROM $tableName"
+
+"$tableName rows: $count"

--- a/Module/Examples/Example.QueryMySql.ps1
+++ b/Module/Examples/Example.QueryMySql.ps1
@@ -1,5 +1,22 @@
 Clear-Host
-Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force
 
-$T = Invoke-DbaXMySql -Query "SELECT 1" -Server "MySqlServer" -Database "master" -Username "user" -Password "pass"
-$T | Format-Table
+$server = $env:DBACLIENTX_MYSQL_SERVER
+$database = $env:DBACLIENTX_MYSQL_DATABASE
+if ([string]::IsNullOrWhiteSpace($server) -or [string]::IsNullOrWhiteSpace($database)) {
+    throw 'Set DBACLIENTX_MYSQL_SERVER and DBACLIENTX_MYSQL_DATABASE before running this example.'
+}
+
+$credential = Get-Credential -Message 'MySQL credentials'
+
+Invoke-DbaXMySql `
+    -Server $server `
+    -Database $database `
+    -Credential $credential `
+    -Query @'
+SELECT
+    DATABASE() AS DatabaseName,
+    VERSION() AS ServerVersion,
+    CURRENT_USER() AS ConnectedAs;
+'@ |
+    Format-Table -AutoSize

--- a/Module/Examples/Example.QueryOracle.ps1
+++ b/Module/Examples/Example.QueryOracle.ps1
@@ -1,5 +1,22 @@
 Clear-Host
-Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force
 
-$T = Invoke-DbaXOracle -Query "SELECT 1 FROM dual" -Server "OracleServer" -Database "ORCL" -Username "user" -Password "pass"
-$T | Format-Table
+$server = $env:DBACLIENTX_ORACLE_SERVER
+$service = $env:DBACLIENTX_ORACLE_SERVICE
+if ([string]::IsNullOrWhiteSpace($server) -or [string]::IsNullOrWhiteSpace($service)) {
+    throw 'Set DBACLIENTX_ORACLE_SERVER and DBACLIENTX_ORACLE_SERVICE before running this example.'
+}
+
+$credential = Get-Credential -Message 'Oracle credentials'
+
+Invoke-DbaXOracle `
+    -Server $server `
+    -Database $service `
+    -Credential $credential `
+    -Query @'
+SELECT
+    USER AS ConnectedUser,
+    SYS_CONTEXT('USERENV', 'SERVICE_NAME') AS ServiceName
+FROM dual
+'@ |
+    Format-Table -AutoSize

--- a/Module/Examples/Example.QueryPostgreSql.ps1
+++ b/Module/Examples/Example.QueryPostgreSql.ps1
@@ -1,5 +1,22 @@
 Clear-Host
-Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force
 
-$T = Invoke-DbaXPostgreSql -Query "SELECT 1" -Server "PostgreServer" -Database "postgres" -Username "user" -Password "pass"
-$T | Format-Table
+$server = $env:DBACLIENTX_POSTGRES_SERVER
+$database = $env:DBACLIENTX_POSTGRES_DATABASE
+if ([string]::IsNullOrWhiteSpace($server) -or [string]::IsNullOrWhiteSpace($database)) {
+    throw 'Set DBACLIENTX_POSTGRES_SERVER and DBACLIENTX_POSTGRES_DATABASE before running this example.'
+}
+
+$credential = Get-Credential -Message 'PostgreSQL credentials'
+
+Invoke-DbaXPostgreSql `
+    -Server $server `
+    -Database $database `
+    -Credential $credential `
+    -Query @'
+SELECT
+    current_database() AS database_name,
+    current_user AS connected_as,
+    version() AS server_version;
+'@ |
+    Format-Table -AutoSize

--- a/Module/Examples/Example.QuerySqlServer.ps1
+++ b/Module/Examples/Example.QuerySqlServer.ps1
@@ -1,17 +1,33 @@
-﻿Clear-Host
-Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+Clear-Host
+Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force
 
-$T = Invoke-DbaXQuery -Query "SELECT * FROM sys.databases" -Server "SQL1" -Database "master"
-$T | Format-Table
+$server = $env:DBACLIENTX_SQLSERVER
+if ([string]::IsNullOrWhiteSpace($server)) {
+    $server = 'localhost'
+}
 
-$T1 = Invoke-DbaXQuery -Query "SELECT * FROM MSreplication_options" -Server "SQL1" -Database "master" -ReturnType DataRow
-$T1 | Format-Table
+$database = $env:DBACLIENTX_SQLDATABASE
+if ([string]::IsNullOrWhiteSpace($database)) {
+    $database = 'master'
+}
 
-$T2 = Invoke-DbaXQuery -Query "SELECT * FROM MSreplication_options" -Server "SQL1" -Database "master" -ReturnType PSObject
-$T2 | Format-Table
+$query = @'
+SELECT
+    name,
+    database_id,
+    create_date,
+    state_desc
+FROM sys.databases
+WHERE database_id > @MinimumDatabaseId
+ORDER BY name;
+'@
 
-$T3 = Invoke-DbaXQuery -Query "SELECT * FROM MSreplication_options" -Server "SQL1" -Database "master" -ReturnType DataSet
-$T3 | Format-Table
+$rows = Invoke-DbaXQuery `
+    -Server $server `
+    -Database $database `
+    -TrustServerCertificate `
+    -Query $query `
+    -Parameters @{ MinimumDatabaseId = 4 } `
+    -ReturnType PSObject
 
-$T4 = Invoke-DbaXQuery -Query "SELECT * FROM MSreplication_options" -Server "SQL1" -Database "master" -ReturnType DataTable
-$T4 | Format-Table
+$rows | Format-Table name, database_id, state_desc, create_date -AutoSize

--- a/Module/Examples/Example.QuerySqlServerParameters.ps1
+++ b/Module/Examples/Example.QuerySqlServerParameters.ps1
@@ -1,5 +1,20 @@
 Clear-Host
-Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force -Verbose
+Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force
 
-$parameters = @{ Id = 1 }
-Invoke-DbaXQuery -Query 'SELECT * FROM sys.databases WHERE database_id = @Id' -Server 'SQL1' -Database 'master' -Parameters $parameters | Format-Table
+$server = $env:DBACLIENTX_SQLSERVER
+if ([string]::IsNullOrWhiteSpace($server)) {
+    $server = 'localhost'
+}
+
+$parameters = @{
+    DatabaseName = 'master'
+}
+
+Invoke-DbaXQuery `
+    -Server $server `
+    -Database 'master' `
+    -TrustServerCertificate `
+    -Query 'SELECT name, database_id, state_desc FROM sys.databases WHERE name = @DatabaseName' `
+    -Parameters $parameters `
+    -ReturnType PSObject |
+    Format-Table -AutoSize

--- a/Module/Examples/Example.QuerySqlServerStream.ps1
+++ b/Module/Examples/Example.QuerySqlServerStream.ps1
@@ -1,5 +1,23 @@
 Clear-Host
-Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force
 
-Invoke-DbaXQuery -Query "SELECT * FROM sys.databases" -Server "SQL1" -Database "master" -Stream |
-    Format-Table
+$server = $env:DBACLIENTX_SQLSERVER
+if ([string]::IsNullOrWhiteSpace($server)) {
+    $server = 'localhost'
+}
+
+Invoke-DbaXQuery `
+    -Server $server `
+    -Database 'master' `
+    -TrustServerCertificate `
+    -Stream `
+    -ReturnType PSObject `
+    -Query @'
+SELECT TOP (25)
+    name,
+    type_desc,
+    create_date
+FROM sys.objects
+ORDER BY create_date DESC;
+'@ |
+    Format-Table name, type_desc, create_date -AutoSize

--- a/Module/Examples/Example.QueryStoredProcedure.ps1
+++ b/Module/Examples/Example.QueryStoredProcedure.ps1
@@ -1,5 +1,15 @@
 Clear-Host
-Import-Module $PSScriptRoot\..\DBAClientX.psd1 -Force -Verbose
+Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force
 
-Invoke-DbaXQuery -StoredProcedure "dbo.MyProcedure" -Server "SQL1" -Database "master"
+$server = $env:DBACLIENTX_SQLSERVER
+if ([string]::IsNullOrWhiteSpace($server)) {
+    $server = 'localhost'
+}
 
+Invoke-DbaXQuery `
+    -Server $server `
+    -Database 'master' `
+    -TrustServerCertificate `
+    -StoredProcedure 'sys.sp_databases' `
+    -ReturnType PSObject |
+    Format-Table DATABASE_NAME, DATABASE_SIZE, REMARKS -AutoSize

--- a/Module/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Module/Tests/AssemblyLoadContext.Tests.ps1
@@ -54,6 +54,11 @@ Import-Module DbaClientX -Force
 `$command = Get-Command Invoke-DbaXQuery -ErrorAction Stop
 `$commandAssembly = `$command.ImplementingType.Assembly
 `$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
+`$moduleSqlClientAssembly = [System.Runtime.Loader.AssemblyLoadContext]::All |
+    Where-Object { `$_.Name -eq 'DbaClientX' } |
+    ForEach-Object { `$_.Assemblies } |
+    Where-Object { `$_.GetName().Name -eq 'Microsoft.Data.SqlClient' } |
+    Select-Object -First 1
 `$loadedAssemblies = [System.Runtime.Loader.AssemblyLoadContext]::All |
     ForEach-Object {
         `$alc = `$_
@@ -77,6 +82,7 @@ Import-Module DbaClientX -Force
     InvokeDbaXQueryAssembly = `$commandAssembly.Location
     InvokeDbaXQueryALC = `$commandAlc.Name
     InvokeDbaXQueryALCIsDefault = [object]::ReferenceEquals(`$commandAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    ModuleSqlClientAssembly = if (`$moduleSqlClientAssembly) { `$moduleSqlClientAssembly.Location } else { `$null }
     LoadedAssemblies = @(`$loadedAssemblies)
 } | ConvertTo-Json -Depth 6 -Compress
 "@
@@ -93,6 +99,9 @@ Import-Module DbaClientX -Force
         $result.InvokeDbaXQueryAssembly | Should -BeLike '*\Module\Artefacts\Unpacked\DbaClientX\Lib\Core\DBAClientX.PowerShell.dll'
         $result.InvokeDbaXQueryALC | Should -Be 'DbaClientX'
         $result.InvokeDbaXQueryALCIsDefault | Should -BeFalse
+        if ($IsWindows) {
+            $result.ModuleSqlClientAssembly | Should -BeLike '*\Module\Artefacts\Unpacked\DbaClientX\Lib\Core\runtimes\win\lib\net8.0\Microsoft.Data.SqlClient.dll'
+        }
 
         $loadedAssemblies = @($result.LoadedAssemblies)
         $dbaClientXPowerShellAssembly = $loadedAssemblies | Where-Object { $_.Assembly -eq 'DbaClientX.PowerShell' -and $_.ALC -eq 'DbaClientX' } | Select-Object -First 1

--- a/Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1
@@ -14,6 +14,10 @@ Describe 'Invoke-DbaXNonQuery cmdlet' {
         (Get-Command Invoke-DbaXNonQuery).Parameters.Keys | Should -Contain 'Credential'
     }
 
+    It 'supports TrustServerCertificate parameter' {
+        (Get-Command Invoke-DbaXNonQuery).Parameters.Keys | Should -Contain 'TrustServerCertificate'
+    }
+
     It 'passes credentials to provider when supplied' {
         $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
         $prop = [DBAClientX.PowerShell.CmdletIInvokeDbaXNonQuery].GetProperty('NonQueryOverride', $binding)
@@ -88,6 +92,25 @@ Describe 'Invoke-DbaXNonQuery cmdlet' {
         } finally {
             $prop.SetValue($null, $orig)
             $script:lastNonQueryOptions = $null
+        }
+    }
+
+    It 'passes TrustServerCertificate to provider execution' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletIInvokeDbaXNonQuery].GetProperty('NonQueryOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:lastNonQueryTrustServerCertificate = $null
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $parameters)
+            $script:lastNonQueryTrustServerCertificate = $cmdlet.TrustServerCertificate.IsPresent
+            return 0
+        })
+        try {
+            Invoke-DbaXNonQuery -Server s -Database db -Query 'Q' -TrustServerCertificate | Out-Null
+            $script:lastNonQueryTrustServerCertificate | Should -BeTrue
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:lastNonQueryTrustServerCertificate = $null
         }
     }
 

--- a/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
@@ -22,6 +22,10 @@ describe 'Invoke-DbaXQuery cmdlet' {
         (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'Credential'
     }
 
+    it 'supports TrustServerCertificate parameter' {
+        (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'TrustServerCertificate'
+    }
+
     it 'fails when Server is empty' {
         { Invoke-DbaXQuery -Server '' -Database db -Query 'SELECT 1' -ErrorAction Stop } | Should -Throw
     }
@@ -110,6 +114,25 @@ describe 'Invoke-DbaXQuery cmdlet' {
         } finally {
             $prop.SetValue($null, $orig)
             $script:lastQueryOptions = $null
+        }
+    }
+
+    it 'passes TrustServerCertificate to query execution' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletIInvokeDbaXQuery].GetProperty('QueryOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:lastQueryTrustServerCertificate = $null
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $parameters, $dbParameters)
+            $script:lastQueryTrustServerCertificate = $cmdlet.TrustServerCertificate.IsPresent
+            return $null
+        })
+        try {
+            Invoke-DbaXQuery -Server s -Database db -Query 'SELECT 1' -TrustServerCertificate | Out-Null
+            $script:lastQueryTrustServerCertificate | Should -BeTrue
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:lastQueryTrustServerCertificate = $null
         }
     }
 


### PR DESCRIPTION
## Summary
- align the DbaClientX module build wrapper with the thin Mailozaurr-style PSPublishModule flow while keeping signing/versioning env-driven
- fix packaged provider loading in PowerShell 7 by preloading runtime-specific managed assemblies into the module ALC
- keep SQL Client native SNI runtime files in the package so Windows PowerShell 5.1 can execute SQL Server commands
- add `-TrustServerCertificate` to SQL Server query/non-query cmdlets and route through trusted connection strings
- refresh command XML examples and module examples with concrete SQL Server, MySQL, Oracle, and PostgreSQL usage

## Validation
- `dotnet build .\DbaClientX.PowerShell\DbaClientX.PowerShell.csproj -c Release`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\Module\Build\Build-Module.ps1` with signing disabled and full packaged build enabled
- packaged artifact import + live local SQL Server query/non-query in PowerShell 7.6.3 against `localhost` / `master`
- packaged artifact import + live local SQL Server query/non-query in Windows PowerShell 5.1 against `localhost` / `master`
- `Invoke-Pester -Path './Module/Tests/AssemblyLoadContext.Tests.ps1' -Tag PackagedALC -Output Detailed`
- `Invoke-Pester -Path './Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1','./Module/Tests/CmdletInvokeDbaXNonQuery.Tests.ps1' -Output Detailed`
- `dotnet test .\DbaClientX.Tests\DbaClientX.Tests.csproj -c Release --no-build --framework net8.0 --filter "FullyQualifiedName~ConnectionStringBuilderTests|FullyQualifiedName~SqlServerTests|FullyQualifiedName~ProviderMappedQueryParityTests"`
- `git diff --check origin/codex/thin-module-build-wrapper..HEAD`
