### PR TITLE
Expand SQL Server data movement benchmarks

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -110,6 +110,10 @@ jobs:
               shell: pwsh
               run: |
                   Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+                  if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+                      Register-PSRepository -Default
+                  }
+                  Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
                   Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
                   Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
 
@@ -190,6 +194,10 @@ jobs:
               shell: pwsh
               run: |
                   Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+                  if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+                      Register-PSRepository -Default
+                  }
+                  Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
                   Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
                   Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
 
@@ -234,6 +242,10 @@ jobs:
               shell: pwsh
               run: |
                   Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+                  if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+                      Register-PSRepository -Default
+                  }
+                  Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
                   Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
                   Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
 

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -1167,15 +1167,20 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             table.Columns.Add(GetUniqueColumnName(reader.GetName(i), i, columnNames), reader.GetFieldType(i));
         }
 
-        while (reader.Read())
+        var fieldCount = reader.FieldCount;
+        var values = new object[fieldCount];
+        table.BeginLoadData();
+        try
         {
-            var row = table.NewRow();
-            for (var i = 0; i < reader.FieldCount; i++)
+            while (reader.Read())
             {
-                row[i] = reader.IsDBNull(i) ? DBNull.Value : reader.GetValue(i);
+                reader.GetValues(values);
+                table.Rows.Add(values);
             }
-
-            table.Rows.Add(row);
+        }
+        finally
+        {
+            table.EndLoadData();
         }
 
         return table;
@@ -1197,17 +1202,20 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             table.Columns.Add(GetUniqueColumnName(reader.GetName(i), i, columnNames), reader.GetFieldType(i));
         }
 
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        var fieldCount = reader.FieldCount;
+        var values = new object[fieldCount];
+        table.BeginLoadData();
+        try
         {
-            var row = table.NewRow();
-            for (var i = 0; i < reader.FieldCount; i++)
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
-                row[i] = await reader.IsDBNullAsync(i, cancellationToken).ConfigureAwait(false)
-                    ? DBNull.Value
-                    : reader.GetValue(i);
+                reader.GetValues(values);
+                table.Rows.Add(values);
             }
-
-            table.Rows.Add(row);
+        }
+        finally
+        {
+            table.EndLoadData();
         }
 
         return table;

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -176,8 +176,10 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
                             foreach (DataRow row in ((DataTable)result).Rows) {
                                 WriteObject(PSObjectConverter.DataRowToPSObject(row));
                             }
-                        } else {
+                        } else if (ReturnType == ReturnType.DataRow) {
                             WriteObject(result, true);
+                        } else {
+                            WriteObject(result);
                         }
                     }
                     return;
@@ -192,8 +194,10 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
                             foreach (DataRow row in ((DataTable)result).Rows) {
                                 WriteObject(PSObjectConverter.DataRowToPSObject(row));
                             }
-                        } else {
+                        } else if (ReturnType == ReturnType.DataRow) {
                             WriteObject(result, true);
+                        } else {
+                            WriteObject(result);
                         }
                     }
                     return;
@@ -244,8 +248,10 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
                     foreach (DataRow row in ((DataTable)result).Rows) {
                         WriteObject(PSObjectConverter.DataRowToPSObject(row));
                     }
