### PR TITLE
Add office file round-trip and dbatools CSV benchmarks

### DIFF
--- a/DbaClientX.PowerShell/README.md
+++ b/DbaClientX.PowerShell/README.md
@@ -49,15 +49,25 @@ $rows | Write-DbaXTableData `
     -PassThru
 ```
 
-Import Excel rows with PSWriteOffice and let DbaClientX own the database write:
+Import CSV or Excel rows with PSWriteOffice and let DbaClientX own the database write:
 
 ```powershell
-Import-OfficeExcel .\Users.xlsx -AsDataTable |
+Import-OfficeCsv .\Users.csv -AsDataTable |
     Write-DbaXTableData `
         -Provider PostgreSql `
         -ConnectionString 'Host=localhost;Database=app;Username=user;Password=secret;SslMode=Require' `
         -DestinationTable 'public.import_users' `
         -BatchSize 5000
+```
+
+```powershell
+Import-OfficeExcel .\Users.xlsx -AsDataTable |
+    Write-DbaXTableData `
+        -Provider SqlServer `
+        -ConnectionString 'Server=.;Database=App;Encrypt=True;TrustServerCertificate=True;Integrated Security=True' `
+        -DestinationTable 'dbo.ImportUsers' `
+        -AutoCreateTable `
+        -TableLock
 ```
 
 ## Copy A Table Between Providers

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -87,6 +87,7 @@ $settings = {
             throw 'No runnable office file round-trip benchmark lanes remain. CSV requires PSWriteOffice with Export-OfficeCsv and Import-OfficeCsv -AsDataTable; choose -FileKind Excel or pass -PSWriteOfficeModulePath to a compatible build.'
         }
     }
+    $comparisonBaseline = if ($fileKinds -contains 'Csv') { 'Csv' } else { $fileKinds[0] }
 
     function Get-DbaClientXOfficeBenchmarkCreateTableQuery {
         param([string] $TableName)
@@ -322,7 +323,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             [double] $case.RowCount / ($run.DurationMs / 1000)
         }
 
-        comparison FileKind -Baseline Csv -Metric MedianMs
+        comparison FileKind -Baseline $comparisonBaseline -Metric MedianMs
         if (Test-Path -LiteralPath $readmePath) {
             readme $readmePath -Block 'office-file-roundtrip-benchmark' -Renderer ComparisonTable
         }

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -55,6 +55,39 @@ $settings = {
     $rowCounts = $RowCount
     $fileKinds = $FileKind
 
+    function Test-DbaClientXOfficeCsvCommandAvailability {
+        param([string] $ModulePath)
+
+        try {
+            $importedModule = Import-Module $ModulePath -Global -Force -PassThru -ErrorAction Stop
+        } catch {
+            Write-Warning "Skipping CSV office file benchmark lane because PSWriteOffice could not be imported from '$ModulePath': $($_.Exception.Message)"
+            return $false
+        }
+
+        $moduleNames = @($importedModule | ForEach-Object { $_.Name })
+        $exportCommand = Get-Command Export-OfficeCsv -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
+        $importCommand = Get-Command Import-OfficeCsv -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
+        if (-not $exportCommand -or -not $importCommand) {
+            Write-Warning "Skipping CSV office file benchmark lane because the imported PSWriteOffice module does not expose Export-OfficeCsv and Import-OfficeCsv."
+            return $false
+        }
+
+        if (-not @($importCommand | Where-Object { $_.Parameters.ContainsKey('AsDataTable') })) {
+            Write-Warning "Skipping CSV office file benchmark lane because Import-OfficeCsv does not expose -AsDataTable."
+            return $false
+        }
+
+        return $true
+    }
+
+    if ($fileKinds -contains 'Csv' -and -not (Test-DbaClientXOfficeCsvCommandAvailability -ModulePath $psWriteOfficeModulePath)) {
+        $fileKinds = @($fileKinds | Where-Object { $_ -ne 'Csv' })
+        if ($fileKinds.Count -eq 0) {
+            throw 'No runnable office file round-trip benchmark lanes remain. CSV requires PSWriteOffice with Export-OfficeCsv and Import-OfficeCsv -AsDataTable; choose -FileKind Excel or pass -PSWriteOfficeModulePath to a compatible build.'
+        }
+    }
+
     function Get-DbaClientXOfficeBenchmarkCreateTableQuery {
         param([string] $TableName)
 

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -1,0 +1,325 @@
+param(
+    [string] $Server = $(if ($env:DBACLIENTX_SQLSERVER) { $env:DBACLIENTX_SQLSERVER } else { 'localhost' }),
+    [string] $Database = $(if ($env:DBACLIENTX_SQLDATABASE) { $env:DBACLIENTX_SQLDATABASE } else { 'tempdb' }),
+    [int[]] $RowCount = @(1000),
+    [ValidateSet('Csv', 'Excel')]
+    [string[]] $FileKind = @('Csv', 'Excel'),
+    [int] $Iterations = 3,
+    [int] $WarmupCount = 1,
+    [string] $ModulePath = $(
+        if ($env:DBACLIENTX_BENCHMARK_MODULE_PATH) {
+            $env:DBACLIENTX_BENCHMARK_MODULE_PATH
+        } elseif ($env:DBACLIENTX_DEVELOPMENT_PATH) {
+            Join-Path $PSScriptRoot '..\DbaClientX.psd1'
+        } else {
+            'DbaClientX'
+        }
+    ),
+    [string] $PSWriteOfficeModulePath = $(if ($env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH) { $env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH } else { 'PSWriteOffice' }),
+    [string] $OutputRoot,
+    [switch] $Plan,
+    [switch] $KeepArtifacts
+)
+
+if ($RowCount.Count -eq 0 -or @($RowCount | Where-Object { $_ -lt 1 }).Count -gt 0) {
+    throw 'RowCount values must be greater than zero.'
+}
+if ($FileKind.Count -eq 0) {
+    throw 'FileKind must contain at least one value.'
+}
+if ($Iterations -lt 1) {
+    throw 'Iterations must be greater than zero.'
+}
+if ($WarmupCount -lt 0) {
+    throw 'WarmupCount cannot be negative.'
+}
+
+Import-Module PSPublishModule -MinimumVersion 3.0.44 -ErrorAction Stop
+
+$benchmarkScriptRoot = $PSScriptRoot
+$settings = {
+    $sourceRoot = (Resolve-Path -LiteralPath (Join-Path $benchmarkScriptRoot '..\..')).Path
+    $readmePath = Join-Path $sourceRoot 'README.md'
+    $defaultOutputRoot = if (Test-Path -LiteralPath $readmePath) {
+        Join-Path $sourceRoot 'Ignore\Benchmarks\OfficeFileRoundTrip'
+    } else {
+        Join-Path ([System.IO.Path]::GetTempPath()) 'DbaClientX\Benchmarks\OfficeFileRoundTrip'
+    }
+    $outputRootBase = if ($OutputRoot) { $OutputRoot } else { $defaultOutputRoot }
+
+    $server = $Server
+    $database = $Database
+    $modulePath = $ModulePath
+    $psWriteOfficeModulePath = $PSWriteOfficeModulePath
+    $keepArtifacts = $KeepArtifacts.IsPresent
+    $rowCounts = $RowCount
+    $fileKinds = $FileKind
+
+    function Get-DbaClientXOfficeBenchmarkCreateTableQuery {
+        param([string] $TableName)
+
+        @"
+IF OBJECT_ID(N'dbo.$TableName', N'U') IS NOT NULL DROP TABLE dbo.$TableName;
+CREATE TABLE dbo.$TableName
+(
+    Id int NOT NULL,
+    DisplayName nvarchar(100) NOT NULL,
+    Score decimal(18,2) NOT NULL,
+    CreatedUtc datetime2 NOT NULL
+);
+"@
+    }
+
+    function Get-DbaClientXOfficeBenchmarkSeedQuery {
+        param(
+            [string] $TableName,
+            [int] $RowCount
+        )
+
+        @"
+WITH numbers AS
+(
+    SELECT TOP ($RowCount)
+        ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS Id
+    FROM sys.all_objects AS a
+    CROSS JOIN sys.all_objects AS b
+)
+INSERT INTO dbo.$TableName (Id, DisplayName, Score, CreatedUtc)
+SELECT
+    Id,
+    CONCAT(N'Row ', Id),
+    CONVERT(decimal(18,2), Id * 1.25),
+    SYSUTCDATETIME()
+FROM numbers;
+"@
+    }
+
+    function Get-DbaClientXOfficeBenchmarkExpectedIntegrity {
+        param([int] $RowCount)
+
+        $expectedIdSum = [long] ([int64] $RowCount * ([int64] $RowCount + 1) / 2)
+        [pscustomobject]@{
+            Rows = $RowCount
+            MinId = 1
+            MaxId = $RowCount
+            IdSum = $expectedIdSum
+            ScoreSum = [decimal] $expectedIdSum * 1.25
+        }
+    }
+
+    function Assert-DbaClientXOfficeBenchmarkIntegrity {
+        param(
+            [string] $FileKind,
+            [string] $TableName,
+            [object] $Actual,
+            [object] $Expected
+        )
+
+        if ($Actual.Rows -ne $Expected.Rows) {
+            throw "$FileKind round trip processed $($Actual.Rows) of $($Expected.Rows) expected row(s) for dbo.$TableName."
+        }
+
+        if ($Actual.MinId -ne $Expected.MinId -or
+            $Actual.MaxId -ne $Expected.MaxId -or
+            $Actual.IdSum -ne $Expected.IdSum -or
+            $Actual.ScoreSum -ne $Expected.ScoreSum) {
+            throw "$FileKind round trip produced unexpected data for dbo.${TableName}: MinId=$($Actual.MinId), MaxId=$($Actual.MaxId), IdSum=$($Actual.IdSum), ScoreSum=$($Actual.ScoreSum)."
+        }
+    }
+
+    function Invoke-DbaClientXOfficeRoundTrip {
+        param($case, $run)
+
+        $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+
+        $rows = @(
+            Invoke-DbaXQuery `
+                -Server $run.Server `
+                -Database $run.Database `
+                -TrustServerCertificate `
+                -Query "SELECT Id, DisplayName, Score, CreatedUtc FROM dbo.$($run.SourceTable) ORDER BY Id;" `
+                -ReturnType PSObject `
+                -ErrorAction Stop
+        )
+
+        if ($case.FileKind -eq 'Csv') {
+            $rows | Export-OfficeCsv -Path $run.FilePath -ErrorAction Stop | Out-Null
+            $run.ImportedTable = Import-OfficeCsv -Path $run.FilePath -AsDataTable -ErrorAction Stop
+        } else {
+            $rows |
+                Export-OfficeExcel `
+                    -Path $run.FilePath `
+                    -WorksheetName 'Rows' `
+                    -TableName 'DbaClientXRows' `
+                    -ErrorAction Stop | Out-Null
+            $run.ImportedTable = Import-OfficeExcel -Path $run.FilePath -WorksheetName 'Rows' -AsDataTable -ErrorAction Stop
+        }
+
+        $writeResult = $run.ImportedTable |
+            Write-DbaXTableData `
+                -Provider SqlServer `
+                -ConnectionString $run.ConnectionString `
+                -DestinationTable "dbo.$($run.DestinationTable)" `
+                -AutoCreateTable `
+                -TableLock `
+                -BatchSize 5000 `
+                -PassThru `
+                -ErrorAction Stop
+
+        $run.RowsWritten = [int] $writeResult.Rows
+    }
+
+    $getCreateTableQuery = ${function:Get-DbaClientXOfficeBenchmarkCreateTableQuery}
+    $getSeedQuery = ${function:Get-DbaClientXOfficeBenchmarkSeedQuery}
+    $getExpectedIntegrity = ${function:Get-DbaClientXOfficeBenchmarkExpectedIntegrity}
+    $assertIntegrity = ${function:Assert-DbaClientXOfficeBenchmarkIntegrity}
+    $invokeRoundTrip = ${function:Invoke-DbaClientXOfficeRoundTrip}
+
+    benchmark 'office-file-roundtrip' -out $outputRootBase {
+        policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
+        profile Current -Cleanup KeepOnFailure
+
+        caseSource {
+            foreach ($rowCount in $rowCounts) {
+                foreach ($fileKind in $fileKinds) {
+                    [pscustomobject]@{
+                        Scenario = "$rowCount rows / $fileKind"
+                        RowCount = $rowCount
+                        FileKind = $fileKind
+                    }
+                }
+            }
+        }
+
+        setup {
+            param($case, $run)
+
+            $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+            $run.Server = $server
+            $run.Database = $database
+            $run.KeepArtifacts = $keepArtifacts
+            $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
+            $run.SourceTable = 'DbaClientXBench_FileSource_{0}' -f ([guid]::NewGuid().ToString('N').Substring(0, 8))
+            $run.DestinationTable = 'DbaClientXBench_FileDest_{0}' -f ([guid]::NewGuid().ToString('N').Substring(0, 8))
+            $extension = if ($case.FileKind -eq 'Csv') { '.csv' } else { '.xlsx' }
+            $run.FilePath = Join-Path $outputRootBase ('DbaClientXBench_{0}_{1}{2}' -f $case.FileKind, ([guid]::NewGuid().ToString('N').Substring(0, 8)), $extension)
+            $run.DropQuery = @"
+IF OBJECT_ID(N'dbo.$($run.DestinationTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run.DestinationTable);
+IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run.SourceTable);
+"@
+
+            New-Item -ItemType Directory -Force -Path $outputRootBase | Out-Null
+            Import-Module $modulePath -Global -Force -ErrorAction Stop
+            Import-Module $psWriteOfficeModulePath -Global -Force -ErrorAction Stop
+
+            Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getCreateTableQuery -TableName $run.SourceTable) -ErrorAction Stop | Out-Null
+            Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getSeedQuery -TableName $run.SourceTable -RowCount ([int] $case.RowCount)) -ErrorAction Stop | Out-Null
+        }
+
+        engine DbaClientX {
+            operation RoundTrip {
+                param($case, $run)
+
+                & $invokeRoundTrip $case $run
+            }
+        }
+
+        validate {
+            param($case, $run)
+
+            $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+            $integrity = Invoke-DbaXQuery `
+                -Server $run.Server `
+                -Database $run.Database `
+                -TrustServerCertificate `
+                -Query "SELECT COUNT(*) AS [Rows], MIN(Id) AS [MinId], MAX(Id) AS [MaxId], SUM(CAST(Id AS bigint)) AS [IdSum], SUM(CAST(Score AS decimal(38,2))) AS [ScoreSum] FROM dbo.$($run.DestinationTable);" `
+                -ReturnType PSObject `
+                -ErrorAction Stop
+            $actual = [pscustomobject]@{
+                Rows = [int] $integrity.Rows
+                MinId = [int] $integrity.MinId
+                MaxId = [int] $integrity.MaxId
+                IdSum = [long] $integrity.IdSum
+                ScoreSum = [decimal] $integrity.ScoreSum
+            }
+            $expected = & $getExpectedIntegrity -RowCount ([int] $case.RowCount)
+            & $assertIntegrity -FileKind $case.FileKind -TableName $run.DestinationTable -Actual $actual -Expected $expected
+
+            if ($run.RowsWritten -ne [int] $case.RowCount) {
+                throw "$($case.FileKind) round trip wrote $($run.RowsWritten) of $($case.RowCount) expected row(s)."
+            }
+
+            $run.RowsProcessed = $actual.Rows
+            $run.IdSum = $actual.IdSum
+            $run.ScoreSum = $actual.ScoreSum
+
+            if (-not $run.KeepArtifacts) {
+                Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropQuery -ErrorAction Stop | Out-Null
+                if (Test-Path -LiteralPath $run.FilePath) {
+                    Remove-Item -LiteralPath $run.FilePath -Force
+                }
+            }
+        }
+
+        metric RowsProcessed {
+            param($case, $run)
+
+            $run.RowsProcessed
+        }
+
+        metric IdSum {
+            param($case, $run)
+
+            $run.IdSum
+        }
+
+        metric ScoreSum {
+            param($case, $run)
+
+            $run.ScoreSum
+        }
+
+        metric RowsPerSecond {
+            param($case, $run)
+
+            if ($run.DurationMs -le 0) {
+                return 0
+            }
+
+            [double] $case.RowCount / ($run.DurationMs / 1000)
+        }
+
+        comparison FileKind -Baseline Csv -Metric MedianMs
+        if (Test-Path -LiteralPath $readmePath) {
+            readme $readmePath -Block 'office-file-roundtrip-benchmark' -Renderer ComparisonTable
+        }
+        artifacts Json, Csv, Markdown
+    }
+}.GetNewClosure()
+
+$parameters = @{
+    Settings = $settings
+    WarmupCount = $WarmupCount
+    IterationCount = $Iterations
+}
+if ($Plan) {
+    $parameters.Plan = $true
+}
+
+$result = Invoke-BenchmarkSuite @parameters
+if (-not $Plan -and $result.Summary) {
+    $failedRows = @($result.Summary | Where-Object { $_.FailureCount -gt 0 -or $_.Status -eq 'Failed' })
+    if ($failedRows.Count -gt 0) {
+        $failedDescriptions = $failedRows | ForEach-Object {
+            $reasons = if ($_.FailureReasons -and $_.FailureReasons.Keys.Count -gt 0) {
+                $_.FailureReasons.Keys -join ' | '
+            } else {
+                'No failure reason was recorded.'
+            }
+            "$($_.Engine) $($_.Operation) $($_.Scenario): $reasons"
+        }
+        throw "Benchmark run $($result.RunId -join ', ') had failed lane(s): $($failedDescriptions -join '; ')"
+    }
+}
+
+$result

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -110,6 +110,34 @@ $settings = {
         return $true
     }
 
+    function Test-DbaClientXOfficeExcelCommandAvailability {
+        param(
+            [string] $ModulePath
+        )
+
+        try {
+            $importedModule = Import-Module $ModulePath -Global -Force -PassThru -ErrorAction Stop
+        } catch {
+            Write-Warning "Skipping Excel office file benchmark lane because PSWriteOffice could not be imported from '$ModulePath': $($_.Exception.Message)"
+            return $false
+        }
+
+        $moduleNames = @($importedModule | ForEach-Object { $_.Name })
+        $exportCommand = Get-Command Export-OfficeExcel -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
+        $importCommand = Get-Command Import-OfficeExcel -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
+        if (-not $exportCommand -or -not $importCommand) {
+            Write-Warning "Skipping Excel office file benchmark lane because the imported PSWriteOffice module does not expose Export-OfficeExcel and Import-OfficeExcel."
+            return $false
+        }
+
+        if (-not @($importCommand | Where-Object { $_.Parameters.ContainsKey('AsDataTable') })) {
+            Write-Warning "Skipping Excel office file benchmark lane because Import-OfficeExcel does not expose -AsDataTable."
+            return $false
+        }
+
+        return $true
+    }
+
     function Test-DbaToolsCsvCommandAvailability {
         param(
             [switch] $RequireCompression
@@ -210,6 +238,7 @@ FROM numbers;
     $getExpectedIntegrity = ${function:Get-DbaClientXOfficeBenchmarkExpectedIntegrity}
     $assertIntegrity = ${function:Assert-DbaClientXOfficeBenchmarkIntegrity}
     $testOfficeCsvCommands = ${function:Test-DbaClientXOfficeCsvCommandAvailability}
+    $testOfficeExcelCommands = ${function:Test-DbaClientXOfficeExcelCommandAvailability}
     $testDbaToolsCsvCommands = ${function:Test-DbaToolsCsvCommandAvailability}
     benchmark 'office-file-roundtrip' -out $outputRootBase {
         policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
@@ -287,13 +316,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 return -not (& $testOfficeCsvCommands -ModulePath $psWriteOfficeModulePath -RequireCompression:($case.FileKind -eq 'CsvGZip'))
             }
 
-            return -not (
-                (Get-Command Export-OfficeExcel -ErrorAction SilentlyContinue) -and
-                @(
-                    Get-Command Import-OfficeExcel -ErrorAction SilentlyContinue |
-                        Where-Object { $_.Parameters.ContainsKey('AsDataTable') }
-                ).Count -gt 0
-            )
+            return -not (& $testOfficeExcelCommands -ModulePath $psWriteOfficeModulePath)
         }
 
         engine DbaClientX {
@@ -312,8 +335,22 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                     -ErrorAction Stop
 
                 if ($case.FileKind -in @('Csv', 'CsvGZip')) {
-                    $data | Export-OfficeCsv -Path $run.FilePath -ErrorAction Stop
-                    $imported = Import-OfficeCsv -Path $run.FilePath -AsDataTable -ErrorAction Stop
+                    $csvExportParameters = @{
+                        Path = $run.FilePath
+                        ErrorAction = 'Stop'
+                    }
+                    $csvImportParameters = @{
+                        Path = $run.FilePath
+                        AsDataTable = $true
+                        ErrorAction = 'Stop'
+                    }
+                    if ($case.FileKind -eq 'CsvGZip') {
+                        $csvExportParameters.CompressionType = 'GZip'
+                        $csvImportParameters.CompressionType = 'GZip'
+                    }
+
+                    $data | Export-OfficeCsv @csvExportParameters
+                    $imported = Import-OfficeCsv @csvImportParameters
                 } else {
                     $data | Export-OfficeExcel -Path $run.FilePath -WorksheetName Data -TableName Data -ErrorAction Stop
                     $imported = Import-OfficeExcel -Path $run.FilePath -WorksheetName Data -AsDataTable -ErrorAction Stop

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -2,7 +2,7 @@ param(
     [string] $Server = $(if ($env:DBACLIENTX_SQLSERVER) { $env:DBACLIENTX_SQLSERVER } else { 'localhost' }),
     [string] $Database = $(if ($env:DBACLIENTX_SQLDATABASE) { $env:DBACLIENTX_SQLDATABASE } else { 'tempdb' }),
     [int[]] $RowCount = @(1000),
-    [ValidateSet('Csv', 'Excel')]
+    [ValidateSet('Csv', 'CsvGZip', 'Excel')]
     [string[]] $FileKind = @('Csv', 'Excel'),
     [int] $Iterations = 3,
     [int] $WarmupCount = 1,
@@ -75,7 +75,10 @@ $settings = {
     $selectedEngines = if ($Engine) { $Engine } else { @('DbaClientX') }
 
     function Test-DbaClientXOfficeCsvCommandAvailability {
-        param([string] $ModulePath)
+        param(
+            [string] $ModulePath,
+            [switch] $RequireCompression
+        )
 
         try {
             $importedModule = Import-Module $ModulePath -Global -Force -PassThru -ErrorAction Stop
@@ -97,10 +100,17 @@ $settings = {
             return $false
         }
 
+        if ($RequireCompression.IsPresent -and
+            (-not @($exportCommand | Where-Object { $_.Parameters.ContainsKey('CompressionType') }) -or
+             -not @($importCommand | Where-Object { $_.Parameters.ContainsKey('CompressionType') }))) {
+            Write-Warning "Skipping compressed CSV office file benchmark lane because the imported PSWriteOffice module does not expose CSV compression parameters."
+            return $false
+        }
+
         return $true
     }
 
-    $comparisonBaseline = if ($fileKinds -contains 'Csv') { 'Csv' } else { $fileKinds[0] }
+    $comparisonBaseline = if ($fileKinds -contains 'Csv') { 'Csv' } elseif ($fileKinds -contains 'CsvGZip') { 'CsvGZip' } else { $fileKinds[0] }
     $engineComparisonBaseline = if ($selectedEngines -contains 'DbaClientX') { 'DbaClientX' } else { $selectedEngines[0] }
 
     function Get-DbaClientXOfficeBenchmarkCreateTableQuery {
@@ -206,7 +216,11 @@ FROM numbers;
             $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
             $run.SourceTable = 'DbaClientXBench_FileSource_{0}' -f ([guid]::NewGuid().ToString('N').Substring(0, 8))
             $run.DestinationTable = 'DbaClientXBench_FileDest_{0}' -f ([guid]::NewGuid().ToString('N').Substring(0, 8))
-            $extension = if ($case.FileKind -eq 'Csv') { '.csv' } else { '.xlsx' }
+            $extension = switch ($case.FileKind) {
+                'Csv' { '.csv' }
+                'CsvGZip' { '.csv.gz' }
+                default { '.xlsx' }
+            }
             $run.FilePath = Join-Path $outputRootBase ('DbaClientXBench_{0}_{1}_{2}{3}' -f $case.Engine, $case.FileKind, ([guid]::NewGuid().ToString('N').Substring(0, 8)), $extension)
             $run.DropQuery = @"
 IF OBJECT_ID(N'dbo.$($run.DestinationTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run.DestinationTable);
@@ -241,7 +255,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             param($case)
 
             if ($case.Engine -eq 'dbatools') {
-                if ($case.FileKind -ne 'Csv') {
+                if ($case.FileKind -notin @('Csv', 'CsvGZip')) {
                     return $true
                 }
 
@@ -252,8 +266,8 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 )
             }
 
-            if ($case.FileKind -eq 'Csv') {
-                return -not (& $testOfficeCsvCommands -ModulePath $psWriteOfficeModulePath)
+            if ($case.FileKind -in @('Csv', 'CsvGZip')) {
+                return -not (& $testOfficeCsvCommands -ModulePath $psWriteOfficeModulePath -RequireCompression:($case.FileKind -eq 'CsvGZip'))
             }
 
             return -not (
@@ -280,7 +294,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                     -ReturnType DataTable `
                     -ErrorAction Stop
 
