### PR TITLE
Expose query-builder DML paths in PowerShell

### DIFF
--- a/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
@@ -252,8 +252,12 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
             return;
         }
 
-        foreach (var pair in GetPairs(Where, nameof(Where), allowNullValues: false)) {
-            query.Where(pair.Column, pair.Value!);
+        foreach (var pair in GetPairs(Where, nameof(Where), allowNullValues: true)) {
+            if (pair.Value == null) {
+                query.WhereNull(pair.Column);
+            } else {
+                query.Where(pair.Column, pair.Value);
+            }
         }
     }
 
@@ -294,16 +298,44 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
     }
 
     private void ValidateUnsupportedOptions() {
-        if (Action == DbaXQueryAction.Select) {
-            return;
-        }
+        var hasColumns = Columns is { Length: > 0 };
+        var hasValues = Values != null;
+        var hasSet = Set != null;
+        var hasWhere = Where != null;
+        var hasConflictColumns = ConflictColumns is { Length: > 0 };
+        var hasUpsertUpdateOnly = UpsertUpdateOnly is { Length: > 0 };
+        var hasPagingOrOrdering = Limit.HasValue || Offset.HasValue || OrderBy is { Length: > 0 } || OrderByDescending is { Length: > 0 };
 
-        if (Limit.HasValue || Offset.HasValue || OrderBy is { Length: > 0 } || OrderByDescending is { Length: > 0 }) {
+        if (Action != DbaXQueryAction.Select && hasPagingOrOrdering) {
             throw new PSArgumentException("Limit, Offset, OrderBy, and OrderByDescending are only supported for Select queries.");
         }
 
-        if ((Action == DbaXQueryAction.Insert || Action == DbaXQueryAction.Upsert) && Where != null) {
-            throw new PSArgumentException("Where is only supported for Select, Update, and Delete queries.");
+        switch (Action) {
+            case DbaXQueryAction.Select:
+                if (hasValues || hasSet || hasConflictColumns || hasUpsertUpdateOnly) {
+                    throw new PSArgumentException("Values, Set, ConflictColumns, and UpsertUpdateOnly are not supported for Select queries.");
+                }
+                break;
+            case DbaXQueryAction.Insert:
+                if (hasColumns || hasSet || hasWhere || hasConflictColumns || hasUpsertUpdateOnly) {
+                    throw new PSArgumentException("Columns, Set, Where, ConflictColumns, and UpsertUpdateOnly are not supported for Insert queries.");
+                }
+                break;
+            case DbaXQueryAction.Update:
+                if (hasColumns || hasValues || hasConflictColumns || hasUpsertUpdateOnly) {
+                    throw new PSArgumentException("Columns, Values, ConflictColumns, and UpsertUpdateOnly are not supported for Update queries.");
+                }
+                break;
+            case DbaXQueryAction.Delete:
+                if (hasColumns || hasValues || hasSet || hasConflictColumns || hasUpsertUpdateOnly) {
+                    throw new PSArgumentException("Columns, Values, Set, ConflictColumns, and UpsertUpdateOnly are not supported for Delete queries.");
+                }
+                break;
+            case DbaXQueryAction.Upsert:
+                if (hasColumns || hasSet || hasWhere) {
+                    throw new PSArgumentException("Columns, Set, and Where are not supported for Upsert queries.");
+                }
+                break;
         }
     }
 

--- a/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Management.Automation;
 using DBAClientX.QueryBuilder;
@@ -31,7 +32,7 @@ public enum DbaXQueryAction {
 
 /// <summary>Creates SQL query-builder objects using the DbaClientX core query builder.</summary>
 /// <para>Builds SELECT, INSERT, UPDATE, DELETE, and UPSERT statements without duplicating SQL-generation logic in PowerShell.</para>
-/// <para>Use <c>-Compile</c> for literal SQL output or <c>-CompileWithParameters</c> to return SQL plus ordered parameter values.</para>
+/// <para>Use <c>-Compile</c> for literal SQL output or <c>-CompileWithParameters</c> to return SQL plus an ordered parameter map.</para>
 /// <list type="alertSet">
 /// <item>
 /// <term>Note</term>
@@ -78,7 +79,7 @@ public enum DbaXQueryAction {
 /// <summary>Compile SQL with ordered parameters.</summary>
 /// <prefix>PS&gt; </prefix>
 /// <code>New-DbaXQuery -Action Update -Dialect PostgreSql -TableName 'public.users' -Set @{ display_name = 'Ada' } -Where @{ id = 42 } -CompileWithParameters</code>
-/// <para>Returns an object with <c>Sql</c> and <c>Parameters</c> properties for callers that want to execute parameterized SQL later.</para>
+/// <para>Returns an object with <c>Sql</c>, <c>Parameters</c>, and <c>ParameterValues</c> properties for callers that want to execute parameterized SQL later.</para>
 /// </example>
 /// <seealso href="https://learn.microsoft.com/sql/t-sql/queries/select-transact-sql">SELECT statement (Transact-SQL)</seealso>
 /// <seealso href="https://github.com/EvotecIT/DbaClientX">Project documentation</seealso>
@@ -177,7 +178,8 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
             var compiled = DbaQueryBuilder.CompileWithParameters(query, Dialect);
             WriteObject(new PSObject(new {
                 compiled.Sql,
-                Parameters = compiled.Parameters.ToArray()
+                Parameters = BuildParameterMap(compiled.Parameters),
+                ParameterValues = compiled.Parameters.ToArray()
             }));
         } else if (Compile) {
             WriteObject(DbaQueryBuilder.Compile(query, Dialect));
@@ -187,6 +189,7 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
     }
 
     private Query BuildQuery() {
+        ValidateUnsupportedOptions();
         var query = DbaQueryBuilder.Query();
 
         switch (Action) {
@@ -219,26 +222,26 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
     }
 
     private void ApplyInsert(Query query) {
-        var pairs = GetPairs(Values, nameof(Values));
+        var pairs = GetPairs(Values, nameof(Values), allowNullValues: true);
         query.InsertInto(TableName, pairs.Select(pair => pair.Column).ToArray())
-            .Values(pairs.Select(pair => pair.Value).ToArray());
+            .Values(ToValueArray(pairs));
     }
 
     private void ApplyUpdate(Query query) {
-        var pairs = GetPairs(Set, nameof(Set));
+        var pairs = GetPairs(Set, nameof(Set), allowNullValues: false);
         query.Update(TableName);
         foreach (var pair in pairs) {
-            query.Set(pair.Column, pair.Value);
+            query.Set(pair.Column, pair.Value!);
         }
     }
 
     private void ApplyUpsert(Query query) {
-        var pairs = GetPairs(Values, nameof(Values));
+        var pairs = GetPairs(Values, nameof(Values), allowNullValues: false);
         if (ConflictColumns is not { Length: > 0 }) {
             throw new PSArgumentException("ConflictColumns must be provided for upsert queries.", nameof(ConflictColumns));
         }
 
-        query.InsertOrUpdate(TableName, pairs, ConflictColumns);
+        query.InsertOrUpdate(TableName, pairs.Select(pair => (pair.Column, Value: pair.Value!)), ConflictColumns);
         if (UpsertUpdateOnly is { Length: > 0 }) {
             query.UpsertUpdateOnly(UpsertUpdateOnly);
         }
@@ -249,8 +252,8 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
             return;
         }
 
-        foreach (var pair in GetPairs(Where, nameof(Where))) {
-            query.Where(pair.Column, pair.Value);
+        foreach (var pair in GetPairs(Where, nameof(Where), allowNullValues: false)) {
+            query.Where(pair.Column, pair.Value!);
         }
     }
 
@@ -290,19 +293,51 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
         }
     }
 
-    private static IReadOnlyList<(string Column, object Value)> GetPairs(IDictionary? dictionary, string parameterName) {
+    private void ValidateUnsupportedOptions() {
+        if (Action == DbaXQueryAction.Select) {
+            return;
+        }
+
+        if (Limit.HasValue || Offset.HasValue || OrderBy is { Length: > 0 } || OrderByDescending is { Length: > 0 }) {
+            throw new PSArgumentException("Limit, Offset, OrderBy, and OrderByDescending are only supported for Select queries.");
+        }
+
+        if ((Action == DbaXQueryAction.Insert || Action == DbaXQueryAction.Upsert) && Where != null) {
+            throw new PSArgumentException("Where is only supported for Select, Update, and Delete queries.");
+        }
+    }
+
+    private static OrderedDictionary BuildParameterMap(IReadOnlyList<object> parameters) {
+        var map = new OrderedDictionary();
+        for (var i = 0; i < parameters.Count; i++) {
+            map.Add("@p" + i, parameters[i]);
+        }
+
+        return map;
+    }
+
+    private static object[] ToValueArray(IReadOnlyList<(string Column, object? Value)> pairs) {
+        var values = new object[pairs.Count];
+        for (var i = 0; i < pairs.Count; i++) {
+            values[i] = pairs[i].Value!;
+        }
+
+        return values;
+    }
+
+    private static IReadOnlyList<(string Column, object? Value)> GetPairs(IDictionary? dictionary, string parameterName, bool allowNullValues) {
         if (dictionary == null || dictionary.Count == 0) {
             throw new PSArgumentException($"{parameterName} must contain at least one column/value pair.", parameterName);
         }
 
-        var pairs = new List<(string Column, object Value)>(dictionary.Count);
+        var pairs = new List<(string Column, object? Value)>(dictionary.Count);
         foreach (DictionaryEntry entry in dictionary) {
             var column = entry.Key?.ToString();
             if (string.IsNullOrWhiteSpace(column)) {
                 throw new PSArgumentException($"{parameterName} contains an empty column name.", parameterName);
             }
 
-            if (entry.Value == null) {
+            if (!allowNullValues && entry.Value == null) {
                 throw new PSArgumentException($"{parameterName} cannot contain null values.", parameterName);
             }
 

--- a/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
@@ -1,47 +1,150 @@
 ﻿
-using System.Collections;
 using System;
-using System.Diagnostics;
+using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
-using System.Net;
+using DBAClientX.QueryBuilder;
+using DbaQueryBuilder = DBAClientX.QueryBuilder.QueryBuilder;
 
 namespace DBAClientX.PowerShell;
 
-/// <summary>Creates a new SQL query using the DbaX query builder.</summary>
-/// <para>Constructs a basic SELECT statement against a specified table and optionally compiles it to SQL text.</para>
-/// <para>Supports limiting and offsetting rows for paging scenarios.</para>
+/// <summary>
+/// Describes which query-builder operation <c>New-DbaXQuery</c> should create.
+/// </summary>
+public enum DbaXQueryAction {
+    /// <summary>Create a SELECT query.</summary>
+    Select,
+
+    /// <summary>Create an INSERT query.</summary>
+    Insert,
+
+    /// <summary>Create an UPDATE query.</summary>
+    Update,
+
+    /// <summary>Create a DELETE query.</summary>
+    Delete,
+
+    /// <summary>Create a provider-aware insert-or-update query.</summary>
+    Upsert
+}
+
+/// <summary>Creates SQL query-builder objects using the DbaClientX core query builder.</summary>
+/// <para>Builds SELECT, INSERT, UPDATE, DELETE, and UPSERT statements without duplicating SQL-generation logic in PowerShell.</para>
+/// <para>Use <c>-Compile</c> for literal SQL output or <c>-CompileWithParameters</c> to return SQL plus ordered parameter values.</para>
 /// <list type="alertSet">
 /// <item>
 /// <term>Note</term>
-/// <description>The cmdlet does not validate table existence; ensure the target table is correct.</description>
+/// <description>The cmdlet does not connect to the database or validate table existence; it only builds query objects or SQL text.</description>
 /// </item>
 /// </list>
 /// <example>
-/// <summary>Create a query object.</summary>
+/// <summary>Create a SELECT query object.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>New-DbaXQuery -TableName 'Users'</code>
-/// <para>Returns a query builder object targeting the Users table.</para>
+/// <code>New-DbaXQuery -TableName 'dbo.Users' -Columns Id,DisplayName</code>
+/// <para>Returns a core query object targeting selected columns from dbo.Users.</para>
 /// </example>
 /// <example>
-/// <summary>Compile the query to SQL.</summary>
+/// <summary>Compile a paged SELECT query.</summary>
 /// <prefix>PS&gt; </prefix>
-/// <code>New-DbaXQuery -TableName 'Users' -Limit 10 -Compile</code>
-/// <para>Outputs the generated SQL statement limited to ten rows.</para>
+/// <code>New-DbaXQuery -TableName 'dbo.Users' -Columns Id,DisplayName -Where @{ IsActive = $true } -OrderBy DisplayName -Limit 10 -Offset 20 -Compile</code>
+/// <para>Outputs a SQL Server SELECT statement with a WHERE clause and OFFSET/FETCH pagination.</para>
+/// </example>
+/// <example>
+/// <summary>Compile an INSERT statement.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>New-DbaXQuery -Action Insert -TableName 'dbo.Users' -Values ([ordered]@{ Id = 42; DisplayName = 'Ada' }) -Compile</code>
+/// <para>Outputs an INSERT statement using the DbaClientX core query compiler.</para>
+/// </example>
+/// <example>
+/// <summary>Compile an UPDATE statement.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>New-DbaXQuery -Action Update -TableName 'dbo.Users' -Set @{ DisplayName = 'Ada Lovelace' } -Where @{ Id = 42 } -Compile</code>
+/// <para>Outputs an UPDATE statement with values supplied by PowerShell hashtables.</para>
+/// </example>
+/// <example>
+/// <summary>Compile a DELETE statement.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>New-DbaXQuery -Action Delete -TableName 'dbo.Users' -Where @{ Id = 42 } -Compile</code>
+/// <para>Outputs a DELETE statement scoped by the provided WHERE values.</para>
+/// </example>
+/// <example>
+/// <summary>Compile a provider-specific UPSERT statement.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>New-DbaXQuery -Action Upsert -Dialect PostgreSql -TableName 'public.users' -Values ([ordered]@{ id = 42; display_name = 'Ada'; email = 'ada@example.test' }) -ConflictColumns id -UpsertUpdateOnly display_name,email -Compile</code>
+/// <para>Outputs a PostgreSQL INSERT ... ON CONFLICT statement. Use another <c>-Dialect</c> value for SQL Server, MySQL, SQLite, or Oracle compiler behavior.</para>
+/// </example>
+/// <example>
+/// <summary>Compile SQL with ordered parameters.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>New-DbaXQuery -Action Update -Dialect PostgreSql -TableName 'public.users' -Set @{ display_name = 'Ada' } -Where @{ id = 42 } -CompileWithParameters</code>
+/// <para>Returns an object with <c>Sql</c> and <c>Parameters</c> properties for callers that want to execute parameterized SQL later.</para>
 /// </example>
 /// <seealso href="https://learn.microsoft.com/sql/t-sql/queries/select-transact-sql">SELECT statement (Transact-SQL)</seealso>
 /// <seealso href="https://github.com/EvotecIT/DbaClientX">Project documentation</seealso>
-[Cmdlet(VerbsCommon.New, "DbaXQuery", DefaultParameterSetName = "Compatibility", SupportsShouldProcess = true)]
+[Cmdlet(VerbsCommon.New, "DbaXQuery", SupportsShouldProcess = true)]
 [CmdletBinding()]
 public sealed class CmdletNewDbaXQuery : PSCmdlet {
-    /// <summary>Name of the table to select from.</summary>
+    /// <summary>The query-builder operation to create.</summary>
+    [Parameter(Mandatory = false)]
+    public DbaXQueryAction Action { get; set; } = DbaXQueryAction.Select;
+
+    /// <summary>Name of the table targeted by the query.</summary>
     [Parameter(Mandatory = true, Position = 0)]
     [ValidateNotNullOrEmpty]
     public string TableName { get; set; } = string.Empty;
 
+    /// <summary>Columns to include in a SELECT statement. When omitted, the core builder emits <c>*</c>.</summary>
+    [Parameter(Mandatory = false)]
+    [ValidateNotNullOrEmpty]
+    public string[]? Columns { get; set; }
+
+    /// <summary>Column/value pairs for INSERT or UPSERT statements.</summary>
+    [Parameter(Mandatory = false)]
+    [ValidateNotNullOrEmpty]
+    public IDictionary? Values { get; set; }
+
+    /// <summary>Column/value pairs for UPDATE SET clauses.</summary>
+    [Parameter(Mandatory = false)]
+    [ValidateNotNullOrEmpty]
+    public IDictionary? Set { get; set; }
+
+    /// <summary>Column/value pairs added as equality predicates to the WHERE clause.</summary>
+    [Parameter(Mandatory = false)]
+    [ValidateNotNullOrEmpty]
+    public IDictionary? Where { get; set; }
+
+    /// <summary>Columns used to detect UPSERT conflicts.</summary>
+    [Parameter(Mandatory = false)]
+    [ValidateNotNullOrEmpty]
+    public string[]? ConflictColumns { get; set; }
+
+    /// <summary>Columns updated during an UPSERT conflict. When omitted, the core builder updates all non-conflict insert columns.</summary>
+    [Parameter(Mandatory = false)]
+    [ValidateNotNullOrEmpty]
+    public string[]? UpsertUpdateOnly { get; set; }
+
+    /// <summary>Columns to add to ORDER BY in ascending order.</summary>
+    [Parameter(Mandatory = false)]
+    [ValidateNotNullOrEmpty]
+    public string[]? OrderBy { get; set; }
+
+    /// <summary>Columns to add to ORDER BY in descending order.</summary>
+    [Parameter(Mandatory = false)]
+    [ValidateNotNullOrEmpty]
+    public string[]? OrderByDescending { get; set; }
+
     /// <summary>Compiles the query to a SQL string.</summary>
     [Parameter(Mandatory = false)]
     public SwitchParameter Compile { get; set; }
+
+    /// <summary>Compiles the query to SQL text and returns ordered parameter values.</summary>
+    [Parameter(Mandatory = false)]
+    public SwitchParameter CompileWithParameters { get; set; }
+
+    /// <summary>SQL dialect used when compiling the query.</summary>
+    [Parameter(Mandatory = false)]
+    public SqlDialect Dialect { get; set; } = SqlDialect.SqlServer;
 
     /// <summary>Limits the number of returned rows.</summary>
     [Parameter(Mandatory = false)]
@@ -68,37 +171,144 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
     /// Processes input and performs the cmdlet's primary work.
     /// </summary>
     protected override void ProcessRecord() {
-        var query = DBAClientX.QueryBuilder.QueryBuilder.Query().From(TableName);
+        var query = BuildQuery();
 
+        if (CompileWithParameters) {
+            var compiled = DbaQueryBuilder.CompileWithParameters(query, Dialect);
+            WriteObject(new PSObject(new {
+                compiled.Sql,
+                Parameters = compiled.Parameters.ToArray()
+            }));
+        } else if (Compile) {
+            WriteObject(DbaQueryBuilder.Compile(query, Dialect));
+        } else {
+            WriteObject(query);
+        }
+    }
+
+    private Query BuildQuery() {
+        var query = DbaQueryBuilder.Query();
+
+        switch (Action) {
+            case DbaXQueryAction.Select:
+                query.From(TableName);
+                if (Columns is { Length: > 0 }) {
+                    query.Select(Columns);
+                }
+                break;
+            case DbaXQueryAction.Insert:
+                ApplyInsert(query);
+                break;
+            case DbaXQueryAction.Update:
+                ApplyUpdate(query);
+                break;
+            case DbaXQueryAction.Delete:
+                query.DeleteFrom(TableName);
+                break;
+            case DbaXQueryAction.Upsert:
+                ApplyUpsert(query);
+                break;
+            default:
+                throw new PSArgumentException($"Unsupported query action '{Action}'.", nameof(Action));
+        }
+
+        ApplyWhere(query);
+        ApplyOrdering(query);
+        ApplyPaging(query);
+        return query;
+    }
+
+    private void ApplyInsert(Query query) {
+        var pairs = GetPairs(Values, nameof(Values));
+        query.InsertInto(TableName, pairs.Select(pair => pair.Column).ToArray())
+            .Values(pairs.Select(pair => pair.Value).ToArray());
+    }
+
+    private void ApplyUpdate(Query query) {
+        var pairs = GetPairs(Set, nameof(Set));
+        query.Update(TableName);
+        foreach (var pair in pairs) {
+            query.Set(pair.Column, pair.Value);
+        }
+    }
+
+    private void ApplyUpsert(Query query) {
+        var pairs = GetPairs(Values, nameof(Values));
+        if (ConflictColumns is not { Length: > 0 }) {
+            throw new PSArgumentException("ConflictColumns must be provided for upsert queries.", nameof(ConflictColumns));
+        }
+
+        query.InsertOrUpdate(TableName, pairs, ConflictColumns);
+        if (UpsertUpdateOnly is { Length: > 0 }) {
+            query.UpsertUpdateOnly(UpsertUpdateOnly);
+        }
+    }
+
+    private void ApplyWhere(Query query) {
+        if (Where == null) {
+            return;
+        }
+
+        foreach (var pair in GetPairs(Where, nameof(Where))) {
+            query.Where(pair.Column, pair.Value);
+        }
+    }
+
+    private void ApplyOrdering(Query query) {
+        if (OrderBy is { Length: > 0 }) {
+            query.OrderBy(OrderBy);
+        }
+
+        if (OrderByDescending is { Length: > 0 }) {
+            query.OrderByDescending(OrderByDescending);
+        }
+    }
+
+    private void ApplyPaging(Query query) {
         if (Limit.HasValue) {
             if (Limit.Value < 0) {
-                var message = "Limit must be a non-negative value.";
-                WriteWarning(message);
-                if (errorAction == ActionPreference.Stop) {
-                    ThrowTerminatingError(new ErrorRecord(new PSArgumentException(message), "LimitNegative", ErrorCategory.InvalidArgument, Limit));
-                }
+                HandleNonNegativeValidation("Limit", Limit.Value);
             } else {
-                query = query.Limit(Limit.Value);
+                query.Limit(Limit.Value);
             }
         }
 
         if (Offset.HasValue) {
             if (Offset.Value < 0) {
-                var message = "Offset must be a non-negative value.";
-                WriteWarning(message);
-                if (errorAction == ActionPreference.Stop) {
-                    ThrowTerminatingError(new ErrorRecord(new PSArgumentException(message), "OffsetNegative", ErrorCategory.InvalidArgument, Offset));
-                }
+                HandleNonNegativeValidation("Offset", Offset.Value);
             } else {
-                query = query.Offset(Offset.Value);
+                query.Offset(Offset.Value);
             }
         }
+    }
 
-        if (!Compile) {
-            WriteObject(query);
-        } else {
-            var sql = DBAClientX.QueryBuilder.QueryBuilder.Compile(query);
-            WriteObject(sql);
+    private void HandleNonNegativeValidation(string parameterName, int value) {
+        var message = $"{parameterName} must be a non-negative value.";
+        WriteWarning(message);
+        if (errorAction == ActionPreference.Stop) {
+            ThrowTerminatingError(new ErrorRecord(new PSArgumentException(message), $"{parameterName}Negative", ErrorCategory.InvalidArgument, value));
         }
+    }
+
+    private static IReadOnlyList<(string Column, object Value)> GetPairs(IDictionary? dictionary, string parameterName) {
+        if (dictionary == null || dictionary.Count == 0) {
+            throw new PSArgumentException($"{parameterName} must contain at least one column/value pair.", parameterName);
+        }
+
+        var pairs = new List<(string Column, object Value)>(dictionary.Count);
+        foreach (DictionaryEntry entry in dictionary) {
+            var column = entry.Key?.ToString();
+            if (string.IsNullOrWhiteSpace(column)) {
+                throw new PSArgumentException($"{parameterName} contains an empty column name.", parameterName);
+            }
+
+            if (entry.Value == null) {
+                throw new PSArgumentException($"{parameterName} cannot contain null values.", parameterName);
+            }
+
+            pairs.Add((column!, entry.Value));
+        }
+
+        return pairs;
     }
 }

--- a/DbaClientX.PowerShell/README.md
+++ b/DbaClientX.PowerShell/README.md
@@ -45,10 +45,11 @@ New-DbaXQuery -Action Delete -Dialect PostgreSql -TableName 'public.users' -Wher
 New-DbaXQuery -Action Upsert -Dialect PostgreSql -TableName 'public.users' -Values ([ordered]@{ id = 42; display_name = 'Ada'; email = 'ada@example.test' }) -ConflictColumns id -UpsertUpdateOnly display_name,email -Compile
 ```
 
-Return parameterized SQL plus ordered parameter values:
+Return parameterized SQL plus a named parameter map:
 
 ```powershell
-New-DbaXQuery -Action Update -Dialect PostgreSql -TableName 'public.users' -Set @{ display_name = 'Ada' } -Where @{ id = 42 } -CompileWithParameters
+$compiled = New-DbaXQuery -Action Update -Dialect PostgreSql -TableName 'public.users' -Set @{ display_name = 'Ada' } -Where @{ id = 42 } -CompileWithParameters
+Invoke-DbaXPostgreSqlNonQuery -Server 'localhost' -Database 'app' -Username 'user' -Password 'p@ss' -Query $compiled.Sql -Parameters $compiled.Parameters
 ```
 
 ## Notes

--- a/DbaClientX.PowerShell/README.md
+++ b/DbaClientX.PowerShell/README.md
@@ -27,8 +27,32 @@ SQLite query returning a DataTable:
 Invoke-DbaXSQLite -Database './app.db' -Query 'SELECT Id, Name FROM Users' -ReturnType DataTable
 ```
 
+Build SQL through the core query builder:
+
+```powershell
+New-DbaXQuery -TableName 'dbo.Users' -Columns Id,DisplayName -Where @{ IsActive = $true } -OrderBy DisplayName -Limit 10 -Compile
+```
+
+Generate INSERT, UPDATE, DELETE, and UPSERT statements without hand-writing provider quoting:
+
+```powershell
+New-DbaXQuery -Action Insert -TableName 'dbo.Users' -Values ([ordered]@{ Id = 42; DisplayName = 'Ada' }) -Compile
+
+New-DbaXQuery -Action Update -Dialect PostgreSql -TableName 'public.users' -Set @{ display_name = 'Ada Lovelace' } -Where @{ id = 42 } -Compile
+
+New-DbaXQuery -Action Delete -Dialect PostgreSql -TableName 'public.users' -Where @{ id = 42 } -Compile
+
+New-DbaXQuery -Action Upsert -Dialect PostgreSql -TableName 'public.users' -Values ([ordered]@{ id = 42; display_name = 'Ada'; email = 'ada@example.test' }) -ConflictColumns id -UpsertUpdateOnly display_name,email -Compile
+```
+
+Return parameterized SQL plus ordered parameter values:
+
+```powershell
+New-DbaXQuery -Action Update -Dialect PostgreSql -TableName 'public.users' -Set @{ display_name = 'Ada' } -Where @{ id = 42 } -CompileWithParameters
+```
+
 ## Notes
 
 - See per-provider README for connection guidance.
 - For large result sets, prefer `-Stream` where supported.
-
+- `New-DbaXQuery` builds query objects and SQL text only; execute SQL with the provider-specific `Invoke-DbaX*` cmdlets.

--- a/Module/Examples/Example.NewDbaXQuery.ps1
+++ b/Module/Examples/Example.NewDbaXQuery.ps1
@@ -1,10 +1,43 @@
 Clear-Host
 Import-Module $PSScriptRoot\..\DbaClientX.psd1 -Force -Verbose
 
-# Build query with modern pagination
-$query = New-DbaXQuery -TableName users -Compile -Limit 5 -Offset 2
-# Outputs: SELECT * FROM [users] OFFSET 2 ROWS FETCH NEXT 5 ROWS ONLY
+# Build query with modern SQL Server pagination. OFFSET/FETCH requires ORDER BY.
+$query = New-DbaXQuery -TableName users -Columns id, name -OrderBy name -Compile -Limit 5 -Offset 2
+# Outputs: SELECT [id], [name] FROM [users] ORDER BY [name] OFFSET 2 ROWS FETCH NEXT 5 ROWS ONLY
 $query
+
+# Build INSERT, UPDATE, DELETE, and UPSERT statements through the same core builder.
+$insert = New-DbaXQuery -Action Insert -TableName users -Values ([ordered]@{
+    id   = 1
+    name = 'Ada'
+}) -Compile
+$insert
+
+$update = New-DbaXQuery -Action Update -Dialect PostgreSql -TableName users -Set @{
+    name = 'Ada Lovelace'
+} -Where @{
+    id = 1
+} -Compile
+$update
+
+$delete = New-DbaXQuery -Action Delete -Dialect PostgreSql -TableName users -Where @{
+    id = 1
+} -Compile
+$delete
+
+$upsert = New-DbaXQuery -Action Upsert -Dialect PostgreSql -TableName users -Values ([ordered]@{
+    id    = 1
+    name  = 'Ada'
+    email = 'ada@example.test'
+}) -ConflictColumns id -UpsertUpdateOnly name, email -Compile
+$upsert
+
+$parameterized = New-DbaXQuery -Action Update -Dialect PostgreSql -TableName users -Set @{
+    name = 'Ada'
+} -Where @{
+    id = 1
+} -CompileWithParameters
+$parameterized
 
 # Invalid pagination values emit warnings and can be converted to errors
 try {

--- a/Module/Tests/CmdletNewDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletNewDbaXQuery.Tests.ps1
@@ -6,8 +6,56 @@ Describe 'New-DbaXQuery builder' {
         $query | Should -Be 'SELECT * FROM [users]'
     }
 
+    It 'Compiles selected columns with SQL Server pagination when ordered' {
+        $query = New-DbaXQuery -TableName users -Columns id, name -OrderBy name -Compile -Limit 5 -Offset 2
+        $query | Should -Be 'SELECT [id], [name] FROM [users] ORDER BY [name] OFFSET 2 ROWS FETCH NEXT 5 ROWS ONLY'
+    }
+
     It 'Rejects SQL Server pagination without ORDER BY' {
         { New-DbaXQuery -TableName users -Compile -Limit 5 -Offset 2 } | Should -Throw
+    }
+
+    It 'Compiles SELECT using the requested dialect' {
+        $query = New-DbaXQuery -TableName users -Columns id, name -OrderBy name -Dialect PostgreSql -Compile -Limit 5 -Offset 2
+        $query | Should -Be 'SELECT "id", "name" FROM "users" ORDER BY "name" LIMIT 5 OFFSET 2'
+    }
+
+    It 'Compiles INSERT from a hashtable through the core builder' {
+        $query = New-DbaXQuery -Action Insert -TableName users -Values ([ordered]@{ id = 1; name = 'Ada' }) -Compile
+        $query | Should -Be "INSERT INTO [users] ([id], [name]) VALUES (1, 'Ada')"
+    }
+
+    It 'Compiles UPDATE from Set and Where hashtables through the core builder' {
+        $query = New-DbaXQuery -Action Update -Dialect PostgreSql -TableName users -Set ([ordered]@{ name = 'Ada' }) -Where ([ordered]@{ id = 1 }) -Compile
+        $query | Should -Be "UPDATE ""users"" SET ""name"" = 'Ada' WHERE ""id"" = 1"
+    }
+
+    It 'Compiles DELETE from a Where hashtable through the core builder' {
+        $query = New-DbaXQuery -Action Delete -Dialect PostgreSql -TableName users -Where ([ordered]@{ id = 1 }) -Compile
+        $query | Should -Be 'DELETE FROM "users" WHERE "id" = 1'
+    }
+
+    It 'Compiles UPSERT using conflict columns and update-only columns' {
+        $query = New-DbaXQuery -Action Upsert -Dialect PostgreSql -TableName users -Values ([ordered]@{ id = 1; name = 'Ada'; email = 'ada@example.test' }) -ConflictColumns id -UpsertUpdateOnly name -Compile
+        $query | Should -Be "INSERT INTO ""users"" (""id"", ""name"", ""email"") VALUES (1, 'Ada', 'ada@example.test') ON CONFLICT (""id"") DO UPDATE SET ""name"" = EXCLUDED.""name"""
+    }
+
+    It 'Returns SQL and ordered parameter values when requested' {
+        $compiled = New-DbaXQuery -Action Update -Dialect PostgreSql -TableName users -Set ([ordered]@{ name = 'Ada' }) -Where ([ordered]@{ id = 1 }) -CompileWithParameters
+        $compiled.Sql | Should -Be 'UPDATE "users" SET "name" = @p0 WHERE "id" = @p1'
+        $compiled.Parameters | Should -Be @('Ada', 1)
+    }
+
+    It 'Requires Values for INSERT' {
+        { New-DbaXQuery -Action Insert -TableName users -Compile } | Should -Throw
+    }
+
+    It 'Requires Set for UPDATE' {
+        { New-DbaXQuery -Action Update -TableName users -Compile } | Should -Throw
+    }
+
+    It 'Requires conflict columns for UPSERT' {
+        { New-DbaXQuery -Action Upsert -TableName users -Values ([ordered]@{ id = 1; name = 'Ada' }) -Compile } | Should -Throw
     }
 
     It 'Ignores negative pagination values with default ErrorAction' {
@@ -31,4 +79,3 @@ Describe 'New-DbaXQuery builder' {
         { New-DbaXQuery -TableName $null -Compile } | Should -Throw
     }
 }
-

--- a/Module/Tests/CmdletNewDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletNewDbaXQuery.Tests.ps1
@@ -20,6 +20,11 @@ Describe 'New-DbaXQuery builder' {
         $query | Should -Be 'SELECT "id", "name" FROM "users" ORDER BY "name" LIMIT 5 OFFSET 2'
     }
 
+    It 'Maps null Where values to IS NULL predicates' {
+        $query = New-DbaXQuery -TableName users -Where @{ deleted_at = $null } -Compile
+        $query | Should -Be 'SELECT * FROM [users] WHERE [deleted_at] IS NULL'
+    }
+
     It 'Compiles INSERT from a hashtable through the core builder' {
         $query = New-DbaXQuery -Action Insert -TableName users -Values ([ordered]@{ id = 1; name = 'Ada' }) -Compile
         $query | Should -Be "INSERT INTO [users] ([id], [name]) VALUES (1, 'Ada')"
@@ -73,6 +78,13 @@ Describe 'New-DbaXQuery builder' {
     It 'Rejects Where for insert and upsert actions' {
         { New-DbaXQuery -Action Insert -TableName users -Values @{ id = 1 } -Where @{ id = 1 } -Compile } | Should -Throw
         { New-DbaXQuery -Action Upsert -TableName users -Values @{ id = 1; name = 'Ada' } -ConflictColumns id -Where @{ id = 1 } -Compile } | Should -Throw
+    }
+
+    It 'Rejects action-specific parameters that would otherwise be ignored' {
+        { New-DbaXQuery -TableName users -Values @{ id = 1 } -Compile } | Should -Throw
+        { New-DbaXQuery -Action Delete -TableName users -Set @{ name = 'Ada' } -Where @{ id = 1 } -Compile } | Should -Throw
+        { New-DbaXQuery -Action Update -TableName users -Values @{ id = 1 } -Set @{ name = 'Ada' } -Compile } | Should -Throw
+        { New-DbaXQuery -Action Upsert -TableName users -Values @{ id = 1; name = 'Ada' } -ConflictColumns id -Columns id -Compile } | Should -Throw
     }
 
     It 'Ignores negative pagination values with default ErrorAction' {

--- a/Module/Tests/CmdletNewDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletNewDbaXQuery.Tests.ps1
@@ -25,6 +25,11 @@ Describe 'New-DbaXQuery builder' {
         $query | Should -Be "INSERT INTO [users] ([id], [name]) VALUES (1, 'Ada')"
     }
 
+    It 'Allows null values in INSERT payloads' {
+        $query = New-DbaXQuery -Action Insert -TableName users -Values ([ordered]@{ id = 1; deleted_at = $null }) -Compile
+        $query | Should -Be 'INSERT INTO [users] ([id], [deleted_at]) VALUES (1, NULL)'
+    }
+
     It 'Compiles UPDATE from Set and Where hashtables through the core builder' {
         $query = New-DbaXQuery -Action Update -Dialect PostgreSql -TableName users -Set ([ordered]@{ name = 'Ada' }) -Where ([ordered]@{ id = 1 }) -Compile
         $query | Should -Be "UPDATE ""users"" SET ""name"" = 'Ada' WHERE ""id"" = 1"
@@ -43,7 +48,9 @@ Describe 'New-DbaXQuery builder' {
     It 'Returns SQL and ordered parameter values when requested' {
         $compiled = New-DbaXQuery -Action Update -Dialect PostgreSql -TableName users -Set ([ordered]@{ name = 'Ada' }) -Where ([ordered]@{ id = 1 }) -CompileWithParameters
         $compiled.Sql | Should -Be 'UPDATE "users" SET "name" = @p0 WHERE "id" = @p1'
-        $compiled.Parameters | Should -Be @('Ada', 1)
+        $compiled.Parameters['@p0'] | Should -Be 'Ada'
+        $compiled.Parameters['@p1'] | Should -Be 1
+        $compiled.ParameterValues | Should -Be @('Ada', 1)
     }
 
     It 'Requires Values for INSERT' {
@@ -56,6 +63,16 @@ Describe 'New-DbaXQuery builder' {
 
     It 'Requires conflict columns for UPSERT' {
         { New-DbaXQuery -Action Upsert -TableName users -Values ([ordered]@{ id = 1; name = 'Ada' }) -Compile } | Should -Throw
+    }
+
+    It 'Rejects paging and ordering options for DML actions' {
+        { New-DbaXQuery -Action Delete -TableName users -Where @{ id = 1 } -Limit 1 -Compile } | Should -Throw
+        { New-DbaXQuery -Action Update -TableName users -Set @{ name = 'Ada' } -OrderBy id -Compile } | Should -Throw
+    }
+
+    It 'Rejects Where for insert and upsert actions' {
+        { New-DbaXQuery -Action Insert -TableName users -Values @{ id = 1 } -Where @{ id = 1 } -Compile } | Should -Throw
+        { New-DbaXQuery -Action Upsert -TableName users -Values @{ id = 1; name = 'Ada' } -ConflictColumns id -Where @{ id = 1 } -Compile } | Should -Throw
     }
 
     It 'Ignores negative pagination values with default ErrorAction' {


### PR DESCRIPTION
## Summary
- expose DbaClientX core query-builder DML paths through `New-DbaXQuery` for select, insert, update, delete, and upsert
- add dialect selection, ordered hashtable mapping, where/order/paging support, and parameterized compilation output
- expand XML help examples, README examples, script examples, and Pester coverage for the PowerShell wrapper contract

## Validation
- `dotnet build DbaClientX.PowerShell\DbaClientX.PowerShell.csproj -c Release`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\Module\DbaClientX.Tests.ps1`
- `dotnet test DbaClientX.Tests\DbaClientX.Tests.csproj -c Debug --framework net8.0`
- `git diff --check`