-                } else {
+                } else if (ReturnType == ReturnType.DataRow) {
                     WriteObject(result, true);
+                } else {
+                    WriteObject(result);
                 }
             }
         } catch (Exception ex) {

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
@@ -178,8 +178,10 @@ public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
                     foreach (DataRow row in ((DataTable)result).Rows) {
                         WriteObject(PSObjectConverter.DataRowToPSObject(row));
                     }
-                } else {
+                } else if (ReturnType == ReturnType.DataRow) {
                     WriteObject(result, true);
+                } else {
+                    WriteObject(result);
                 }
             }
         } catch (Exception ex) {

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXOracle.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXOracle.cs
@@ -141,8 +141,10 @@ public sealed class CmdletInvokeDbaXOracle : AsyncPSCmdlet {
                     foreach (DataRow row in ((DataTable)result).Rows) {
                         WriteObject(PSObjectConverter.DataRowToPSObject(row));
                     }
-                } else {
+                } else if (ReturnType == ReturnType.DataRow) {
                     WriteObject(result, true);
+                } else {
+                    WriteObject(result);
                 }
             }
         } catch (Exception ex) {

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSql.cs
@@ -189,8 +189,10 @@ public sealed class CmdletInvokeDbaXPostgreSql : AsyncPSCmdlet {
                     foreach (DataRow row in ((DataTable)result).Rows) {
                         WriteObject(PSObjectConverter.DataRowToPSObject(row));
                     }
-                } else {
+                } else if (ReturnType == ReturnType.DataRow) {
                     WriteObject(result, true);
+                } else {
+                    WriteObject(result);
                 }
             }
         } catch (Exception ex) {

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
@@ -134,8 +134,10 @@ public sealed class CmdletInvokeDbaXSQLite : AsyncPSCmdlet {
                     foreach (DataRow row in ((DataTable)result).Rows) {
                         WriteObject(PSObjectConverter.DataRowToPSObject(row));
                     }
-                } else {
+                } else if (ReturnType == ReturnType.DataRow) {
                     WriteObject(result, true);
+                } else {
+                    WriteObject(result);
                 }
             }
         } catch (Exception ex) {

--- a/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
+++ b/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
@@ -1,0 +1,95 @@
+using System.Data;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using System.Management.Automation.Runspaces;
+using DBAClientX;
+using DBAClientX.PowerShell;
+using Microsoft.Data.SqlClient;
+
+namespace DbaClientX.Tests;
+
+public class InvokeDbaXQueryCmdletTests
+{
+    [Fact]
+    public void DataTableReturnType_EmitsSingleDataTable()
+    {
+        using var table = CreateTable();
+        CmdletIInvokeDbaXQuery.SqlServerFactory = () => new DataTableSqlServer(table);
+
+        try
+        {
+            var results = InvokeQuery(ReturnType.DataTable);
+
+            var result = Assert.Single(results);
+            var resultTable = Assert.IsType<DataTable>(result.BaseObject);
+            Assert.Equal(2, resultTable.Rows.Count);
+        }
+        finally
+        {
+            CmdletIInvokeDbaXQuery.SqlServerFactory = () => new SqlServer();
+        }
+    }
+
+    [Fact]
+    public void DataRowReturnType_EmitsEachDataRow()
+    {
+        using var table = CreateTable();
+        CmdletIInvokeDbaXQuery.SqlServerFactory = () => new DataTableSqlServer(table);
+
+        try
+        {
+            var results = InvokeQuery(ReturnType.DataRow);
+
+            Assert.Equal(2, results.Count);
+            Assert.All(results, result => Assert.IsType<DataRow>(result.BaseObject));
+        }
+        finally
+        {
+            CmdletIInvokeDbaXQuery.SqlServerFactory = () => new SqlServer();
+        }
+    }
+
+    private sealed class DataTableSqlServer : SqlServer
+    {
+        private readonly DataTable _table;
+
+        public DataTableSqlServer(DataTable table)
+        {
+            _table = table;
+        }
+
+        public override object? Query(
+            string connectionString,
+            string query,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            IDictionary<string, SqlDbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+            => ReturnType == ReturnType.DataRow ? _table.Rows : _table;
+    }
+
+    private static DataTable CreateTable()
+    {
+        var table = new DataTable("Rows");
+        table.Columns.Add("Id", typeof(int));
+        table.Rows.Add(1);
+        table.Rows.Add(2);
+        return table;
+    }
+
+    private static Collection<PSObject> InvokeQuery(ReturnType returnType)
+    {
+        var state = InitialSessionState.CreateDefault();
+        state.Commands.Add(new SessionStateCmdletEntry("Invoke-DbaXQuery", typeof(CmdletIInvokeDbaXQuery), helpFileName: null));
+
+        using var powerShell = PowerShell.Create(state);
+        powerShell
+            .AddCommand("Invoke-DbaXQuery")
+            .AddParameter("Server", "localhost")
+            .AddParameter("Database", "tempdb")
+            .AddParameter("Query", "SELECT 1")
+            .AddParameter("ReturnType", returnType);
+
+        return powerShell.Invoke();
+    }
+}

--- a/Module/Examples/Benchmark.SqlServerDataMovement.ps1
+++ b/Module/Examples/Benchmark.SqlServerDataMovement.ps1
@@ -18,6 +18,7 @@ param(
         }
     ),
     [string[]] $Engine,
+    [ValidateSet('Read', 'Write')]
     [string[]] $Operation,
     [string] $OutputRoot,
     [switch] $Plan,
@@ -48,11 +49,12 @@ $settings = {
     $moduleRoot = (Resolve-Path -LiteralPath (Join-Path $benchmarkScriptRoot '..')).Path
     $moduleManifest = Join-Path $moduleRoot 'DbaClientX.psd1'
     $readmePath = Join-Path $sourceRoot 'README.md'
-    $outputRoot = if (Test-Path -LiteralPath $readmePath) {
+    $defaultOutputRoot = if (Test-Path -LiteralPath $readmePath) {
         Join-Path $sourceRoot 'Ignore\Benchmarks\SqlServerDataMovement'
     } else {
         Join-Path ([System.IO.Path]::GetTempPath()) 'DbaClientX\Benchmarks\SqlServerDataMovement'
     }
+    $outputRootBase = if ($OutputRoot) { $OutputRoot } else { $defaultOutputRoot }
 
     $server = $Server
     $database = $Database
@@ -61,61 +63,47 @@ $settings = {
     $rowCounts = $RowCount
     $batchSizes = $BatchSize
     $inputKinds = $InputKind
+    $selectedOperations = if ($Operation) { $Operation } else { @('Write', 'Read') }
 
-    benchmark 'sqlserver-data-movement' -out $outputRoot {
-        policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
-        profile Current -Cleanup KeepOnFailure
+    function New-DbaClientXBenchmarkData {
+        param(
+            [int] $RowCount,
+            [ValidateSet('DataTable', 'PSCustomObject', 'Class')]
+            [string] $InputKind,
+            [datetime] $CreatedUtc
+        )
 
-        caseSource {
-            foreach ($rowCount in $rowCounts) {
-                foreach ($batchSize in $batchSizes) {
-                    foreach ($inputKind in $inputKinds) {
-                        [pscustomobject]@{
-                            Scenario = "$rowCount rows / batch $batchSize / $inputKind"
-                            RowCount = $rowCount
-                            BatchSize = $batchSize
-                            InputKind = $inputKind
-                        }
-                    }
-                }
+        if ($InputKind -eq 'DataTable') {
+            $table = [System.Data.DataTable]::new('DbaClientXBenchmark')
+            [void] $table.Columns.Add('Id', [int])
+            [void] $table.Columns.Add('DisplayName', [string])
+            [void] $table.Columns.Add('Score', [decimal])
+            [void] $table.Columns.Add('CreatedUtc', [datetime])
+
+            for ($index = 1; $index -le $RowCount; $index++) {
+                [void] $table.Rows.Add($index, "Row $index", [decimal]($index * 1.25), $CreatedUtc)
             }
+
+            return $table
         }
 
-        setup {
-            param($case, $run)
+        if ($InputKind -eq 'PSCustomObject') {
+            $rows = [System.Collections.Generic.List[object]]::new($RowCount)
+            for ($index = 1; $index -le $RowCount; $index++) {
+                $rows.Add([pscustomobject]@{
+                    Id = $index
+                    DisplayName = "Row $index"
+                    Score = [decimal]($index * 1.25)
+                    CreatedUtc = $CreatedUtc
+                })
+            }
 
-            $run.Server = $server
-            $run.Database = $database
-            $run.ModulePath = $modulePath
-            $run.KeepTables = $keepTables
-            $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
-            $run.TableName = 'DbaClientXBench_{0}_{1}' -f ($case.Engine -replace '[^A-Za-z0-9_]', ''), ([guid]::NewGuid().ToString('N').Substring(0, 8))
-            $createdUtc = [datetime]::UtcNow
-            if ($case.InputKind -eq 'DataTable') {
-                $run.Data = [System.Data.DataTable]::new('DbaClientXBenchmark')
-                [void] $run.Data.Columns.Add('Id', [int])
-                [void] $run.Data.Columns.Add('DisplayName', [string])
-                [void] $run.Data.Columns.Add('Score', [decimal])
-                [void] $run.Data.Columns.Add('CreatedUtc', [datetime])
+            return $rows.ToArray()
+        }
 
-                foreach ($index in 1..([int] $case.RowCount)) {
-                    [void] $run.Data.Rows.Add($index, "Row $index", [decimal]($index * 1.25), $createdUtc)
-                }
-            } elseif ($case.InputKind -eq 'PSCustomObject') {
-                $rows = [System.Collections.Generic.List[object]]::new()
-                foreach ($index in 1..([int] $case.RowCount)) {
-                    $rows.Add([pscustomobject]@{
-                        Id = $index
-                        DisplayName = "Row $index"
-                        Score = [decimal]($index * 1.25)
-                        CreatedUtc = $createdUtc
-                    })
-                }
-                $run.Data = $rows.ToArray()
-            } else {
-                $rowType = 'DbaClientX.Benchmarks.DbaClientXBenchmarkRow' -as [type]
-                if (-not $rowType) {
-                    Add-Type -TypeDefinition @'
+        $rowType = 'DbaClientX.Benchmarks.DbaClientXBenchmarkRow' -as [type]
+        if (-not $rowType) {
+            Add-Type -TypeDefinition @'
 namespace DbaClientX.Benchmarks
 {
     public sealed class DbaClientXBenchmarkRow
@@ -127,202 +115,498 @@ namespace DbaClientX.Benchmarks
     }
 }
 '@
-                    $rowType = 'DbaClientX.Benchmarks.DbaClientXBenchmarkRow' -as [type]
-                }
+            $rowType = 'DbaClientX.Benchmarks.DbaClientXBenchmarkRow' -as [type]
+        }
 
-                $rows = [System.Collections.Generic.List[object]]::new()
-                foreach ($index in 1..([int] $case.RowCount)) {
-                    $row = [System.Activator]::CreateInstance($rowType)
-                    $row.Id = $index
-                    $row.DisplayName = "Row $index"
-                    $row.Score = [decimal]($index * 1.25)
-                    $row.CreatedUtc = $createdUtc
-                    $rows.Add($row)
-                }
-                $run.Data = $rows.ToArray()
-            }
+        $typedRows = [System.Collections.Generic.List[object]]::new($RowCount)
+        for ($index = 1; $index -le $RowCount; $index++) {
+            $row = [System.Activator]::CreateInstance($rowType)
+            $row.Id = $index
+            $row.DisplayName = "Row $index"
+            $row.Score = [decimal]($index * 1.25)
+            $row.CreatedUtc = $CreatedUtc
+            $typedRows.Add($row)
+        }
 
-            Import-Module $run.ModulePath -Global -Force -ErrorAction Stop
-            Invoke-DbaXNonQuery `
-                -Server $run.Server `
-                -Database $run.Database `
-                -TrustServerCertificate `
-                -Query @"
-IF OBJECT_ID(N'dbo.$($run.TableName)', N'U') IS NOT NULL DROP TABLE dbo.$($run.TableName);
-CREATE TABLE dbo.$($run.TableName)
+        $typedRows.ToArray()
+    }
+
+    function Get-DbaClientXBenchmarkCreateTableQuery {
+        param([string] $TableName)
+
+        @"
+IF OBJECT_ID(N'dbo.$TableName', N'U') IS NOT NULL DROP TABLE dbo.$TableName;
+CREATE TABLE dbo.$TableName
 (
     Id int NOT NULL,
     DisplayName nvarchar(100) NOT NULL,
     Score decimal(18,2) NOT NULL,
     CreatedUtc datetime2 NOT NULL
 );
-"@ `
-                -ErrorAction Stop | Out-Null
+"@
+    }
 
-            if ($case.Engine -eq 'dbatools') {
-                $connectCommand = Get-Command Connect-DbaInstance -ErrorAction Stop
-                $parameters = @{
-                    SqlInstance = $run.Server
-                    Database = $run.Database
-                }
-                if ($connectCommand.Parameters.ContainsKey('TrustServerCertificate')) {
-                    $parameters.TrustServerCertificate = $true
-                }
+    function Get-DbaClientXBenchmarkDropTableQuery {
+        param([string] $TableName)
 
-                $run.DbatoolsInstance = Connect-DbaInstance @parameters
+        "IF OBJECT_ID(N'dbo.$TableName', N'U') IS NOT NULL DROP TABLE dbo.$TableName;"
+    }
+
+    function Get-DbaClientXBenchmarkExpectedIntegrity {
+        param([int] $RowCount)
+
+        $expectedIdSum = [long] ([int64] $RowCount * ([int64] $RowCount + 1) / 2)
+        [pscustomobject]@{
+            Rows = $RowCount
+            MinId = 1
+            MaxId = $RowCount
+            IdSum = $expectedIdSum
+            ScoreSum = [decimal] $expectedIdSum * 1.25
+        }
+    }
+
+    function Get-DbaClientXBenchmarkReadIntegrity {
+        param([object] $Data)
+
+        if ($Data -is [System.Data.DataSet]) {
+            if ($Data.Tables.Count -eq 0) {
+                return [pscustomobject]@{ Rows = 0; MinId = 0; MaxId = 0; IdSum = [long]0; ScoreSum = [decimal]0 }
             }
+
+            $Data = $Data.Tables[0]
         }
 
-        skip {
-            param($case)
-
-            if ($case.Engine -eq 'dbatools' -and -not (Get-Command Write-DbaDbTableData -ErrorAction SilentlyContinue)) {
-                return $true
-            }
-
-            if ($case.Engine -eq 'SqlServer' -and -not (Get-Command Write-SqlTableData -ErrorAction SilentlyContinue)) {
-                return $true
-            }
-
-            return $false
+        $rows = if ($Data -is [System.Data.DataTable]) {
+            $Data.Rows
+        } elseif ($Data -is [System.Collections.IEnumerable] -and $Data -isnot [string]) {
+            @($Data)
+        } elseif ($null -eq $Data) {
+            @()
+        } else {
+            @($Data)
         }
 
-        engine DbaClientX {
-            operation Write {
+        $count = 0
+        $minId = [int]::MaxValue
+        $maxId = [int]::MinValue
+        $idSum = [long] 0
+        $scoreSum = [decimal] 0
+
+        foreach ($row in $rows) {
+            $id = if ($row -is [System.Data.DataRow]) { [int] $row['Id'] } else { [int] $row.Id }
+            $score = if ($row -is [System.Data.DataRow]) { [decimal] $row['Score'] } else { [decimal] $row.Score }
+            $count++
+            if ($id -lt $minId) { $minId = $id }
+            if ($id -gt $maxId) { $maxId = $id }
+            $idSum += $id
+            $scoreSum += $score
+        }
+
+        if ($count -eq 0) {
+            $minId = 0
+            $maxId = 0
+        }
+
+        [pscustomobject]@{
+            Rows = $count
+            MinId = $minId
+            MaxId = $maxId
+            IdSum = $idSum
+            ScoreSum = $scoreSum
+        }
+    }
+
+    function Assert-DbaClientXBenchmarkIntegrity {
+        param(
+            [string] $Engine,
+            [string] $TableName,
+            [object] $Actual,
+            [object] $Expected
+        )
+
+        if ($Actual.Rows -ne $Expected.Rows) {
+            throw "$Engine processed $($Actual.Rows) of $($Expected.Rows) expected row(s) for dbo.$TableName."
+        }
+
+        if ($Actual.MinId -ne $Expected.MinId -or
+            $Actual.MaxId -ne $Expected.MaxId -or
+            $Actual.IdSum -ne $Expected.IdSum -or
+            $Actual.ScoreSum -ne $Expected.ScoreSum) {
+            throw "$Engine produced unexpected data for dbo.${TableName}: MinId=$($Actual.MinId), MaxId=$($Actual.MaxId), IdSum=$($Actual.IdSum), ScoreSum=$($Actual.ScoreSum)."
+        }
+    }
+
+    $newBenchmarkData = ${function:New-DbaClientXBenchmarkData}
+    $getCreateTableQuery = ${function:Get-DbaClientXBenchmarkCreateTableQuery}
+    $getDropTableQuery = ${function:Get-DbaClientXBenchmarkDropTableQuery}
+    $getExpectedIntegrity = ${function:Get-DbaClientXBenchmarkExpectedIntegrity}
+    $getReadIntegrity = ${function:Get-DbaClientXBenchmarkReadIntegrity}
+    $assertIntegrity = ${function:Assert-DbaClientXBenchmarkIntegrity}
+
+    if ($selectedOperations -contains 'Write') {
+        benchmark 'sqlserver-data-movement-write' -out (Join-Path $outputRootBase 'Write') {
+            policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
+            profile Current -Cleanup KeepOnFailure
+
+            caseSource {
+                foreach ($rowCount in $rowCounts) {
+                    foreach ($batchSize in $batchSizes) {
+                        foreach ($inputKind in $inputKinds) {
+                            [pscustomobject]@{
+                                Scenario = "$rowCount rows / batch $batchSize / $inputKind"
+                                RowCount = $rowCount
+                                BatchSize = $batchSize
+                                InputKind = $inputKind
+                            }
+                        }
+                    }
+                }
+            }
+
+            setup {
                 param($case, $run)
 
+                $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                $run.Server = $server
+                $run.Database = $database
+                $run.ModulePath = $modulePath
+                $run.KeepTables = $keepTables
+                $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
+                $run.TableName = 'DbaClientXBench_Write_{0}_{1}' -f ($case.Engine -replace '[^A-Za-z0-9_]', ''), ([guid]::NewGuid().ToString('N').Substring(0, 8))
+                $run.Data = & $newBenchmarkData -RowCount ([int] $case.RowCount) -InputKind $case.InputKind -CreatedUtc ([datetime]::UtcNow)
+
+                Import-Module $run.ModulePath -Global -Force -ErrorAction Stop
+                Invoke-DbaXNonQuery `
+                    -Server $run.Server `
+                    -Database $run.Database `
+                    -TrustServerCertificate `
+                    -Query (& $getCreateTableQuery -TableName $run.TableName) `
+                    -ErrorAction Stop | Out-Null
+
+                if ($case.Engine -eq 'dbatools') {
+                    $connectCommand = Get-Command Connect-DbaInstance -ErrorAction Stop
+                    $parameters = @{
+                        SqlInstance = $run.Server
+                        Database = $run.Database
+                    }
+                    if ($connectCommand.Parameters.ContainsKey('TrustServerCertificate')) {
+                        $parameters.TrustServerCertificate = $true
+                    }
+
+                    $run.DbatoolsInstance = Connect-DbaInstance @parameters
+                }
+            }
+
+            skip {
+                param($case)
+
+                if ($case.Engine -eq 'dbatools' -and -not (Get-Command Write-DbaDbTableData -ErrorAction SilentlyContinue)) {
+                    return $true
+                }
+
+                if ($case.Engine -eq 'SqlServer' -and -not (Get-Command Write-SqlTableData -ErrorAction SilentlyContinue)) {
+                    return $true
+                }
+
+                return $false
+            }
+
+            engine DbaClientX {
+                operation Write {
+                    param($case, $run)
+
+                    $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                    Write-DbaXTableData `
+                        -Provider SqlServer `
+                        -ConnectionString $run.ConnectionString `
+                        -DestinationTable "dbo.$($run.TableName)" `
+                        -InputObject $run.Data `
+                        -BatchSize ([int] $case.BatchSize) `
+                        -TableLock `
+                        -ErrorAction Stop | Out-Null
+                    if ($run.Iteration -lt 0 -and -not $run.KeepTables) {
+                        Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getDropTableQuery -TableName $run.TableName) -ErrorAction Stop | Out-Null
+                    }
+                }
+            }
+
+            engine dbatools {
+                operation Write {
+                    param($case, $run)
+
+                    $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                    $parameters = @{
+                        SqlInstance = $run.DbatoolsInstance
+                        Database = $run.Database
+                        Schema = 'dbo'
+                        Table = $run.TableName
+                        InputObject = $run.Data
+                    }
+
+                    $command = Get-Command Write-DbaDbTableData -ErrorAction Stop
+                    if ($command.Parameters.ContainsKey('BatchSize')) {
+                        $parameters.BatchSize = [int] $case.BatchSize
+                    }
+                    if ($command.Parameters.ContainsKey('EnableException')) {
+                        $parameters.EnableException = $true
+                    }
+
+                    Write-DbaDbTableData @parameters | Out-Null
+                    if ($run.Iteration -lt 0 -and -not $run.KeepTables) {
+                        Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getDropTableQuery -TableName $run.TableName) -ErrorAction Stop | Out-Null
+                    }
+                }
+            }
+
+            engine SqlServer {
+                operation Write {
+                    param($case, $run)
+
+                    $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                    $parameters = @{
+                        ServerInstance = $run.Server
+                        DatabaseName = $run.Database
+                        SchemaName = 'dbo'
+                        TableName = $run.TableName
+                        InputData = $run.Data
+                    }
+
+                    $command = Get-Command Write-SqlTableData -ErrorAction Stop
+                    if ($command.Parameters.ContainsKey('Force')) {
+                        $parameters.Force = $true
+                    }
+                    if ($command.Parameters.ContainsKey('TrustServerCertificate')) {
+                        $parameters.TrustServerCertificate = $true
+                    }
+
+                    Write-SqlTableData @parameters | Out-Null
+                    if ($run.Iteration -lt 0 -and -not $run.KeepTables) {
+                        Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getDropTableQuery -TableName $run.TableName) -ErrorAction Stop | Out-Null
+                    }
+                }
+            }
+
+            validate {
+                param($case, $run)
+
+                $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                $integrity = Invoke-DbaXQuery `
+                    -Server $run.Server `
+                    -Database $run.Database `
+                    -TrustServerCertificate `
+                    -Query "SELECT COUNT(*) AS [Rows], MIN(Id) AS [MinId], MAX(Id) AS [MaxId], SUM(CAST(Id AS bigint)) AS [IdSum], SUM(CAST(Score AS decimal(38,2))) AS [ScoreSum] FROM dbo.$($run.TableName);" `
+                    -ReturnType PSObject `
+                    -ErrorAction Stop
+                $actual = [pscustomobject]@{
+                    Rows = [int] $integrity.Rows
+                    MinId = [int] $integrity.MinId
+                    MaxId = [int] $integrity.MaxId
+                    IdSum = [long] $integrity.IdSum
+                    ScoreSum = [decimal] $integrity.ScoreSum
+                }
+                $expected = & $getExpectedIntegrity -RowCount ([int] $case.RowCount)
+                & $assertIntegrity -Engine $case.Engine -TableName $run.TableName -Actual $actual -Expected $expected
+
+                $run.RowsProcessed = $actual.Rows
+                $run.IdSum = $actual.IdSum
+                $run.ScoreSum = $actual.ScoreSum
+
+                if (-not $run.KeepTables) {
+                    Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getDropTableQuery -TableName $run.TableName) -ErrorAction Stop | Out-Null
+                }
+            }
+
+            metric RowsProcessed {
+                param($case, $run)
+
+                $run.RowsProcessed
+            }
+
+            metric IdSum {
+                param($case, $run)
+
+                $run.IdSum
+            }
+
+            metric ScoreSum {
+                param($case, $run)
+
+                $run.ScoreSum
+            }
+
+            metric RowsPerSecond {
+                param($case, $run)
+
+                if ($run.DurationMs -le 0) {
+                    return 0
+                }
+
+                [double] $case.RowCount / ($run.DurationMs / 1000)
+            }
+
+            comparison Engine -Baseline DbaClientX -Metric MedianMs
+            if (Test-Path -LiteralPath $readmePath) {
+                readme $readmePath -Block 'sqlserver-data-movement-write-benchmark' -Renderer ComparisonTable
+            }
+            artifacts Json, Csv, Markdown
+        }
+    }
+
+    if ($selectedOperations -contains 'Read') {
+        benchmark 'sqlserver-data-movement-read' -out (Join-Path $outputRootBase 'Read') {
+            policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
+            profile Current -Cleanup KeepOnFailure
+
+            caseSource {
+                foreach ($rowCount in $rowCounts) {
+                    [pscustomobject]@{
+                        Scenario = "$rowCount rows"
+                        RowCount = $rowCount
+                    }
+                }
+            }
+
+            setup {
+                param($case, $run)
+
+                $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                $run.Server = $server
+                $run.Database = $database
+                $run.ModulePath = $modulePath
+                $run.KeepTables = $keepTables
+                $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
+                $run.TableName = 'DbaClientXBench_Read_{0}_{1}' -f ($case.Engine -replace '[^A-Za-z0-9_]', ''), ([guid]::NewGuid().ToString('N').Substring(0, 8))
+                $run.ReadQuery = "SELECT Id, DisplayName, Score, CreatedUtc FROM dbo.$($run.TableName) ORDER BY Id;"
+                $run.SeedData = & $newBenchmarkData -RowCount ([int] $case.RowCount) -InputKind DataTable -CreatedUtc ([datetime]::UtcNow)
+
+                Import-Module $run.ModulePath -Global -Force -ErrorAction Stop
+                Invoke-DbaXNonQuery `
+                    -Server $run.Server `
+                    -Database $run.Database `
+                    -TrustServerCertificate `
+                    -Query (& $getCreateTableQuery -TableName $run.TableName) `
+                    -ErrorAction Stop | Out-Null
                 Write-DbaXTableData `
                     -Provider SqlServer `
                     -ConnectionString $run.ConnectionString `
                     -DestinationTable "dbo.$($run.TableName)" `
-                    -InputObject $run.Data `
-                    -BatchSize ([int] $case.BatchSize) `
+                    -InputObject $run.SeedData `
+                    -BatchSize 5000 `
                     -TableLock `
                     -ErrorAction Stop | Out-Null
-                if ($run.Iteration -lt 0 -and -not $run.KeepTables) {
-                    Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query "IF OBJECT_ID(N'dbo.$($run.TableName)', N'U') IS NOT NULL DROP TABLE dbo.$($run.TableName);" -ErrorAction Stop | Out-Null
+
+                if ($case.Engine -eq 'dbatools') {
+                    $connectCommand = Get-Command Connect-DbaInstance -ErrorAction Stop
+                    $parameters = @{
+                        SqlInstance = $run.Server
+                        Database = $run.Database
+                    }
+                    if ($connectCommand.Parameters.ContainsKey('TrustServerCertificate')) {
+                        $parameters.TrustServerCertificate = $true
+                    }
+
+                    $run.DbatoolsInstance = Connect-DbaInstance @parameters
                 }
             }
-        }
 
-        engine dbatools {
-            operation Write {
+            skip {
+                param($case)
+
+                if ($case.Engine -eq 'dbatools' -and -not (Get-Command Invoke-DbaQuery -ErrorAction SilentlyContinue)) {
+                    return $true
+                }
+
+                return $false
+            }
+
+            engine DbaClientX {
+                operation Read {
+                    param($case, $run)
+
+                    $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                    $run.ReadData = Invoke-DbaXQuery `
+                        -Server $run.Server `
+                        -Database $run.Database `
+                        -TrustServerCertificate `
+                        -Query $run.ReadQuery `
+                        -ReturnType DataTable `
+                        -ErrorAction Stop
+                }
+            }
+
+            engine dbatools {
+                operation Read {
+                    param($case, $run)
+
+                    $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                    $parameters = @{
+                        SqlInstance = $run.DbatoolsInstance
+                        Database = $run.Database
+                        Query = $run.ReadQuery
+                    }
+                    $command = Get-Command Invoke-DbaQuery -ErrorAction Stop
+                    if ($command.Parameters.ContainsKey('As')) {
+                        $parameters.As = 'DataTable'
+                    }
+                    if ($command.Parameters.ContainsKey('EnableException')) {
+                        $parameters.EnableException = $true
+                    }
+
+                    $run.ReadData = Invoke-DbaQuery @parameters
+                }
+            }
+
+            validate {
                 param($case, $run)
 
-                $parameters = @{
-                    SqlInstance = $run.DbatoolsInstance
-                    Database = $run.Database
-                    Schema = 'dbo'
-                    Table = $run.TableName
-                    InputObject = $run.Data
-                }
+                $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                $actual = & $getReadIntegrity -Data $run.ReadData
+                $expected = & $getExpectedIntegrity -RowCount ([int] $case.RowCount)
+                & $assertIntegrity -Engine $case.Engine -TableName $run.TableName -Actual $actual -Expected $expected
 
-                $command = Get-Command Write-DbaDbTableData -ErrorAction Stop
-                if ($command.Parameters.ContainsKey('BatchSize')) {
-                    $parameters.BatchSize = [int] $case.BatchSize
-                }
-                if ($command.Parameters.ContainsKey('EnableException')) {
-                    $parameters.EnableException = $true
-                }
+                $run.RowsProcessed = $actual.Rows
+                $run.IdSum = $actual.IdSum
+                $run.ScoreSum = $actual.ScoreSum
 
-                Write-DbaDbTableData @parameters | Out-Null
-                if ($run.Iteration -lt 0 -and -not $run.KeepTables) {
-                    Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query "IF OBJECT_ID(N'dbo.$($run.TableName)', N'U') IS NOT NULL DROP TABLE dbo.$($run.TableName);" -ErrorAction Stop | Out-Null
+                if (-not $run.KeepTables) {
+                    Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getDropTableQuery -TableName $run.TableName) -ErrorAction Stop | Out-Null
                 }
             }
-        }
 
-        engine SqlServer {
-            operation Write {
+            metric RowsProcessed {
                 param($case, $run)
 
-                $parameters = @{
-                    ServerInstance = $run.Server
-                    DatabaseName = $run.Database
-                    SchemaName = 'dbo'
-                    TableName = $run.TableName
-                    InputData = $run.Data
+                $run.RowsProcessed
+            }
+
+            metric IdSum {
+                param($case, $run)
+
+                $run.IdSum
+            }
+
+            metric ScoreSum {
+                param($case, $run)
+
+                $run.ScoreSum
+            }
+
+            metric RowsPerSecond {
+                param($case, $run)
+
+                if ($run.DurationMs -le 0) {
+                    return 0
                 }
 
-                $command = Get-Command Write-SqlTableData -ErrorAction Stop
-                if ($command.Parameters.ContainsKey('Force')) {
-                    $parameters.Force = $true
-                }
-                if ($command.Parameters.ContainsKey('TrustServerCertificate')) {
-                    $parameters.TrustServerCertificate = $true
-                }
-
-                Write-SqlTableData @parameters | Out-Null
-                if ($run.Iteration -lt 0 -and -not $run.KeepTables) {
-                    Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query "IF OBJECT_ID(N'dbo.$($run.TableName)', N'U') IS NOT NULL DROP TABLE dbo.$($run.TableName);" -ErrorAction Stop | Out-Null
-                }
-            }
-        }
-
-        validate {
-            param($case, $run)
-
-            $integrity = Invoke-DbaXQuery `
-                -Server $run.Server `
-                -Database $run.Database `
-                -TrustServerCertificate `
-                -Query "SELECT COUNT(*) AS [RowsLoaded], MIN(Id) AS [MinId], MAX(Id) AS [MaxId], SUM(CAST(Id AS bigint)) AS [IdSum], SUM(CAST(Score AS decimal(38,2))) AS [ScoreSum] FROM dbo.$($run.TableName);" `
-                -ReturnType PSObject `
-                -ErrorAction Stop
-            $run.RowsLoaded = [int] $integrity.RowsLoaded
-            if ($run.RowsLoaded -ne [int] $case.RowCount) {
-                throw "$($case.Engine) loaded $($run.RowsLoaded) of $($case.RowCount) expected row(s) into dbo.$($run.TableName)."
+                [double] $case.RowCount / ($run.DurationMs / 1000)
             }
 
-            $run.MinId = [int] $integrity.MinId
-            $run.MaxId = [int] $integrity.MaxId
-            $run.IdSum = [long] $integrity.IdSum
-            $run.ScoreSum = [decimal] $integrity.ScoreSum
-            $expectedIdSum = [long] ([int64] $case.RowCount * ([int64] $case.RowCount + 1) / 2)
-            $expectedScoreSum = [decimal] $expectedIdSum * 1.25
-
-            if ($run.MinId -ne 1 -or $run.MaxId -ne [int] $case.RowCount -or $run.IdSum -ne $expectedIdSum -or $run.ScoreSum -ne $expectedScoreSum) {
-                throw "$($case.Engine) wrote unexpected data into dbo.$($run.TableName): MinId=$($run.MinId), MaxId=$($run.MaxId), IdSum=$($run.IdSum), ScoreSum=$($run.ScoreSum)."
+            comparison Engine -Baseline DbaClientX -Metric MedianMs
+            if (Test-Path -LiteralPath $readmePath) {
+                readme $readmePath -Block 'sqlserver-data-movement-read-benchmark' -Renderer ComparisonTable
             }
-
-            if (-not $run.KeepTables) {
-                Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query "IF OBJECT_ID(N'dbo.$($run.TableName)', N'U') IS NOT NULL DROP TABLE dbo.$($run.TableName);" -ErrorAction Stop | Out-Null
-            }
+            artifacts Json, Csv, Markdown
         }
-
-        metric RowsLoaded {
-            param($case, $run)
-
-            $run.RowsLoaded
-        }
-
-        metric IdSum {
-            param($case, $run)
-
-            $run.IdSum
-        }
-
-        metric ScoreSum {
-            param($case, $run)
-
-            $run.ScoreSum
-        }
-
-        metric RowsPerSecond {
-            param($case, $run)
-
-            if ($run.DurationMs -le 0) {
-                return 0
-            }
-
-            [double] $case.RowCount / ($run.DurationMs / 1000)
-        }
-
-        comparison Engine -Baseline DbaClientX -Metric MedianMs
-        if (Test-Path -LiteralPath $readmePath) {
-            readme $readmePath -Block 'sqlserver-data-movement-benchmark' -Renderer ComparisonTable
-        }
-        artifacts Json, Csv, Markdown
     }
 }.GetNewClosure()
 
@@ -335,12 +619,6 @@ $parameters = @{
 if ($Engine) {
     $parameters.Engine = $Engine
 }
-if ($Operation) {
-    $parameters.Operation = $Operation
-}
-if ($OutputRoot) {
-    $parameters.OutputRoot = $OutputRoot
-}
 if ($Plan) {
     $parameters.Plan = $true
 }
@@ -349,8 +627,15 @@ $result = Invoke-BenchmarkSuite @parameters
 if (-not $Plan -and $result.Summary) {
     $failedRows = @($result.Summary | Where-Object { $_.FailureCount -gt 0 -or $_.Status -eq 'Failed' })
     if ($failedRows.Count -gt 0) {
-        $failedDescriptions = $failedRows | ForEach-Object { "$($_.Engine) $($_.Scenario): $($_.FailureReasons)" }
-        throw "Benchmark run $($result.RunId) had failed lane(s): $($failedDescriptions -join '; ')"
+        $failedDescriptions = $failedRows | ForEach-Object {
+            $reasons = if ($_.FailureReasons -and $_.FailureReasons.Keys.Count -gt 0) {
+                $_.FailureReasons.Keys -join ' | '
+            } else {
+                'No failure reason was recorded.'
+            }
+            "$($_.Engine) $($_.Operation) $($_.Scenario): $reasons"
+        }
+        throw "Benchmark run $($result.RunId -join ', ') had failed lane(s): $($failedDescriptions -join '; ')"
     }
 }
 

--- a/Module/Examples/Benchmark.SqlServerDataMovement.ps1
+++ b/Module/Examples/Benchmark.SqlServerDataMovement.ps1
@@ -588,6 +588,9 @@ CREATE TABLE dbo.$TableName
                             -ReturnType $run.ReturnType `
                             -ErrorAction Stop
                     }
+                    if ($run.Iteration -lt 0 -and -not $run.KeepTables) {
+                        Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropTableQuery -ErrorAction Stop | Out-Null
+                    }
                 }
             }
 
@@ -613,6 +616,9 @@ CREATE TABLE dbo.$TableName
                         $run.ReadData = @(Invoke-DbaQuery @parameters)
                     } else {
                         $run.ReadData = Invoke-DbaQuery @parameters
+                    }
+                    if ($run.Iteration -lt 0 -and -not $run.KeepTables) {
+                        Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropTableQuery -ErrorAction Stop | Out-Null
                     }
                 }
             }

--- a/Module/Examples/Benchmark.SqlServerDataMovement.ps1
+++ b/Module/Examples/Benchmark.SqlServerDataMovement.ps1
@@ -5,6 +5,8 @@ param(
     [int[]] $BatchSize = @(5000),
     [ValidateSet('DataTable', 'PSCustomObject', 'Class')]
     [string[]] $InputKind = @('DataTable', 'PSCustomObject', 'Class'),
+    [ValidateSet('DataTableAll', 'DataSetAll', 'PSObjectAll')]
+    [string[]] $ReadShape = @('DataTableAll', 'PSObjectAll'),
     [int] $Iterations = 3,
     [int] $WarmupCount = 1,
     [string] $ModulePath = $(
@@ -33,6 +35,9 @@ if ($BatchSize.Count -eq 0 -or @($BatchSize | Where-Object { $_ -lt 1 }).Count -
 }
 if ($InputKind.Count -eq 0) {
     throw 'InputKind must contain at least one value.'
+}
+if ($ReadShape.Count -eq 0) {
+    throw 'ReadShape must contain at least one value.'
 }
 if ($Iterations -lt 1) {
     throw 'Iterations must be greater than zero.'
@@ -63,6 +68,7 @@ $settings = {
     $rowCounts = $RowCount
     $batchSizes = $BatchSize
     $inputKinds = $InputKind
+    $readShapes = $ReadShape
     $selectedOperations = if ($Operation) { $Operation } else { @('Write', 'Read') }
 
     function New-DbaClientXBenchmarkData {
@@ -152,6 +158,38 @@ CREATE TABLE dbo.$TableName
         "IF OBJECT_ID(N'dbo.$TableName', N'U') IS NOT NULL DROP TABLE dbo.$TableName;"
     }
 
+    function Get-DbaClientXBenchmarkReadShape {
+        param(
+            [string] $ReadShape,
+            [string] $TableName
+        )
+
+        $query = "SELECT Id, DisplayName, Score, CreatedUtc FROM dbo.$TableName ORDER BY Id;"
+        switch ($ReadShape) {
+            'DataSetAll' {
+                [pscustomobject]@{
+                    Query = $query
+                    ReturnType = 'DataSet'
+                    DbatoolsAs = 'DataSet'
+                }
+            }
+            'PSObjectAll' {
+                [pscustomobject]@{
+                    Query = $query
+                    ReturnType = 'PSObject'
+                    DbatoolsAs = 'PSObject'
+                }
+            }
+            default {
+                [pscustomobject]@{
+                    Query = $query
+                    ReturnType = 'DataTable'
+                    DbatoolsAs = 'DataTable'
+                }
+            }
+        }
+    }
+
     function Get-DbaClientXBenchmarkExpectedIntegrity {
         param([int] $RowCount)
 
@@ -239,6 +277,7 @@ CREATE TABLE dbo.$TableName
     $newBenchmarkData = ${function:New-DbaClientXBenchmarkData}
     $getCreateTableQuery = ${function:Get-DbaClientXBenchmarkCreateTableQuery}
     $getDropTableQuery = ${function:Get-DbaClientXBenchmarkDropTableQuery}
+    $getReadShape = ${function:Get-DbaClientXBenchmarkReadShape}
     $getExpectedIntegrity = ${function:Get-DbaClientXBenchmarkExpectedIntegrity}
     $getReadIntegrity = ${function:Get-DbaClientXBenchmarkReadIntegrity}
     $assertIntegrity = ${function:Assert-DbaClientXBenchmarkIntegrity}
@@ -273,6 +312,7 @@ CREATE TABLE dbo.$TableName
                 $run.KeepTables = $keepTables
                 $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
                 $run.TableName = 'DbaClientXBench_Write_{0}_{1}' -f ($case.Engine -replace '[^A-Za-z0-9_]', ''), ([guid]::NewGuid().ToString('N').Substring(0, 8))
+                $run.DropTableQuery = "IF OBJECT_ID(N'dbo.$($run.TableName)', N'U') IS NOT NULL DROP TABLE dbo.$($run.TableName);"
                 $run.Data = & $newBenchmarkData -RowCount ([int] $case.RowCount) -InputKind $case.InputKind -CreatedUtc ([datetime]::UtcNow)
 
                 Import-Module $run.ModulePath -Global -Force -ErrorAction Stop
@@ -325,7 +365,7 @@ CREATE TABLE dbo.$TableName
                         -TableLock `
                         -ErrorAction Stop | Out-Null
                     if ($run.Iteration -lt 0 -and -not $run.KeepTables) {
-                        Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getDropTableQuery -TableName $run.TableName) -ErrorAction Stop | Out-Null
+                        Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropTableQuery -ErrorAction Stop | Out-Null
                     }
                 }
             }
@@ -353,7 +393,7 @@ CREATE TABLE dbo.$TableName
 
                     Write-DbaDbTableData @parameters | Out-Null
                     if ($run.Iteration -lt 0 -and -not $run.KeepTables) {
-                        Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getDropTableQuery -TableName $run.TableName) -ErrorAction Stop | Out-Null
+                        Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropTableQuery -ErrorAction Stop | Out-Null
                     }
                 }
             }
@@ -381,7 +421,7 @@ CREATE TABLE dbo.$TableName
 
                     Write-SqlTableData @parameters | Out-Null
                     if ($run.Iteration -lt 0 -and -not $run.KeepTables) {
-                        Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getDropTableQuery -TableName $run.TableName) -ErrorAction Stop | Out-Null
+                        Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropTableQuery -ErrorAction Stop | Out-Null
                     }
                 }
             }
@@ -412,7 +452,7 @@ CREATE TABLE dbo.$TableName
                 $run.ScoreSum = $actual.ScoreSum
 
                 if (-not $run.KeepTables) {
-                    Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getDropTableQuery -TableName $run.TableName) -ErrorAction Stop | Out-Null
+                    Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropTableQuery -ErrorAction Stop | Out-Null
                 }
             }
 