-                if ($case.FileKind -eq 'Csv') {
+                if ($case.FileKind -in @('Csv', 'CsvGZip')) {
                     $data | Export-OfficeCsv -Path $run.FilePath -ErrorAction Stop
                     $imported = Import-OfficeCsv -Path $run.FilePath -AsDataTable -ErrorAction Stop
                 } else {

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -6,6 +6,7 @@ param(
     [string[]] $FileKind = @('Csv', 'Excel'),
     [int] $Iterations = 3,
     [int] $WarmupCount = 1,
+    [string[]] $Engine,
     [string] $ModulePath = $(
         if ($env:DBACLIENTX_BENCHMARK_MODULE_PATH) {
             $env:DBACLIENTX_BENCHMARK_MODULE_PATH
@@ -26,6 +27,23 @@ if ($RowCount.Count -eq 0 -or @($RowCount | Where-Object { $_ -lt 1 }).Count -gt
 }
 if ($FileKind.Count -eq 0) {
     throw 'FileKind must contain at least one value.'
+}
+
+$Engine = @(
+    foreach ($engineName in @($Engine)) {
+        foreach ($part in ([string] $engineName -split ',')) {
+            $normalized = $part.Trim()
+            if (-not [string]::IsNullOrWhiteSpace($normalized)) {
+                $normalized
+            }
+        }
+    }
+) | Select-Object -Unique
+
+$validEngines = @('DbaClientX', 'dbatools')
+$invalidEngines = @($Engine | Where-Object { $_ -notin $validEngines })
+if ($invalidEngines.Count -gt 0) {
+    throw "Engine must contain only: $($validEngines -join ', '). Invalid value(s): $($invalidEngines -join ', ')."
 }
 if ($Iterations -lt 1) {
     throw 'Iterations must be greater than zero.'
@@ -54,6 +72,7 @@ $settings = {
     $keepArtifacts = $KeepArtifacts.IsPresent
     $rowCounts = $RowCount
     $fileKinds = $FileKind
+    $selectedEngines = if ($Engine) { $Engine } else { @('DbaClientX') }
 
     function Test-DbaClientXOfficeCsvCommandAvailability {
         param([string] $ModulePath)
@@ -81,13 +100,8 @@ $settings = {
         return $true
     }
 
-    if ($fileKinds -contains 'Csv' -and -not (Test-DbaClientXOfficeCsvCommandAvailability -ModulePath $psWriteOfficeModulePath)) {
-        $fileKinds = @($fileKinds | Where-Object { $_ -ne 'Csv' })
-        if ($fileKinds.Count -eq 0) {
-            throw 'No runnable office file round-trip benchmark lanes remain. CSV requires PSWriteOffice with Export-OfficeCsv and Import-OfficeCsv -AsDataTable; choose -FileKind Excel or pass -PSWriteOfficeModulePath to a compatible build.'
-        }
-    }
     $comparisonBaseline = if ($fileKinds -contains 'Csv') { 'Csv' } else { $fileKinds[0] }
+    $engineComparisonBaseline = if ($selectedEngines -contains 'DbaClientX') { 'DbaClientX' } else { $selectedEngines[0] }
 
     function Get-DbaClientXOfficeBenchmarkCreateTableQuery {
         param([string] $TableName)
@@ -161,54 +175,11 @@ FROM numbers;
         }
     }
 
-    function Invoke-DbaClientXOfficeRoundTrip {
-        param($case, $run)
-
-        $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
-
-        $rows = @(
-            Invoke-DbaXQuery `
-                -Server $run.Server `
-                -Database $run.Database `
-                -TrustServerCertificate `
-                -Query "SELECT Id, DisplayName, Score, CreatedUtc FROM dbo.$($run.SourceTable) ORDER BY Id;" `
-                -ReturnType PSObject `
-                -ErrorAction Stop
-        )
-
-        if ($case.FileKind -eq 'Csv') {
-            $rows | Export-OfficeCsv -Path $run.FilePath -ErrorAction Stop | Out-Null
-            $run.ImportedTable = Import-OfficeCsv -Path $run.FilePath -AsDataTable -ErrorAction Stop
-        } else {
-            $rows |
-                Export-OfficeExcel `
-                    -Path $run.FilePath `
-                    -WorksheetName 'Rows' `
-                    -TableName 'DbaClientXRows' `
-                    -ErrorAction Stop | Out-Null
-            $run.ImportedTable = Import-OfficeExcel -Path $run.FilePath -WorksheetName 'Rows' -AsDataTable -ErrorAction Stop
-        }
-
-        $writeResult = $run.ImportedTable |
-            Write-DbaXTableData `
-                -Provider SqlServer `
-                -ConnectionString $run.ConnectionString `
-                -DestinationTable "dbo.$($run.DestinationTable)" `
-                -AutoCreateTable `
-                -TableLock `
-                -BatchSize 5000 `
-                -PassThru `
-                -ErrorAction Stop
-
-        $run.RowsWritten = [int] $writeResult.Rows
-    }
-
     $getCreateTableQuery = ${function:Get-DbaClientXOfficeBenchmarkCreateTableQuery}
     $getSeedQuery = ${function:Get-DbaClientXOfficeBenchmarkSeedQuery}
     $getExpectedIntegrity = ${function:Get-DbaClientXOfficeBenchmarkExpectedIntegrity}
     $assertIntegrity = ${function:Assert-DbaClientXOfficeBenchmarkIntegrity}
-    $invokeRoundTrip = ${function:Invoke-DbaClientXOfficeRoundTrip}
-
+    $testOfficeCsvCommands = ${function:Test-DbaClientXOfficeCsvCommandAvailability}
     benchmark 'office-file-roundtrip' -out $outputRootBase {
         policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
         profile Current -Cleanup KeepOnFailure
@@ -236,7 +207,7 @@ FROM numbers;
             $run.SourceTable = 'DbaClientXBench_FileSource_{0}' -f ([guid]::NewGuid().ToString('N').Substring(0, 8))
             $run.DestinationTable = 'DbaClientXBench_FileDest_{0}' -f ([guid]::NewGuid().ToString('N').Substring(0, 8))
             $extension = if ($case.FileKind -eq 'Csv') { '.csv' } else { '.xlsx' }
-            $run.FilePath = Join-Path $outputRootBase ('DbaClientXBench_{0}_{1}{2}' -f $case.FileKind, ([guid]::NewGuid().ToString('N').Substring(0, 8)), $extension)
+            $run.FilePath = Join-Path $outputRootBase ('DbaClientXBench_{0}_{1}_{2}{3}' -f $case.Engine, $case.FileKind, ([guid]::NewGuid().ToString('N').Substring(0, 8)), $extension)
             $run.DropQuery = @"
 IF OBJECT_ID(N'dbo.$($run.DestinationTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run.DestinationTable);
 IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run.SourceTable);
@@ -244,17 +215,140 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
 
             New-Item -ItemType Directory -Force -Path $outputRootBase | Out-Null
             Import-Module $modulePath -Global -Force -ErrorAction Stop
-            Import-Module $psWriteOfficeModulePath -Global -Force -ErrorAction Stop
+
+            if ($case.Engine -eq 'DbaClientX') {
+                Import-Module $psWriteOfficeModulePath -Global -Force -ErrorAction Stop
+            }
 
             Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getCreateTableQuery -TableName $run.SourceTable) -ErrorAction Stop | Out-Null
             Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getSeedQuery -TableName $run.SourceTable -RowCount ([int] $case.RowCount)) -ErrorAction Stop | Out-Null
+
+            if ($case.Engine -eq 'dbatools') {
+                $connectCommand = Get-Command Connect-DbaInstance -ErrorAction Stop
+                $parameters = @{
+                    SqlInstance = $run.Server
+                    Database = $run.Database
+                }
+                if ($connectCommand.Parameters.ContainsKey('TrustServerCertificate')) {
+                    $parameters.TrustServerCertificate = $true
+                }
+
+                $run.DbatoolsInstance = Connect-DbaInstance @parameters
+            }
+        }
+
+        skip {
+            param($case)
+
+            if ($case.Engine -eq 'dbatools') {
+                if ($case.FileKind -ne 'Csv') {
+                    return $true
+                }
+
+                return -not (
+                    (Get-Command Connect-DbaInstance -ErrorAction SilentlyContinue) -and
+                    (Get-Command Export-DbaCsv -ErrorAction SilentlyContinue) -and
+                    (Get-Command Import-DbaCsv -ErrorAction SilentlyContinue)
+                )
+            }
+
+            if ($case.FileKind -eq 'Csv') {
+                return -not (& $testOfficeCsvCommands -ModulePath $psWriteOfficeModulePath)
+            }
+
+            return -not (
+                (Get-Command Export-OfficeExcel -ErrorAction SilentlyContinue) -and
+                @(
+                    Get-Command Import-OfficeExcel -ErrorAction SilentlyContinue |
+                        Where-Object { $_.Parameters.ContainsKey('AsDataTable') }
+                ).Count -gt 0
+            )
         }
 
         engine DbaClientX {
             operation RoundTrip {
                 param($case, $run)
 
-                & $invokeRoundTrip $case $run
+                $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+
+                $query = "SELECT Id, DisplayName, Score, CreatedUtc FROM dbo.$($run.SourceTable) ORDER BY Id;"
+                $data = Invoke-DbaXQuery `
+                    -Server $run.Server `
+                    -Database $run.Database `
+                    -TrustServerCertificate `
+                    -Query $query `
+                    -ReturnType DataTable `
+                    -ErrorAction Stop
+
+                if ($case.FileKind -eq 'Csv') {
+                    $data | Export-OfficeCsv -Path $run.FilePath -ErrorAction Stop
+                    $imported = Import-OfficeCsv -Path $run.FilePath -AsDataTable -ErrorAction Stop
+                } else {
+                    $data | Export-OfficeExcel -Path $run.FilePath -WorksheetName Data -TableName Data -ErrorAction Stop
+                    $imported = Import-OfficeExcel -Path $run.FilePath -WorksheetName Data -AsDataTable -ErrorAction Stop
+                }
+
+                $writeResult = $imported | Write-DbaXTableData `
+                    -Provider SqlServer `
+                    -ConnectionString $run.ConnectionString `
+                    -DestinationTable "dbo.$($run.DestinationTable)" `
+                    -AutoCreateTable `
+                    -BatchSize 5000 `
+                    -TableLock `
+                    -PassThru `
+                    -ErrorAction Stop
+                $run.RowsWritten = [int] $writeResult.Rows
+            }
+        }
+
+        engine dbatools {
+            operation RoundTrip {
+                param($case, $run)
+
+                $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+
+                $query = "SELECT Id, DisplayName, Score, CreatedUtc FROM dbo.$($run.SourceTable) ORDER BY Id;"
+                $exportParameters = @{
+                    SqlInstance = $run.DbatoolsInstance
+                    Database = $run.Database
+                    Query = $query
+                    Path = $run.FilePath
+                    Delimiter = ','
+                }
+                $exportCommand = Get-Command Export-DbaCsv -ErrorAction Stop
+                if ($exportCommand.Parameters.ContainsKey('QuotingBehavior')) {
+                    $exportParameters.QuotingBehavior = 'Always'
+                }
+                if ($exportCommand.Parameters.ContainsKey('EnableException')) {
+                    $exportParameters.EnableException = $true
+                }
+
+                Export-DbaCsv @exportParameters | Out-Null
+
+                $importParameters = @{
+                    Path = $run.FilePath
+                    SqlInstance = $run.DbatoolsInstance
+                    Database = $run.Database
+                    Schema = 'dbo'
+                    Table = $run.DestinationTable
+                    AutoCreateTable = $true
+                    BatchSize = 5000
+                    TableLock = $true
+                    Delimiter = ','
+                }
+                $importCommand = Get-Command Import-DbaCsv -ErrorAction Stop
+                $currentCultureName = [System.Globalization.CultureInfo]::CurrentCulture.Name
+                if ($importCommand.Parameters.ContainsKey('Culture') -and -not [string]::IsNullOrWhiteSpace($currentCultureName)) {
+                    $importParameters.Culture = $currentCultureName
+                }
+                if ($importCommand.Parameters.ContainsKey('EnableException')) {
+                    $importParameters.EnableException = $true
+                }
+                if ($importCommand.Parameters.ContainsKey('NoProgress')) {
+                    $importParameters.NoProgress = $true
+                }
+
+                Import-DbaCsv @importParameters | Out-Null
             }
         }
 
@@ -266,7 +360,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 -Server $run.Server `
                 -Database $run.Database `
                 -TrustServerCertificate `
-                -Query "SELECT COUNT(*) AS [Rows], MIN(Id) AS [MinId], MAX(Id) AS [MaxId], SUM(CAST(Id AS bigint)) AS [IdSum], SUM(CAST(Score AS decimal(38,2))) AS [ScoreSum] FROM dbo.$($run.DestinationTable);" `
+                -Query "SELECT COUNT(*) AS [Rows], MIN(CAST(Id AS int)) AS [MinId], MAX(CAST(Id AS int)) AS [MaxId], SUM(CAST(Id AS bigint)) AS [IdSum], SUM(CAST(Score AS decimal(38,2))) AS [ScoreSum] FROM dbo.$($run.DestinationTable);" `
                 -ReturnType PSObject `
                 -ErrorAction Stop
             $actual = [pscustomobject]@{
@@ -279,7 +373,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             $expected = & $getExpectedIntegrity -RowCount ([int] $case.RowCount)
             & $assertIntegrity -FileKind $case.FileKind -TableName $run.DestinationTable -Actual $actual -Expected $expected
 
-            if ($run.RowsWritten -ne [int] $case.RowCount) {
+            if ($null -ne $run.RowsWritten -and $run.RowsWritten -ne [int] $case.RowCount) {
                 throw "$($case.FileKind) round trip wrote $($run.RowsWritten) of $($case.RowCount) expected row(s)."
             }
 
@@ -323,7 +417,11 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             [double] $case.RowCount / ($run.DurationMs / 1000)
         }
 
-        comparison FileKind -Baseline $comparisonBaseline -Metric MedianMs
+        if ($selectedEngines.Count -gt 1) {
+            comparison Engine -Baseline $engineComparisonBaseline -Metric MedianMs
+        } else {
+            comparison FileKind -Baseline $comparisonBaseline -Metric MedianMs
+        }
         if (Test-Path -LiteralPath $readmePath) {
             readme $readmePath -Block 'office-file-roundtrip-benchmark' -Renderer ComparisonTable
         }
@@ -335,6 +433,10 @@ $parameters = @{
     Settings = $settings
     WarmupCount = $WarmupCount
     IterationCount = $Iterations
+    Engine = $Engine
+}
+if (-not $Engine) {
+    $parameters.Engine = @('DbaClientX')
 }
 if ($Plan) {
     $parameters.Plan = $true

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -110,6 +110,26 @@ $settings = {
         return $true
     }
 
+    function Test-DbaToolsCsvCommandAvailability {
+        param(
+            [switch] $RequireCompression
+        )
+
+        $connectCommand = Get-Command Connect-DbaInstance -ErrorAction SilentlyContinue
+        $exportCommand = Get-Command Export-DbaCsv -ErrorAction SilentlyContinue
+        $importCommand = Get-Command Import-DbaCsv -ErrorAction SilentlyContinue
+        if (-not $connectCommand -or -not $exportCommand -or -not $importCommand) {
+            return $false
+        }
+
+        if ($RequireCompression.IsPresent -and -not $exportCommand.Parameters.ContainsKey('CompressionType')) {
+            Write-Warning "Skipping compressed dbatools CSV benchmark lane because Export-DbaCsv does not expose -CompressionType."
+            return $false
+        }
+
+        return $true
+    }
+
     $comparisonBaseline = if ($fileKinds -contains 'Csv') { 'Csv' } elseif ($fileKinds -contains 'CsvGZip') { 'CsvGZip' } else { $fileKinds[0] }
     $engineComparisonBaseline = if ($selectedEngines -contains 'DbaClientX') { 'DbaClientX' } else { $selectedEngines[0] }
 
@@ -190,6 +210,7 @@ FROM numbers;
     $getExpectedIntegrity = ${function:Get-DbaClientXOfficeBenchmarkExpectedIntegrity}
     $assertIntegrity = ${function:Assert-DbaClientXOfficeBenchmarkIntegrity}
     $testOfficeCsvCommands = ${function:Test-DbaClientXOfficeCsvCommandAvailability}
+    $testDbaToolsCsvCommands = ${function:Test-DbaToolsCsvCommandAvailability}
     benchmark 'office-file-roundtrip' -out $outputRootBase {
         policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
         profile Current -Cleanup KeepOnFailure
@@ -259,11 +280,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                     return $true
                 }
 
-                return -not (
-                    (Get-Command Connect-DbaInstance -ErrorAction SilentlyContinue) -and
-                    (Get-Command Export-DbaCsv -ErrorAction SilentlyContinue) -and
-                    (Get-Command Import-DbaCsv -ErrorAction SilentlyContinue)
-                )
+                return -not (& $testDbaToolsCsvCommands -RequireCompression:($case.FileKind -eq 'CsvGZip'))
             }
 
             if ($case.FileKind -in @('Csv', 'CsvGZip')) {
@@ -332,6 +349,12 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 $exportCommand = Get-Command Export-DbaCsv -ErrorAction Stop
                 if ($exportCommand.Parameters.ContainsKey('QuotingBehavior')) {
                     $exportParameters.QuotingBehavior = 'Always'
+                }
+                if ($case.FileKind -eq 'CsvGZip' -and $exportCommand.Parameters.ContainsKey('CompressionType')) {
+                    $exportParameters.CompressionType = 'GZip'
+                }
+                if ($case.FileKind -eq 'CsvGZip' -and $exportCommand.Parameters.ContainsKey('CompressionLevel')) {
+                    $exportParameters.CompressionLevel = 'Optimal'
                 }
                 if ($exportCommand.Parameters.ContainsKey('EnableException')) {
                     $exportParameters.EnableException = $true

--- a/Module/Examples/Example.CsvRoundTrip.ps1
+++ b/Module/Examples/Example.CsvRoundTrip.ps1
@@ -21,6 +21,12 @@ if ($RowCount -lt 1) {
     throw 'RowCount must be greater than zero.'
 }
 
+$exportOfficeCsv = Get-Command Export-OfficeCsv -ErrorAction SilentlyContinue
+$importOfficeCsv = Get-Command Import-OfficeCsv -ErrorAction SilentlyContinue
+if (-not $exportOfficeCsv -or -not @($importOfficeCsv | Where-Object { $_.Parameters.ContainsKey('AsDataTable') })) {
+    throw 'This CSV round-trip example requires PSWriteOffice with Export-OfficeCsv and Import-OfficeCsv -AsDataTable. Import or install a compatible PSWriteOffice build before running the example.'
+}
+
 $connectionString = "Server=$Server;Database=$Database;Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
 
 Invoke-DbaXNonQuery -Server $Server -Database $Database -TrustServerCertificate -Query @"

--- a/Module/Examples/Example.CsvRoundTrip.ps1
+++ b/Module/Examples/Example.CsvRoundTrip.ps1
@@ -1,0 +1,135 @@
+param(
+    [string] $Server = $(if ($env:DBACLIENTX_SQLSERVER) { $env:DBACLIENTX_SQLSERVER } else { 'localhost' }),
+    [string] $Database = $(if ($env:DBACLIENTX_SQLDATABASE) { $env:DBACLIENTX_SQLDATABASE } else { 'tempdb' }),
+    [string] $SourceTable = 'dbo.DbaClientXCsvSource',
+    [string] $DestinationTable = 'dbo.DbaClientXCsvRoundTrip',
+    [string] $CsvPath = (Join-Path $PWD 'DbaClientXCsvRoundTrip.csv'),
+    [int] $RowCount = 100,
+    [switch] $KeepArtifacts
+)
+
+# Use this example to prove the SQL Server -> CSV -> SQL Server workflow:
+# DbaClientX reads source rows, PSWriteOffice writes and reads the CSV file,
+# and DbaClientX writes the imported DataTable back to SQL Server.
+# Example:
+#   .\Example.CsvRoundTrip.ps1 -Server localhost -Database tempdb -RowCount 100 -KeepArtifacts
+
+Import-Module DbaClientX -Force
+Import-Module PSWriteOffice -Force
+
+if ($RowCount -lt 1) {
+    throw 'RowCount must be greater than zero.'
+}
+
+$connectionString = "Server=$Server;Database=$Database;Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
+
+Invoke-DbaXNonQuery -Server $Server -Database $Database -TrustServerCertificate -Query @"
+IF OBJECT_ID(N'$SourceTable', N'U') IS NOT NULL DROP TABLE $SourceTable;
+IF OBJECT_ID(N'$DestinationTable', N'U') IS NOT NULL DROP TABLE $DestinationTable;
+
+CREATE TABLE $SourceTable
+(
+    Id int NOT NULL,
+    DisplayName nvarchar(100) NOT NULL,
+    Score decimal(18,2) NOT NULL,
+    CreatedUtc datetime2 NOT NULL
+);
+
+WITH numbers AS
+(
+    SELECT TOP ($RowCount)
+        ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS Id
+    FROM sys.all_objects AS a
+    CROSS JOIN sys.all_objects AS b
+)
+INSERT INTO $SourceTable (Id, DisplayName, Score, CreatedUtc)
+SELECT
+    Id,
+    CONCAT(N'Row ', Id),
+    CONVERT(decimal(18,2), Id * 1.25),
+    SYSUTCDATETIME()
+FROM numbers;
+"@ -ErrorAction Stop | Out-Null
+
+try {
+    $rows = @(
+        Invoke-DbaXQuery `
+            -Server $Server `
+            -Database $Database `
+            -TrustServerCertificate `
+            -Query "SELECT Id, DisplayName, Score, CreatedUtc FROM $SourceTable ORDER BY Id;" `
+            -ReturnType PSObject `
+            -ErrorAction Stop
+    )
+
+    if (Test-Path -LiteralPath $CsvPath) {
+        Remove-Item -LiteralPath $CsvPath -Force
+    }
+
+    $rows |
+        Export-OfficeCsv `
+            -Path $CsvPath `
+            -ErrorAction Stop | Out-Null
+
+    $csvTable = Import-OfficeCsv `
+        -Path $CsvPath `
+        -AsDataTable `
+        -ErrorAction Stop
+
+    $writeResult = $csvTable |
+        Write-DbaXTableData `
+            -Provider SqlServer `
+            -ConnectionString $connectionString `
+            -DestinationTable $DestinationTable `
+            -AutoCreateTable `
+            -TableLock `
+            -BatchSize 5000 `
+            -PassThru `
+            -ErrorAction Stop
+
+    $verification = Invoke-DbaXQuery `
+        -Server $Server `
+        -Database $Database `
+        -TrustServerCertificate `
+        -Query "SELECT COUNT(*) AS SourceRows FROM $SourceTable; SELECT COUNT(*) AS DestinationRows FROM $DestinationTable;" `
+        -ReturnType DataSet `
+        -ErrorAction Stop
+
+    $sourceRows = [int] $verification.Tables[0].Rows[0]['SourceRows']
+    $destinationRows = [int] $verification.Tables[1].Rows[0]['DestinationRows']
+
+    $hasMismatch = $rows.Count -ne $RowCount -or
+        $csvTable.Rows.Count -ne $RowCount -or
+        $writeResult.Rows -ne $RowCount -or
+        $sourceRows -ne $RowCount -or
+        $destinationRows -ne $RowCount
+
+    if ($hasMismatch) {
+        throw "Round-trip row count mismatch. Exported=$($rows.Count), Imported=$($csvTable.Rows.Count), Written=$($writeResult.Rows), Source=$sourceRows, Destination=$destinationRows, Expected=$RowCount."
+    }
+
+    [pscustomobject]@{
+        Server = $Server
+        Database = $Database
+        CsvPath = $CsvPath
+        SourceTable = $SourceTable
+        DestinationTable = $DestinationTable
+        ExportedRows = $rows.Count
+        ImportedRows = $csvTable.Rows.Count
+        WrittenRows = $writeResult.Rows
+        SourceRows = $sourceRows
+        DestinationRows = $destinationRows
+    }
+}
+finally {
+    if (-not $KeepArtifacts) {
+        Invoke-DbaXNonQuery -Server $Server -Database $Database -TrustServerCertificate -Query @"
+IF OBJECT_ID(N'$DestinationTable', N'U') IS NOT NULL DROP TABLE $DestinationTable;
+IF OBJECT_ID(N'$SourceTable', N'U') IS NOT NULL DROP TABLE $SourceTable;
+"@ -ErrorAction SilentlyContinue | Out-Null
+
+        if (Test-Path -LiteralPath $CsvPath) {
+            Remove-Item -LiteralPath $CsvPath -Force
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -299,25 +299,25 @@ Use the office file round-trip benchmark when you want evidence for the combined
     -Server localhost `
     -Database tempdb `
     -RowCount 1000,5000 `
-    -FileKind Csv,Excel `
+    -FileKind Csv,CsvGZip,Excel `
     -Iterations 3
 ```
 
-The default engine is `DbaClientX`. Add `-Engine DbaClientX,dbatools -FileKind Csv` to compare the DbaClientX + PSWriteOffice CSV round trip with dbatools' CSV fast path (`Export-DbaCsv` plus `Import-DbaCsv` into SQL Server bulk copy). The dbatools engine is CSV-only; Excel remains a DbaClientX + PSWriteOffice lane because dbatools does not own Excel import/export.
+The default engine is `DbaClientX`. Add `-Engine DbaClientX,dbatools -FileKind Csv,CsvGZip` to compare the DbaClientX + PSWriteOffice CSV round trip with dbatools' CSV fast path (`Export-DbaCsv` plus `Import-DbaCsv` into SQL Server bulk copy). `CsvGZip` uses a `.csv.gz` file so both sides exercise compressed CSV. The dbatools engine is CSV-only; Excel remains a DbaClientX + PSWriteOffice lane because dbatools does not own Excel import/export.
 
 ```powershell
 .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
     -Server localhost `
     -Database tempdb `
     -RowCount 1000,5000 `
-    -FileKind Csv `
+    -FileKind Csv,CsvGZip `
     -Engine DbaClientX,dbatools `
     -Iterations 3
 ```
 
 By default the wrapper imports installed `DbaClientX` and `PSWriteOffice` modules. Use `-ModulePath`, `$env:DBACLIENTX_BENCHMARK_MODULE_PATH`, `-PSWriteOfficeModulePath`, or `$env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH` when benchmarking local source builds. To inspect the matrix without touching SQL Server:
 
-If the imported PSWriteOffice module does not expose `Export-OfficeCsv` and `Import-OfficeCsv -AsDataTable`, the wrapper skips the DbaClientX CSV lane and runs any remaining file kinds. Use `-FileKind Excel` for installed PSWriteOffice versions without those CSV cmdlets. If dbatools is not installed or does not expose `Export-DbaCsv` and `Import-DbaCsv`, the wrapper skips the dbatools CSV lane.
+If the imported PSWriteOffice module does not expose `Export-OfficeCsv` and `Import-OfficeCsv -AsDataTable`, the wrapper skips the DbaClientX CSV lane and runs any remaining file kinds. The `CsvGZip` lane also requires PSWriteOffice CSV compression parameters so the benchmark cannot accidentally measure an uncompressed `.csv.gz` file. Use `-FileKind Excel` for installed PSWriteOffice versions without those CSV cmdlets. If dbatools is not installed or does not expose `Export-DbaCsv` and `Import-DbaCsv`, the wrapper skips the dbatools CSV lane.
 
 ```powershell
 .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 -Plan

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The default engine is `DbaClientX`. Add `-Engine DbaClientX,dbatools -FileKind C
 
 By default the wrapper imports installed `DbaClientX` and `PSWriteOffice` modules. Use `-ModulePath`, `$env:DBACLIENTX_BENCHMARK_MODULE_PATH`, `-PSWriteOfficeModulePath`, or `$env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH` when benchmarking local source builds. To inspect the matrix without touching SQL Server:
 
-If the imported PSWriteOffice module does not expose `Export-OfficeCsv` and `Import-OfficeCsv -AsDataTable`, the wrapper skips the DbaClientX CSV lane and runs any remaining file kinds. The `CsvGZip` lane also requires PSWriteOffice CSV compression parameters so the benchmark cannot accidentally measure an uncompressed `.csv.gz` file. Use `-FileKind Excel` for installed PSWriteOffice versions without those CSV cmdlets. If dbatools is not installed or does not expose `Export-DbaCsv` and `Import-DbaCsv`, the wrapper skips the dbatools CSV lane.
+If the imported PSWriteOffice module does not expose `Export-OfficeCsv` and `Import-OfficeCsv -AsDataTable`, the wrapper skips the DbaClientX CSV lane and runs any remaining file kinds. The `CsvGZip` lane also requires PSWriteOffice CSV compression parameters so the benchmark cannot accidentally measure an uncompressed `.csv.gz` file. Use `-FileKind Excel` for installed PSWriteOffice versions without those CSV cmdlets. If dbatools is not installed or does not expose `Export-DbaCsv` and `Import-DbaCsv`, the wrapper skips the dbatools CSV lane. The compressed dbatools lane also requires `Export-DbaCsv -CompressionType`, and passes `GZip` explicitly when it is available.
 
 ```powershell
 .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 -Plan

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Start with the job you need to finish:
 | Copy one or more tables between database providers | `Copy-DbaXTableData` | `DBAClientX.Core` owns the copy contracts/runner; provider packages own concrete adapters |
 | Export SQL rows to CSV or Excel and import the file back | DbaClientX cmdlets plus PSWriteOffice `Export-OfficeCsv` / `Import-OfficeCsv` or `Export-OfficeExcel` / `Import-OfficeExcel` | DbaClientX owns database work; PSWriteOffice/OfficeIMO owns file-format work |
 
+The CSV round-trip path requires a PSWriteOffice build that exposes `Export-OfficeCsv` and `Import-OfficeCsv -AsDataTable`. When those CSV cmdlets are not available, use the Excel lane or pass `-PSWriteOfficeModulePath` to a compatible local PSWriteOffice build.
+
 The PowerShell layer is intentionally thin: it maps friendly parameters to provider-owned C# APIs. Put repeatable database behavior in DbaClientX and keep consumer scripts focused on choosing source data, destination names, and credentials.
 
 ## Install
@@ -302,6 +304,8 @@ Use the office file round-trip benchmark when you want evidence for the combined
 ```
 
 By default the wrapper imports installed `DbaClientX` and `PSWriteOffice` modules. Use `-ModulePath`, `$env:DBACLIENTX_BENCHMARK_MODULE_PATH`, `-PSWriteOfficeModulePath`, or `$env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH` when benchmarking local source builds. To inspect the matrix without touching SQL Server:
+
+If the imported PSWriteOffice module does not expose `Export-OfficeCsv` and `Import-OfficeCsv -AsDataTable`, the wrapper skips the CSV lane and runs any remaining file kinds. Use `-FileKind Excel` for installed PSWriteOffice versions without those CSV cmdlets.
 
 ```powershell
 .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 -Plan

--- a/README.md
+++ b/README.md
@@ -303,15 +303,30 @@ Use the office file round-trip benchmark when you want evidence for the combined
     -Iterations 3
 ```
 
+The default engine is `DbaClientX`. Add `-Engine DbaClientX,dbatools -FileKind Csv` to compare the DbaClientX + PSWriteOffice CSV round trip with dbatools' CSV fast path (`Export-DbaCsv` plus `Import-DbaCsv` into SQL Server bulk copy). The dbatools engine is CSV-only; Excel remains a DbaClientX + PSWriteOffice lane because dbatools does not own Excel import/export.
+
+```powershell
+.\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
+    -Server localhost `
+    -Database tempdb `
+    -RowCount 1000,5000 `
+    -FileKind Csv `
+    -Engine DbaClientX,dbatools `
+    -Iterations 3
+```
+
 By default the wrapper imports installed `DbaClientX` and `PSWriteOffice` modules. Use `-ModulePath`, `$env:DBACLIENTX_BENCHMARK_MODULE_PATH`, `-PSWriteOfficeModulePath`, or `$env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH` when benchmarking local source builds. To inspect the matrix without touching SQL Server:
 
-If the imported PSWriteOffice module does not expose `Export-OfficeCsv` and `Import-OfficeCsv -AsDataTable`, the wrapper skips the CSV lane and runs any remaining file kinds. Use `-FileKind Excel` for installed PSWriteOffice versions without those CSV cmdlets.
+If the imported PSWriteOffice module does not expose `Export-OfficeCsv` and `Import-OfficeCsv -AsDataTable`, the wrapper skips the DbaClientX CSV lane and runs any remaining file kinds. Use `-FileKind Excel` for installed PSWriteOffice versions without those CSV cmdlets. If dbatools is not installed or does not expose `Export-DbaCsv` and `Import-DbaCsv`, the wrapper skips the dbatools CSV lane.
 
 ```powershell
 .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 -Plan
 ```
 
 <!-- office-file-roundtrip-benchmark:start -->
+| Scenario | Variables | Host | Operation | DbaClientX | dbatools | Result |
+| --- | --- | --- | --- | ---: | ---: | --- |
+| 1000 rows / Csv | FileKind=Csv, RowCount=1000 | Core-7.6.3 | RoundTrip | 1.00x (152ms) | 2.67x (405ms) | DbaClientX fastest |
 <!-- office-file-roundtrip-benchmark:end -->
 
 ## .NET Usage

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Start with the job you need to finish:
 | Write PowerShell objects, `DataTable`, `DataView`, `IDataReader`, or Excel-imported rows to a table | `Write-DbaXTableData` | DbaClientX provider packages own the database write |
 | Load a SQL Server staging table and let the command create the table, map columns, lock the table, preserve identities/nulls, fire triggers, check constraints, or report progress | `Write-DbaXTableData -Provider SqlServer` | SQL Server-specific knobs map to `SqlServerBulkInsertOptions` |
 | Copy one or more tables between database providers | `Copy-DbaXTableData` | `DBAClientX.Core` owns the copy contracts/runner; provider packages own concrete adapters |
-| Export SQL rows to Excel and import the workbook back | DbaClientX cmdlets plus PSWriteOffice `Export-OfficeExcel` / `Import-OfficeExcel` | DbaClientX owns database work; PSWriteOffice/OfficeIMO owns workbook work |
+| Export SQL rows to CSV or Excel and import the file back | DbaClientX cmdlets plus PSWriteOffice `Export-OfficeCsv` / `Import-OfficeCsv` or `Export-OfficeExcel` / `Import-OfficeExcel` | DbaClientX owns database work; PSWriteOffice/OfficeIMO owns file-format work |
 
 The PowerShell layer is intentionally thin: it maps friendly parameters to provider-owned C# APIs. Put repeatable database behavior in DbaClientX and keep consumer scripts focused on choosing source data, destination names, and credentials.
 
@@ -161,10 +161,10 @@ $rows | Write-DbaXTableData `
     -PassThru
 ```
 
-Import rows from Excel with PSWriteOffice, then hand the `DataTable` to DbaClientX for the database write:
+Import rows from CSV or Excel with PSWriteOffice, then hand the `DataTable` to DbaClientX for the database write:
 
 ```powershell
-Import-OfficeExcel .\Users.xlsx -AsDataTable |
+Import-OfficeCsv .\Users.csv -AsDataTable |
     Write-DbaXTableData `
         -Provider PostgreSql `
         -ConnectionString 'Host=localhost;Database=app;Username=user;Password=secret' `
@@ -172,13 +172,26 @@ Import-OfficeExcel .\Users.xlsx -AsDataTable |
         -BatchSize 5000
 ```
 
-Run the full SQL Server -> Excel -> SQL Server round trip when you want to prove both sides together:
+The same database write path accepts Excel-imported tables:
 
 ```powershell
+Import-OfficeExcel .\Users.xlsx -AsDataTable |
+    Write-DbaXTableData `
+        -Provider SqlServer `
+        -ConnectionString 'Server=.;Database=App;Encrypt=True;TrustServerCertificate=True;Integrated Security=True' `
+        -DestinationTable 'dbo.ImportUsers' `
+        -AutoCreateTable `
+        -TableLock
+```
+
+Run the full SQL Server -> file -> SQL Server examples when you want to prove both sides together:
+
+```powershell
+.\Module\Examples\Example.CsvRoundTrip.ps1 -Server localhost -Database tempdb -RowCount 100 -KeepArtifacts
 .\Module\Examples\Example.ExcelRoundTrip.ps1 -Server localhost -Database tempdb -RowCount 100 -KeepArtifacts
 ```
 
-The example creates SQL Server source rows, exports them to an `.xlsx` workbook with PSWriteOffice, imports the workbook back as a `DataTable`, writes it to SQL Server with `-AutoCreateTable`, and fails if any row count does not match.
+The examples create SQL Server source rows, export them to a `.csv` or `.xlsx` file with PSWriteOffice, import the file back as a `DataTable`, write it to SQL Server with `-AutoCreateTable`, and fail if any row count does not match.
 
 When the destination table has SQL Server-specific requirements, opt into the needed knobs explicitly:
 
@@ -274,6 +287,28 @@ The suite rewrites the marker-delimited tables below when it runs from a source 
 <!-- sqlserver-data-movement-read-benchmark:end -->
 
 Treat benchmark numbers as workstation evidence, not universal rankings. SQL Server version, storage, TLS, table indexes, triggers, recovery model, batch size, and client runtime can dominate the result; rerun the suite in the environment that matters.
+
+## Office File Round-Trip Benchmark
+
+Use the office file round-trip benchmark when you want evidence for the combined DbaClientX and PSWriteOffice workflow. The measured operation reads source rows from SQL Server with DbaClientX, writes a CSV or Excel file with PSWriteOffice, imports the file back as a `DataTable`, then writes the rows to SQL Server with `Write-DbaXTableData`. Validation checks destination row count and simple integrity metrics before cleanup.
+
+```powershell
+.\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
+    -Server localhost `
+    -Database tempdb `
+    -RowCount 1000,5000 `
+    -FileKind Csv,Excel `
+    -Iterations 3
+```
+
+By default the wrapper imports installed `DbaClientX` and `PSWriteOffice` modules. Use `-ModulePath`, `$env:DBACLIENTX_BENCHMARK_MODULE_PATH`, `-PSWriteOfficeModulePath`, or `$env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH` when benchmarking local source builds. To inspect the matrix without touching SQL Server:
+
+```powershell
+.\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 -Plan
+```
+
+<!-- office-file-roundtrip-benchmark:start -->
+<!-- office-file-roundtrip-benchmark:end -->
 
 ## .NET Usage
 

--- a/README.md
+++ b/README.md
@@ -319,6 +319,22 @@ By default the wrapper imports installed `DbaClientX` and `PSWriteOffice` module
 
 If the imported PSWriteOffice module does not expose `Export-OfficeCsv` and `Import-OfficeCsv -AsDataTable`, the wrapper skips the DbaClientX CSV lane and runs any remaining file kinds. The `CsvGZip` lane also requires PSWriteOffice CSV compression parameters so the benchmark cannot accidentally measure an uncompressed `.csv.gz` file. Use `-FileKind Excel` for installed PSWriteOffice versions without those CSV cmdlets. If dbatools is not installed or does not expose `Export-DbaCsv` and `Import-DbaCsv`, the wrapper skips the dbatools CSV lane. The compressed dbatools lane also requires `Export-DbaCsv -CompressionType`, and passes `GZip` explicitly when it is available.
 
+The benchmark is intentionally paired with feature coverage, because the useful target is not only the fastest happy path. dbatools documents a broad CSV-to-SQL surface in `Import-DbaCsv` and `Export-DbaCsv`; this table keeps the comparable DbaClientX + PSWriteOffice surface visible while the remaining gaps are closed in the owning libraries.
+
+| Capability | dbatools CSV path | DbaClientX + PSWriteOffice path | Benchmark visibility |
+| --- | --- | --- | --- |
+| SQL query/table to CSV | `Export-DbaCsv -SqlInstance/-Database/-Query/-Table` | `Invoke-DbaXQuery -ReturnType DataTable` then `Export-OfficeCsv` | `Csv` round trip compares both engines |
+| CSV to SQL bulk load | `Import-DbaCsv` uses SQL Server bulk copy | `Import-OfficeCsv -AsDataTable` then `Write-DbaXTableData -Provider SqlServer` | `Csv` round trip compares both engines |
+| Compressed CSV | `Export-DbaCsv -CompressionType` and `.csv.gz` import | OfficeIMO owns compressed CSV core; PSWriteOffice compression surface is pending that release | `CsvGZip` is present; DbaClientX lane skips until PSWriteOffice exposes compression |
+| Excel to or from SQL | Not a dbatools CSV feature | `Export-OfficeExcel` / `Import-OfficeExcel -AsDataTable` with `Write-DbaXTableData` | `Excel` round trip covers the direct Excel path |
+| Bulk-write knobs | `BatchSize`, `TableLock`, `CheckConstraints`, `FireTriggers`, `KeepIdentity`, `KeepNulls` | `Write-DbaXTableData` exposes the same SQL Server bulk-copy knobs | Covered by data-movement and office round-trip suites |
+| Auto-create destination table | `Import-DbaCsv -AutoCreateTable` with optional column optimization | `Write-DbaXTableData -AutoCreateTable`; typed columns depend on the incoming `DataTable` | Covered by round-trip suites |
+| Column mapping and selected columns | `Column`, `ColumnMap`, ordinal fallback | `Write-DbaXTableData -ColumnMap`; select or shape columns before the file/database boundary | Covered by command tests, not yet by office round-trip benchmark |
+| CSV dialect basics | Delimiter, no header, quote, encoding, null value, culture-oriented parsing | Delimiter, no header/header, quote mode, encoding, culture, trimming, comments, W3C headers | Partly covered by PSWriteOffice CSV tests; round-trip benchmark uses the default dialect |
+| Messy CSV handling | Skip rows, comments, duplicate header behavior, mismatched rows, quote mode, parse-error collection | Skip rows, comments, W3C headers, column-count mismatch policy; duplicate header and parse-error collection remain parity gaps | Not yet part of the DbaClientX round-trip benchmark |
+| Type detection for CSV import | `SampleRows` and `DetectColumnTypes` | Use typed Excel/DataTable input or shape CSV values before bulk load; CSV type detection remains a parity gap | Not benchmarked yet |
+| Parallel CSV import | `Parallel`, `ThrottleLimit`, `ParallelBatchSize` | Database/provider parallel query helpers exist, but CSV-to-SQL parallel import is not a current round-trip feature | Not benchmarked yet |
+
 ```powershell
 .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 -Plan
 ```


### PR DESCRIPTION
## Summary
- add SQL Server -> CSV/Excel -> SQL Server round-trip examples using PSWriteOffice for file I/O and DbaClientX for database reads/writes
- add a PowerForge benchmark wrapper for DbaClientX + PSWriteOffice office file round trips
- add dbatools CSV comparison lanes using `Export-DbaCsv` plus `Import-DbaCsv`, including explicit `GZip` export when dbatools exposes `-CompressionType`
- document CSV and Excel handoff patterns, including `Import-OfficeCsv -AsDataTable` and `Import-OfficeExcel -AsDataTable`

## Notes
- Base is current `master` after PR #196 merged.
- PSWriteOffice PR #140 has merged, so the normal CSV lane can use `Import-OfficeCsv -AsDataTable` once the consuming environment has that source/package available.
- `CsvGZip` is visible in the matrix now, but DbaClientX + PSWriteOffice skips that lane until the OfficeIMO CSV compression API lands and PSWriteOffice exposes it.
- dbatools is CSV-only in this benchmark; Excel remains a DbaClientX + PSWriteOffice lane because dbatools does not own Excel import/export.

## Validation
- `dotnet build .\DbaClientX.sln -c Release -v:minimal`
- parser check for `Module/Examples/Benchmark.OfficeFileRoundTrip.ps1`
- benchmark plan check for `Module/Examples/Benchmark.OfficeFileRoundTrip.ps1` with `-FileKind Csv,CsvGZip,Excel -Engine DbaClientX,dbatools`
- local 1k CSV SQL round-trip smoke from earlier branch state: DbaClientX 152 ms, dbatools 405 ms on EVOMAGIC