### PR TITLE
Set explicit test workflow permissions

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -14,6 +14,9 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   DOTNET_VERSION: '8.x'
   BUILD_CONFIGURATION: 'Release'

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -14,6 +14,9 @@ on:
             - master
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 env:
     DOTNET_VERSION: '8.x'
     BUILD_CONFIGURATION: 'Debug'


### PR DESCRIPTION
## Summary
- Add explicit read-only `GITHUB_TOKEN` permissions to the .NET and PowerShell test workflows.
- Keep the workflows least-privilege while preserving checkout, build, test, artifact, and coverage upload behavior.

## Validation
- Parsed both edited workflow YAML files locally.
- Ran `git diff --check`.