@@ -459,9 +499,12 @@ CREATE TABLE dbo.$TableName
 
             caseSource {
                 foreach ($rowCount in $rowCounts) {
-                    [pscustomobject]@{
-                        Scenario = "$rowCount rows"
-                        RowCount = $rowCount
+                    foreach ($readShape in $readShapes) {
+                        [pscustomobject]@{
+                            Scenario = "$rowCount rows / $readShape"
+                            RowCount = $rowCount
+                            ReadShape = $readShape
+                        }
                     }
                 }
             }
@@ -476,7 +519,11 @@ CREATE TABLE dbo.$TableName
                 $run.KeepTables = $keepTables
                 $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
                 $run.TableName = 'DbaClientXBench_Read_{0}_{1}' -f ($case.Engine -replace '[^A-Za-z0-9_]', ''), ([guid]::NewGuid().ToString('N').Substring(0, 8))
-                $run.ReadQuery = "SELECT Id, DisplayName, Score, CreatedUtc FROM dbo.$($run.TableName) ORDER BY Id;"
+                $run.DropTableQuery = "IF OBJECT_ID(N'dbo.$($run.TableName)', N'U') IS NOT NULL DROP TABLE dbo.$($run.TableName);"
+                $shape = & $getReadShape -ReadShape $case.ReadShape -TableName $run.TableName
+                $run.ReadQuery = $shape.Query
+                $run.ReturnType = $shape.ReturnType
+                $run.DbatoolsAs = $shape.DbatoolsAs
                 $run.SeedData = & $newBenchmarkData -RowCount ([int] $case.RowCount) -InputKind DataTable -CreatedUtc ([datetime]::UtcNow)
 
                 Import-Module $run.ModulePath -Global -Force -ErrorAction Stop
@@ -524,13 +571,23 @@ CREATE TABLE dbo.$TableName
                     param($case, $run)
 
                     $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
-                    $run.ReadData = Invoke-DbaXQuery `
-                        -Server $run.Server `
-                        -Database $run.Database `
-                        -TrustServerCertificate `
-                        -Query $run.ReadQuery `
-                        -ReturnType DataTable `
-                        -ErrorAction Stop
+                    if ($run.ReturnType -eq 'DataRow' -or $run.ReturnType -eq 'PSObject') {
+                        $run.ReadData = @(Invoke-DbaXQuery `
+                            -Server $run.Server `
+                            -Database $run.Database `
+                            -TrustServerCertificate `
+                            -Query $run.ReadQuery `
+                            -ReturnType $run.ReturnType `
+                            -ErrorAction Stop)
+                    } else {
+                        $run.ReadData = Invoke-DbaXQuery `
+                            -Server $run.Server `
+                            -Database $run.Database `
+                            -TrustServerCertificate `
+                            -Query $run.ReadQuery `
+                            -ReturnType $run.ReturnType `
+                            -ErrorAction Stop
+                    }
                 }
             }
 
