### PR TITLE
Add SQLite online backup helper

### DIFF
--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX SQLite provider</Description>
     <AssemblyName>DbaClientX.SQLite</AssemblyName>
     <AssemblyTitle>DbaClientX.SQLite</AssemblyTitle>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <VersionPrefix>0.8.0</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.SQLite/README.md
+++ b/DbaClientX.SQLite/README.md
@@ -1,7 +1,7 @@
 # DbaClientX.SQLite
 
 SQLite provider for DbaClientX (Microsoft.Data.Sqlite). Supports non-query, scalar, queries, streaming, transactions, bulk insert.
-Also includes SQLite maintenance helpers for WAL checkpointing, `PRAGMA optimize`, and graceful shutdown preparation.
+Also includes SQLite maintenance helpers for online database backup, WAL checkpointing, `PRAGMA optimize`, and graceful shutdown preparation.
 
 - Target Frameworks: `net472` (win-x64), `net8.0`, `net10.0`
 - NuGet: `DBAClientX.SQLite`
@@ -61,6 +61,13 @@ await sq.PrepareForShutdownAsync(
         CheckpointMode = SqliteCheckpointMode.Truncate,
         OptimizeAfterCheckpoint = true
     });
+```
+
+Backup before maintenance:
+
+```csharp
+var sq = new DBAClientX.SQLite();
+sq.BackupDatabase("app.db", "backups/app.db");
 ```
 
 ## See also

--- a/DbaClientX.SQLite/SQLite.Maintenance.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.cs
@@ -10,6 +10,50 @@ namespace DBAClientX;
 public partial class SQLite
 {
     /// <summary>
+    /// Copies a SQLite database into a destination database using SQLite's online backup API.
+    /// </summary>
+    /// <param name="sourceDatabase">Absolute or relative path of the source SQLite database file.</param>
+    /// <param name="destinationDatabase">Absolute or relative path of the destination SQLite database file.</param>
+    /// <param name="busyTimeoutMs">Optional busy timeout in milliseconds applied to both connections.</param>
+    /// <remarks>
+    /// The source database is opened read-only and the destination is created when it does not exist. This is
+    /// intended for backup-first maintenance workflows that need a provider-owned copy operation without exposing
+    /// <c>Microsoft.Data.Sqlite</c> objects to consumer projects.
+    /// </remarks>
+    public virtual void BackupDatabase(
+        string sourceDatabase,
+        string destinationDatabase,
+        int? busyTimeoutMs = null)
+    {
+        ValidateDatabasePath(sourceDatabase);
+        ValidateDatabasePath(destinationDatabase);
+        EnsureNoActiveTransaction();
+
+        var destinationDirectory = Path.GetDirectoryName(destinationDatabase);
+        if (!string.IsNullOrWhiteSpace(destinationDirectory))
+        {
+            Directory.CreateDirectory(destinationDirectory);
+        }
+
+        try
+        {
+            using var source = new SqliteConnection(BuildOperationalConnectionString(sourceDatabase, readOnly: true));
+            source.Open();
+            ApplyBusyTimeout(source, busyTimeoutMs);
+
+            using var destination = new SqliteConnection(BuildConnectionString(destinationDatabase, readOnly: false, busyTimeoutMs: null));
+            destination.Open();
+            ApplyBusyTimeout(destination, busyTimeoutMs);
+
+            source.BackupDatabase(destination);
+        }
+        catch (Exception ex)
+        {
+            throw new DbaQueryExecutionException("Failed to back up SQLite database.", "SQLite online backup", ex);
+        }
+    }
+
+    /// <summary>
     /// Executes <c>PRAGMA wal_checkpoint(...)</c> using the supplied checkpoint mode.
     /// </summary>
     /// <param name="database">Absolute or relative path of the SQLite database file.</param>

--- a/DbaClientX.SQLite/SQLite.Maintenance.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.cs
@@ -47,11 +47,34 @@ public partial class SQLite
 
             source.BackupDatabase(destination);
         }
-        catch (Exception ex)
+        catch (SqliteException ex)
         {
-            throw new DbaQueryExecutionException("Failed to back up SQLite database.", "SQLite online backup", ex);
+            throw CreateBackupException(ex);
+        }
+        catch (IOException ex)
+        {
+            throw CreateBackupException(ex);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            throw CreateBackupException(ex);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw CreateBackupException(ex);
+        }
+        catch (ArgumentException ex)
+        {
+            throw CreateBackupException(ex);
+        }
+        catch (NotSupportedException ex)
+        {
+            throw CreateBackupException(ex);
         }
     }
+
+    private static DbaQueryExecutionException CreateBackupException(Exception exception) =>
+        new("Failed to back up SQLite database.", "SQLite online backup", exception);
 
     /// <summary>
     /// Executes <c>PRAGMA wal_checkpoint(...)</c> using the supplied checkpoint mode.

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -503,8 +503,8 @@ public class SqliteTests
     public void BackupDatabase_CopiesReadableDatabase()
     {
         var source = Path.GetTempFileName();
-        var destinationDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        var destination = Path.Combine(destinationDirectory, "backup.sqlite");
+        var destinationDirectory = Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var destination = Path.Join(destinationDirectory, "backup.sqlite");
         try
         {
             using var sqlite = new DBAClientX.SQLite();

--- a/DbaClientX.Tests/SqliteTests.cs
+++ b/DbaClientX.Tests/SqliteTests.cs
@@ -500,6 +500,38 @@ public class SqliteTests
     }
 
     [Fact]
+    public void BackupDatabase_CopiesReadableDatabase()
+    {
+        var source = Path.GetTempFileName();
+        var destinationDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var destination = Path.Combine(destinationDirectory, "backup.sqlite");
+        try
+        {
+            using var sqlite = new DBAClientX.SQLite();
+            sqlite.ExecuteNonQuery(source, "CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT NOT NULL);");
+            sqlite.ExecuteNonQuery(source, "INSERT INTO t(name) VALUES ($name);", new Dictionary<string, object?>
+            {
+                ["$name"] = "copied"
+            });
+
+            sqlite.BackupDatabase(source, destination);
+
+            Assert.True(File.Exists(destination));
+            var result = sqlite.ExecuteScalar(destination, "SELECT name FROM t WHERE id = 1;");
+            Assert.Equal("copied", result);
+        }
+        finally
+        {
+            Cleanup(source);
+            Cleanup(destination);
+            if (Directory.Exists(destinationDirectory))
+            {
+                Directory.Delete(destinationDirectory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task CollectDiagnosticsAsync_FileDatabase_ReturnsHealthAndFileState()
     {
         var path = Path.GetTempFileName();


### PR DESCRIPTION
## Summary
- add a provider-owned `SQLite.BackupDatabase` helper that uses SQLite online backup without exposing Microsoft.Data.Sqlite to consumers
- bump `DBAClientX.SQLite` to 0.8.0 for the new public API
- document the backup helper and cover it with a SQLite copy/readback test

## Validation
- `dotnet test DbaClientX.Tests\DbaClientX.Tests.csproj -c Debug --filter "FullyQualifiedName~BackupDatabase_CopiesReadableDatabase|FullyQualifiedName~PrepareForShutdownAsync|FullyQualifiedName~CollectDiagnosticsAsync" -m:1`
- `dotnet test DbaClientX.Tests\DbaClientX.Tests.csproj -c Debug -m:1`
- `dotnet build DbaClientX.SQLite\DbaClientX.SQLite.csproj -c Release -m:1`
- `dotnet list DbaClientX.SQLite\DbaClientX.SQLite.csproj package --include-transitive --vulnerable`
- `dotnet pack DbaClientX.SQLite\DbaClientX.SQLite.csproj -c Release --no-build -o .\artifacts\packages`
- `git diff --check`