@@ -546,13 +603,17 @@ CREATE TABLE dbo.$TableName
                     }
                     $command = Get-Command Invoke-DbaQuery -ErrorAction Stop
                     if ($command.Parameters.ContainsKey('As')) {
-                        $parameters.As = 'DataTable'
+                        $parameters.As = $run.DbatoolsAs
                     }
                     if ($command.Parameters.ContainsKey('EnableException')) {
                         $parameters.EnableException = $true
                     }
 
-                    $run.ReadData = Invoke-DbaQuery @parameters
+                    if ($run.DbatoolsAs -eq 'DataRow' -or $run.DbatoolsAs -eq 'PSObject') {
+                        $run.ReadData = @(Invoke-DbaQuery @parameters)
+                    } else {
+                        $run.ReadData = Invoke-DbaQuery @parameters
+                    }
                 }
             }
 
@@ -569,7 +630,7 @@ CREATE TABLE dbo.$TableName
                 $run.ScoreSum = $actual.ScoreSum
 
                 if (-not $run.KeepTables) {
-                    Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getDropTableQuery -TableName $run.TableName) -ErrorAction Stop | Out-Null
+                    Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropTableQuery -ErrorAction Stop | Out-Null
                 }
             }
 

--- a/Module/Examples/Benchmark.SqlServerDataMovement.ps1
+++ b/Module/Examples/Benchmark.SqlServerDataMovement.ps1
@@ -90,7 +90,8 @@ $settings = {
                 [void] $table.Rows.Add($index, "Row $index", [decimal]($index * 1.25), $CreatedUtc)
             }
 
-            return $table
+            Write-Output -NoEnumerate $table
+            return
         }
 
         if ($InputKind -eq 'PSCustomObject') {

--- a/README.md
+++ b/README.md
@@ -227,35 +227,39 @@ Install-Module PSPublishModule -MinimumVersion 3.0.43 -Scope CurrentUser
 .\Module\Examples\Benchmark.SqlServerDataMovement.ps1 `
     -Server localhost `
     -Database tempdb `
-    -RowCount 1000, 5000, 20000 `
+    -RowCount 1000, 5000, 20000, 100000 `
     -BatchSize 5000 `
     -InputKind DataTable, PSCustomObject, Class `
     -Iterations 3
 ```
 
-The suite always benchmarks DbaClientX across `DataTable`, `PSCustomObject`, and typed class input shapes. It adds dbatools and SqlServer module lanes only when `Write-DbaDbTableData` or `Write-SqlTableData` are available, and records unavailable lanes as skipped. The dbatools `DataTable` lane uses a direct value passed to `-InputObject` so it stays on the documented SqlBulkCopy fast path instead of the slower piped-`DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import. Successful lanes verify row counts plus simple data integrity (`Id` min/max/sum and `Score` sum) before dropping their isolated tables; failed lanes leave their table behind for inspection.
+The suite benchmarks SQL Server writes and reads separately. The write suite covers DbaClientX across `DataTable`, `PSCustomObject`, and typed class input shapes, and adds dbatools and SqlServer module lanes only when `Write-DbaDbTableData` or `Write-SqlTableData` are available. The dbatools `DataTable` write lane uses a direct value passed to `-InputObject` so it stays on the documented SqlBulkCopy fast path instead of the slower piped-`DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import.
+
+The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery -ReturnType DataTable` with dbatools `Invoke-DbaQuery` when dbatools is available. Successful lanes verify row counts plus simple data integrity (`Id` min/max/sum and `Score` sum) before dropping their isolated tables; failed lanes leave their table behind for inspection.
 
 By default the wrapper imports the installed `DbaClientX` module. Use `-ModulePath`, `$env:DBACLIENTX_BENCHMARK_MODULE_PATH`, or `$env:DBACLIENTX_DEVELOPMENT_PATH` when benchmarking a local source build.
 
-The suite rewrites the marker-delimited table below when it runs from a source checkout. Artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement`, which is intentionally ignored by Git. To inspect the matrix without touching SQL Server:
+The suite rewrites the marker-delimited tables below when it runs from a source checkout. Artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement\Write` and `Ignore\Benchmarks\SqlServerDataMovement\Read`, which are intentionally ignored by Git. To inspect the matrix without touching SQL Server:
 
 ```powershell
 .\Module\Examples\Benchmark.SqlServerDataMovement.ps1 -Plan
 ```
 
-<!-- sqlserver-data-movement-benchmark:start -->
-| Scenario | Variables | Host | Operation | DbaClientX | dbatools | SqlServer | Result |
-| --- | --- | --- | --- | ---: | ---: | ---: | --- |
-| 1000 rows / batch 5000 / Class | BatchSize=5000, InputKind=Class, RowCount=1000 | Core-7.6.3 | Write | 1.00x (19ms) | 9.28x (178ms) | Skipped | DbaClientX fastest |
-| 1000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=1000 | Core-7.6.3 | Write | 1.00x (26ms) | 7.29x (188ms) | Skipped | DbaClientX fastest |
-| 1000 rows / batch 5000 / PSCustomObject | BatchSize=5000, InputKind=PSCustomObject, RowCount=1000 | Core-7.6.3 | Write | 1.00x (19ms) | 6.67x (126ms) | Skipped | DbaClientX fastest |
-| 20000 rows / batch 5000 / Class | BatchSize=5000, InputKind=Class, RowCount=20000 | Core-7.6.3 | Write | 1.00x (368ms) | 6.72x (2.47s) | Skipped | DbaClientX fastest |
-| 20000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=20000 | Core-7.6.3 | Write | 1.00x (33ms) | 3.15x (103ms) | Skipped | DbaClientX fastest |
-| 20000 rows / batch 5000 / PSCustomObject | BatchSize=5000, InputKind=PSCustomObject, RowCount=20000 | Core-7.6.3 | Write | 1.00x (413ms) | 4.87x (2.01s) | Skipped | DbaClientX fastest |
-| 5000 rows / batch 5000 / Class | BatchSize=5000, InputKind=Class, RowCount=5000 | Core-7.6.3 | Write | 1.00x (52ms) | 10.95x (568ms) | Skipped | DbaClientX fastest |
-| 5000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=5000 | Core-7.6.3 | Write | 1.00x (22ms) | 2.28x (50ms) | Skipped | DbaClientX fastest |
-| 5000 rows / batch 5000 / PSCustomObject | BatchSize=5000, InputKind=PSCustomObject, RowCount=5000 | Core-7.6.3 | Write | 1.00x (68ms) | 7.38x (501ms) | Skipped | DbaClientX fastest |
-<!-- sqlserver-data-movement-benchmark:end -->
+### Write Benchmark
+
+<!-- sqlserver-data-movement-write-benchmark:start -->
+| Scenario | Variables | Host | Operation | DbaClientX | dbatools | Result |
+| --- | --- | --- | --- | ---: | ---: | --- |
+| 100000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=100000 | Core-7.6.3 | Write | 1.00x (564ms) | 530.73x (299.30s) | DbaClientX fastest |
+<!-- sqlserver-data-movement-write-benchmark:end -->
+
+### Read Benchmark
+
+<!-- sqlserver-data-movement-read-benchmark:start -->
+| Scenario | Variables | Host | Operation | DbaClientX | dbatools | Result |
+| --- | --- | --- | --- | ---: | ---: | --- |
+| 100000 rows | RowCount=100000 | Core-7.6.3 | Read | 1.00x (245ms) | 0.76x (186ms) | DbaClientX slower than dbatools |
+<!-- sqlserver-data-movement-read-benchmark:end -->
 
 Treat benchmark numbers as workstation evidence, not universal rankings. SQL Server version, storage, TLS, table indexes, triggers, recovery model, batch size, and client runtime can dominate the result; rerun the suite in the environment that matters.
 

--- a/README.md
+++ b/README.md
@@ -235,9 +235,11 @@ Install-Module PSPublishModule -MinimumVersion 3.0.43 -Scope CurrentUser
 
 The suite benchmarks SQL Server writes and reads separately. The write suite covers DbaClientX across `DataTable`, `PSCustomObject`, and typed class input shapes, and adds dbatools and SqlServer module lanes only when `Write-DbaDbTableData` or `Write-SqlTableData` are available. The dbatools `DataTable` write lane uses a direct value passed to `-InputObject` so it stays on the documented SqlBulkCopy fast path instead of the slower piped-`DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import.
 
-The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery -ReturnType DataTable` with dbatools `Invoke-DbaQuery` when dbatools is available. Successful lanes verify row counts plus simple data integrity (`Id` min/max/sum and `Score` sum) before dropping their isolated tables; failed lanes leave their table behind for inspection.
+The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery` with dbatools `Invoke-DbaQuery` when dbatools is available. By default it reads every row as both `DataTable` and PowerShell-object output; `DataSet` can be selected with `-ReadShape DataSetAll` for local diagnosis. Successful lanes verify row counts plus simple data integrity (`Id` min/max/sum and `Score` sum) before dropping their isolated tables; failed lanes leave their table behind for inspection.
 
 By default the wrapper imports the installed `DbaClientX` module. Use `-ModulePath`, `$env:DBACLIENTX_BENCHMARK_MODULE_PATH`, or `$env:DBACLIENTX_DEVELOPMENT_PATH` when benchmarking a local source build.
+
+The checked-in snapshot below uses `DataTable` write input and full-result `DataTable` plus `PSObject` reads at 1k, 5k, 20k, and 100k rows. Pass additional `-InputKind` or `-ReadShape` values for a broader local matrix.
 
 The suite rewrites the marker-delimited tables below when it runs from a source checkout. Artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement\Write` and `Ignore\Benchmarks\SqlServerDataMovement\Read`, which are intentionally ignored by Git. To inspect the matrix without touching SQL Server:
 
@@ -250,7 +252,10 @@ The suite rewrites the marker-delimited tables below when it runs from a source 
 <!-- sqlserver-data-movement-write-benchmark:start -->
 | Scenario | Variables | Host | Operation | DbaClientX | dbatools | Result |
 | --- | --- | --- | --- | ---: | ---: | --- |
-| 100000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=100000 | Core-7.6.3 | Write | 1.00x (564ms) | 530.73x (299.30s) | DbaClientX fastest |
+| 1000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=1000 | Core-7.6.3 | Write | 1.00x (112ms) | 26.47x (2.97s) | DbaClientX fastest |
+| 5000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=5000 | Core-7.6.3 | Write | 1.00x (41ms) | 267.14x (11.06s) | DbaClientX fastest |
+| 20000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=20000 | Core-7.6.3 | Write | 1.00x (116ms) | 497.23x (57.51s) | DbaClientX fastest |
+| 100000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=100000 | Core-7.6.3 | Write | 1.00x (279ms) | 1055.78x (294.59s) | DbaClientX fastest |
 <!-- sqlserver-data-movement-write-benchmark:end -->
 
 ### Read Benchmark
@@ -258,7 +263,14 @@ The suite rewrites the marker-delimited tables below when it runs from a source 
 <!-- sqlserver-data-movement-read-benchmark:start -->
 | Scenario | Variables | Host | Operation | DbaClientX | dbatools | Result |
 | --- | --- | --- | --- | ---: | ---: | --- |
-| 100000 rows | RowCount=100000 | Core-7.6.3 | Read | 1.00x (245ms) | 0.76x (186ms) | DbaClientX slower than dbatools |
+| 1000 rows / DataTableAll | ReadShape=DataTableAll, RowCount=1000 | Core-7.6.3 | Read | 1.00x (8ms) | 3.31x (25ms) | DbaClientX fastest |
+| 1000 rows / PSObjectAll | ReadShape=PSObjectAll, RowCount=1000 | Core-7.6.3 | Read | 1.00x (7ms) | 4.10x (30ms) | DbaClientX fastest |
+| 5000 rows / DataTableAll | ReadShape=DataTableAll, RowCount=5000 | Core-7.6.3 | Read | 1.00x (9ms) | 1.96x (18ms) | DbaClientX fastest |
+| 5000 rows / PSObjectAll | ReadShape=PSObjectAll, RowCount=5000 | Core-7.6.3 | Read | 1.00x (16ms) | 5.36x (87ms) | DbaClientX fastest |
+| 20000 rows / DataTableAll | ReadShape=DataTableAll, RowCount=20000 | Core-7.6.3 | Read | 1.00x (29ms) | 1.46x (42ms) | DbaClientX fastest |
+| 20000 rows / PSObjectAll | ReadShape=PSObjectAll, RowCount=20000 | Core-7.6.3 | Read | 1.00x (95ms) | 2.50x (236ms) | DbaClientX fastest |
+| 100000 rows / DataTableAll | ReadShape=DataTableAll, RowCount=100000 | Core-7.6.3 | Read | 1.00x (147ms) | 1.08x (159ms) | DbaClientX fastest |
+| 100000 rows / PSObjectAll | ReadShape=PSObjectAll, RowCount=100000 | Core-7.6.3 | Read | 1.00x (1.49s) | 1.56x (2.33s) | DbaClientX fastest |
 <!-- sqlserver-data-movement-read-benchmark:end -->
 
 Treat benchmark numbers as workstation evidence, not universal rankings. SQL Server version, storage, TLS, table indexes, triggers, recovery model, batch size, and client runtime can dominate the result; rerun the suite in the environment that matters.

--- a/docs/data-movement.md
+++ b/docs/data-movement.md
@@ -416,7 +416,7 @@ The wrapper imports the installed `DbaClientX` module unless you pass `-ModulePa
 
 The write suite benchmarks `Write-DbaXTableData` across `DataTable`, `PSCustomObject`, and typed class input shapes. If optional comparison commands are already installed, it adds dbatools `Write-DbaDbTableData` and SqlServer `Write-SqlTableData` lanes. The dbatools `DataTable` lane passes a direct value to `-InputObject`, matching dbatools' documented SqlBulkCopy fast path and avoiding the slower piped `DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import. Otherwise those lanes are skipped by the shared runner instead of being treated as failures.
 
-The read suite seeds an isolated SQL Server table outside the measured operation and compares DbaClientX `Invoke-DbaXQuery -ReturnType DataTable` with dbatools `Invoke-DbaQuery` when dbatools is available. Successful read and write lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) before their isolated tables are dropped.
+The read suite seeds an isolated SQL Server table outside the measured operation and compares DbaClientX `Invoke-DbaXQuery` with dbatools `Invoke-DbaQuery` when dbatools is available. By default it reads every row as full-result `DataTable` and PowerShell-object output; pass `-ReadShape DataSetAll` to include a `DataSet` materialization lane for local diagnosis. Successful read and write lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) before their isolated tables are dropped.
 
 Use `-Plan` to inspect the resolved benchmark matrix without creating SQL Server tables:
 

--- a/docs/data-movement.md
+++ b/docs/data-movement.md
@@ -406,7 +406,7 @@ Install-Module PSPublishModule -MinimumVersion 3.0.43 -Scope CurrentUser
 .\Module\Examples\Benchmark.SqlServerDataMovement.ps1 `
     -Server localhost `
     -Database tempdb `
-    -RowCount 1000, 5000, 20000 `
+    -RowCount 1000, 5000, 20000, 100000 `
     -BatchSize 5000 `
     -InputKind DataTable, PSCustomObject, Class `
     -Iterations 3
@@ -414,7 +414,9 @@ Install-Module PSPublishModule -MinimumVersion 3.0.43 -Scope CurrentUser
 
 The wrapper imports the installed `DbaClientX` module unless you pass `-ModulePath` or set `$env:DBACLIENTX_BENCHMARK_MODULE_PATH` / `$env:DBACLIENTX_DEVELOPMENT_PATH` for a local source build.
 
-The suite always benchmarks `Write-DbaXTableData` across `DataTable`, `PSCustomObject`, and typed class input shapes. If optional comparison commands are already installed, it adds dbatools `Write-DbaDbTableData` and SqlServer `Write-SqlTableData` lanes. The dbatools `DataTable` lane passes a direct value to `-InputObject`, matching dbatools' documented SqlBulkCopy fast path and avoiding the slower piped `DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import. Otherwise those lanes are skipped by the shared runner instead of being treated as failures. Successful write lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) before their isolated tables are dropped.
+The write suite benchmarks `Write-DbaXTableData` across `DataTable`, `PSCustomObject`, and typed class input shapes. If optional comparison commands are already installed, it adds dbatools `Write-DbaDbTableData` and SqlServer `Write-SqlTableData` lanes. The dbatools `DataTable` lane passes a direct value to `-InputObject`, matching dbatools' documented SqlBulkCopy fast path and avoiding the slower piped `DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import. Otherwise those lanes are skipped by the shared runner instead of being treated as failures.
+
+The read suite seeds an isolated SQL Server table outside the measured operation and compares DbaClientX `Invoke-DbaXQuery -ReturnType DataTable` with dbatools `Invoke-DbaQuery` when dbatools is available. Successful read and write lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) before their isolated tables are dropped.
 
 Use `-Plan` to inspect the resolved benchmark matrix without creating SQL Server tables:
 
@@ -424,4 +426,4 @@ Use `-Plan` to inspect the resolved benchmark matrix without creating SQL Server
 
 Interpret the numbers as local evidence, not a universal ranking. SQL Server version, disk, network, TLS, table indexes, triggers, recovery model, batch size, and client runtime can dominate the result.
 
-The README includes a benchmark block that the suite can refresh with a normalized comparison table. JSON, CSV, and Markdown artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement`.
+The README includes benchmark blocks that the suite can refresh with normalized comparison tables. JSON, CSV, and Markdown artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement\Write` and `Ignore\Benchmarks\SqlServerDataMovement\Read`.

--- a/docs/sqlserver-benchmark-notes.md
+++ b/docs/sqlserver-benchmark-notes.md
@@ -29,7 +29,7 @@ Use `-Plan` to inspect the matrix without touching SQL Server:
 
 The write suite benchmarks DbaClientX `Write-DbaXTableData` across `DataTable`, `PSCustomObject`, and typed class input shapes. It adds dbatools `Write-DbaDbTableData` and SqlServer `Write-SqlTableData` only when those commands are available. The dbatools `DataTable` lane passes a direct value to `-InputObject`, matching dbatools' documented SqlBulkCopy fast path and avoiding the slower piped `DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import.
 
-The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery -ReturnType DataTable` with dbatools `Invoke-DbaQuery` when dbatools is available. Successful lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) and then drop their isolated table. Failed lanes keep their table so the failing state can be inspected.
+The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery` with dbatools `Invoke-DbaQuery` when dbatools is available. By default it reads every row as full-result `DataTable` and PowerShell-object output; pass `-ReadShape DataSetAll` to include a `DataSet` materialization lane for local diagnosis. Successful lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) and then drop their isolated table. Failed lanes keep their table so the failing state can be inspected.
 
 Artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement\Write` and `Ignore\Benchmarks\SqlServerDataMovement\Read`:
 

--- a/docs/sqlserver-benchmark-notes.md
+++ b/docs/sqlserver-benchmark-notes.md
@@ -8,10 +8,17 @@ Run the benchmark:
 .\Module\Examples\Benchmark.SqlServerDataMovement.ps1 `
     -Server localhost `
     -Database tempdb `
-    -RowCount 1000, 5000, 20000 `
+    -RowCount 1000, 5000, 20000, 100000 `
     -BatchSize 5000 `
     -InputKind DataTable, PSCustomObject, Class `
     -Iterations 3
+```
+
+Run only one side of the suite when you want a smaller pass:
+
+```powershell
+.\Module\Examples\Benchmark.SqlServerDataMovement.ps1 -Operation Write -RowCount 100000
+.\Module\Examples\Benchmark.SqlServerDataMovement.ps1 -Operation Read -RowCount 100000
 ```
 
 Use `-Plan` to inspect the matrix without touching SQL Server:
@@ -20,9 +27,11 @@ Use `-Plan` to inspect the matrix without touching SQL Server:
 .\Module\Examples\Benchmark.SqlServerDataMovement.ps1 -Plan
 ```
 
-The suite always benchmarks DbaClientX `Write-DbaXTableData` across `DataTable`, `PSCustomObject`, and typed class input shapes. It adds dbatools `Write-DbaDbTableData` and SqlServer `Write-SqlTableData` only when those commands are available. The dbatools `DataTable` lane passes a direct value to `-InputObject`, matching dbatools' documented SqlBulkCopy fast path and avoiding the slower piped `DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import. Successful lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) and then drop their isolated table. Failed lanes keep their table so the failing state can be inspected.
+The write suite benchmarks DbaClientX `Write-DbaXTableData` across `DataTable`, `PSCustomObject`, and typed class input shapes. It adds dbatools `Write-DbaDbTableData` and SqlServer `Write-SqlTableData` only when those commands are available. The dbatools `DataTable` lane passes a direct value to `-InputObject`, matching dbatools' documented SqlBulkCopy fast path and avoiding the slower piped `DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import.
 
-Artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement`:
+The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery -ReturnType DataTable` with dbatools `Invoke-DbaQuery` when dbatools is available. Successful lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) and then drop their isolated table. Failed lanes keep their table so the failing state can be inspected.
+
+Artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement\Write` and `Ignore\Benchmarks\SqlServerDataMovement\Read`:
 
 - `samples.json` / `samples.csv`
 - `summary.json` / `summary.csv`


### PR DESCRIPTION
## Summary
- split SQL Server data movement evidence into dedicated write and read benchmark suites
- expand the checked-in matrix to 1k, 5k, 20k, and 100k rows, with DataTable writes and full-result DataTable/PSObject reads against dbatools
- optimize DataTable materialization with bulk reader value loading and preserve correct PowerShell output behavior for DataTable/DataSet/DataRow/PSObject return shapes
- update README and benchmark docs with the final read/write commands, artifact paths, and benchmark snapshot
- make PowerShell CI register PSGallery before installing test modules on PowerShell 7 runners

## Notes
- Write lanes compare client-side DataTable import into the same isolated SQL Server table shape; table creation, data generation, and validation stay outside measured operations.
- Read lanes seed isolated tables outside measured operations, then validate row count plus Id/Score integrity after each lane.
- `DataSetAll` remains selectable through `-ReadShape DataSetAll` for local diagnosis, but the checked-in read snapshot focuses on full-result DataTable and PSObject output because those are stable and representative.

## Validation
- `dotnet test .\DbaClientX.Tests\DbaClientX.Tests.csproj -c Release --no-build --nologo`
- PowerShell parser check for `Module/Examples/Benchmark.SqlServerDataMovement.ps1`
- benchmark `-Plan` check for the read matrix
- local SQL Server benchmark refresh against `tempdb`
- `git diff --check`