### PR TITLE
Add CSV parity benchmark lanes

### DIFF
--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -4,6 +4,7 @@ param(
     [string] $Database = $(if ($env:DBACLIENTX_SQLDATABASE) { $env:DBACLIENTX_SQLDATABASE } else { 'tempdb' }),
     [int[]] $RowCount = @(1000),
     [string[]] $FileKind = @('Csv', 'CsvGZip', 'Excel'),
+    [string[]] $ColumnShape = @('Default'),
     [int] $Iterations = 3,
     [int] $WarmupCount = 1,
     [string[]] $Engine,
@@ -56,6 +57,7 @@ function Assert-DbaClientXBenchmarkValue {
 }
 
 $FileKind = Convert-DbaClientXBenchmarkList -Value $FileKind
+$ColumnShape = Convert-DbaClientXBenchmarkList -Value $ColumnShape
 $Engine = Convert-DbaClientXBenchmarkList -Value $Engine
 
 if ($RowCount.Count -eq 0 -or @($RowCount | Where-Object { $_ -lt 1 }).Count -gt 0) {
@@ -64,7 +66,11 @@ if ($RowCount.Count -eq 0 -or @($RowCount | Where-Object { $_ -lt 1 }).Count -gt
 if ($FileKind.Count -eq 0) {
     throw 'FileKind must contain at least one value.'
 }
+if ($ColumnShape.Count -eq 0) {
+    throw 'ColumnShape must contain at least one value.'
+}
 Assert-DbaClientXBenchmarkValue -Name FileKind -Value $FileKind -ValidValue @('Csv', 'CsvGZip', 'CsvTyped', 'CsvGZipTyped', 'Excel')
+Assert-DbaClientXBenchmarkValue -Name ColumnShape -Value $ColumnShape -ValidValue @('Default', 'Mapped')
 Assert-DbaClientXBenchmarkValue -Name Engine -Value $Engine -ValidValue @('DbaClientX', 'dbatools')
 if ($Iterations -lt 1) {
     throw 'Iterations must be greater than zero.'
@@ -94,6 +100,7 @@ $settings = {
     $keepArtifacts = $KeepArtifacts.IsPresent
     $rowCounts = $RowCount
     $fileKinds = $FileKind
+    $columnShapes = $ColumnShape
     $selectedEngines = if ($Engine) { $Engine } else { @('DbaClientX') }
 
     function Test-DbaClientXOfficeCsvCommandAvailability {
@@ -169,7 +176,8 @@ $settings = {
     function Test-DbaToolsCsvCommandAvailability {
         param(
             [switch] $RequireCompression,
-            [switch] $RequireTypeDetection
+            [switch] $RequireTypeDetection,
+            [switch] $RequireColumnMapping
         )
 
         $connectCommand = Get-Command Connect-DbaInstance -ErrorAction SilentlyContinue
@@ -186,6 +194,11 @@ $settings = {
 
         if ($RequireTypeDetection.IsPresent -and -not $importCommand.Parameters.ContainsKey('DetectColumnTypes')) {
             Write-Warning "Skipping typed dbatools CSV benchmark lane because Import-DbaCsv does not expose -DetectColumnTypes."
+            return $false
+        }
+
+        if ($RequireColumnMapping.IsPresent -and -not $importCommand.Parameters.ContainsKey('ColumnMap')) {
+            Write-Warning "Skipping mapped-column dbatools CSV benchmark lane because Import-DbaCsv does not expose -ColumnMap."
             return $false
         }
 
@@ -280,10 +293,19 @@ FROM numbers;
         caseSource {
             foreach ($rowCount in $rowCounts) {
                 foreach ($fileKind in $fileKinds) {
-                    [pscustomobject]@{
-                        Scenario = "$rowCount rows / $fileKind"
-                        RowCount = $rowCount
-                        FileKind = $fileKind
+                    foreach ($columnShape in $columnShapes) {
+                        $scenario = if ($columnShape -eq 'Default') {
+                            "$rowCount rows / $fileKind"
+                        } else {
+                            "$rowCount rows / $fileKind / $columnShape columns"
+                        }
+
+                        [pscustomobject]@{
+                            Scenario = $scenario
+                            RowCount = $rowCount
+                            FileKind = $fileKind
+                            ColumnShape = $columnShape
+                        }
                     }
                 }
             }
@@ -299,6 +321,18 @@ FROM numbers;
             $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
             $run.SourceTable = 'DbaClientXBench_FileSource_{0}' -f ([guid]::NewGuid().ToString('N').Substring(0, 8))
             $run.DestinationTable = 'DbaClientXBench_FileDest_{0}' -f ([guid]::NewGuid().ToString('N').Substring(0, 8))
+            if ($case.ColumnShape -eq 'Mapped') {
+                $run.SelectQuery = "SELECT Id AS CustomerId, DisplayName AS CustomerName, Score AS WeightedScore, CreatedUtc AS SeenUtc FROM dbo.$($run.SourceTable) ORDER BY Id;"
+                $run.ColumnMap = @{
+                    CustomerId = 'Id'
+                    CustomerName = 'DisplayName'
+                    WeightedScore = 'Score'
+                    SeenUtc = 'CreatedUtc'
+                }
+            } else {
+                $run.SelectQuery = "SELECT Id, DisplayName, Score, CreatedUtc FROM dbo.$($run.SourceTable) ORDER BY Id;"
+                $run.ColumnMap = $null
+            }
             $extension = switch ($case.FileKind) {
                 'Csv' { '.csv' }
                 'CsvGZip' { '.csv.gz' }
@@ -306,7 +340,7 @@ FROM numbers;
                 'CsvGZipTyped' { '.csv.gz' }
                 default { '.xlsx' }
             }
-            $run.FilePath = Join-Path $outputRootBase ('DbaClientXBench_{0}_{1}_{2}{3}' -f $case.Engine, $case.FileKind, ([guid]::NewGuid().ToString('N').Substring(0, 8)), $extension)
+            $run.FilePath = Join-Path $outputRootBase ('DbaClientXBench_{0}_{1}_{2}_{3}{4}' -f $case.Engine, $case.FileKind, $case.ColumnShape, ([guid]::NewGuid().ToString('N').Substring(0, 8)), $extension)
             $run.DropQuery = @"
 IF OBJECT_ID(N'dbo.$($run.DestinationTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run.DestinationTable);
 IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run.SourceTable);
@@ -344,7 +378,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                     return $true
                 }
 
-                return -not (& $testDbaToolsCsvCommands -RequireCompression:($case.FileKind -in @('CsvGZip', 'CsvGZipTyped')) -RequireTypeDetection:($case.FileKind -in @('CsvTyped', 'CsvGZipTyped')))
+                return -not (& $testDbaToolsCsvCommands -RequireCompression:($case.FileKind -in @('CsvGZip', 'CsvGZipTyped')) -RequireTypeDetection:($case.FileKind -in @('CsvTyped', 'CsvGZipTyped')) -RequireColumnMapping:($case.ColumnShape -eq 'Mapped'))
             }
 
             if ($case.FileKind -in @('Csv', 'CsvGZip', 'CsvTyped', 'CsvGZipTyped')) {
@@ -360,12 +394,11 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
 
-                $query = "SELECT Id, DisplayName, Score, CreatedUtc FROM dbo.$($run.SourceTable) ORDER BY Id;"
                 $data = Invoke-DbaXQuery `
                     -Server $run.Server `
                     -Database $run.Database `
                     -TrustServerCertificate `
-                    -Query $query `
+                    -Query $run.SelectQuery `
                     -QueryTimeout 120 `
                     -ReturnType DataTable `
                     -ErrorAction Stop
@@ -398,17 +431,23 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
 
                 try {
                     $inputObject = if ($imported -is [System.Data.IDataReader]) { (, $imported) } else { $imported }
-                    $writeResult = Write-DbaXTableData `
-                        -Provider SqlServer `
-                        -ConnectionString $run.ConnectionString `
-                        -DestinationTable "dbo.$($run.DestinationTable)" `
-                        -InputObject $inputObject `
-                        -AutoCreateTable `
-                        -BatchSize 5000 `
-                        -BulkCopyTimeout 120 `
-                        -TableLock `
-                        -PassThru `
-                        -ErrorAction Stop
+                    $writeParameters = @{
+                        Provider = 'SqlServer'
+                        ConnectionString = $run.ConnectionString
+                        DestinationTable = "dbo.$($run.DestinationTable)"
+                        InputObject = $inputObject
+                        AutoCreateTable = $true
+                        BatchSize = 5000
+                        BulkCopyTimeout = 120
+                        TableLock = $true
+                        PassThru = $true
+                        ErrorAction = 'Stop'
+                    }
+                    if ($null -ne $run.ColumnMap) {
+                        $writeParameters.ColumnMap = $run.ColumnMap
+                    }
+
+                    $writeResult = Write-DbaXTableData @writeParameters
                     $run.RowsWritten = [int] $writeResult.Rows
                 } finally {
                     if ($imported -is [System.IDisposable]) {
@@ -424,11 +463,10 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
 
-                $query = "SELECT Id, DisplayName, Score, CreatedUtc FROM dbo.$($run.SourceTable) ORDER BY Id;"
                 $exportParameters = @{
                     SqlInstance = $run.DbatoolsInstance
                     Database = $run.Database
-                    Query = $query
+                    Query = $run.SelectQuery
                     Path = $run.FilePath
                     Delimiter = ','
                 }
@@ -472,6 +510,9 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 }
                 if ($case.FileKind -in @('CsvTyped', 'CsvGZipTyped') -and $importCommand.Parameters.ContainsKey('DetectColumnTypes')) {
                     $importParameters.DetectColumnTypes = $true
+                }
+                if ($null -ne $run.ColumnMap -and $importCommand.Parameters.ContainsKey('ColumnMap')) {
+                    $importParameters.ColumnMap = $run.ColumnMap
                 }
 
                 Import-DbaCsv @importParameters | Out-Null
@@ -576,6 +617,7 @@ if ($Plan) {
             Operation = $_.Operation
             RowCount = $_.Values.RowCount
             FileKind = $_.Values.FileKind
+            ColumnShape = $_.Values.ColumnShape
             Skipped = [bool] $_.IsSkipped
         }
     } | Sort-Object Scenario, Engine | Format-Table -AutoSize

--- a/Module/Examples/Benchmark.SqlServerCsvExport.ps1
+++ b/Module/Examples/Benchmark.SqlServerCsvExport.ps1
@@ -20,6 +20,7 @@ param(
     [ValidateSet('None', 'Random', 'RangeId', 'Ntile')]
     [string] $FastBcpParallelMethod = 'Ntile',
     [int] $FastBcpParallelDegree = -2,
+    [int] $DbaClientXPartitionDegree = 0,
     [string] $OutputRoot,
     [switch] $Plan,
     [switch] $UpdateReadme,
@@ -62,12 +63,15 @@ $Engine = Convert-DbaClientXBenchmarkList -Value $Engine
 if ($RowCount.Count -eq 0 -or @($RowCount | Where-Object { $_ -lt 1 }).Count -gt 0) {
     throw 'RowCount values must be greater than zero.'
 }
-Assert-DbaClientXBenchmarkValue -Name Engine -Value $Engine -ValidValue @('DbaClientX', 'DbaClientXStream', 'DbaClientXReader', 'dbatools', 'bcp', 'FastBCP')
+Assert-DbaClientXBenchmarkValue -Name Engine -Value $Engine -ValidValue @('DbaClientX', 'DbaClientXStream', 'DbaClientXReader', 'DbaClientXPartitionedReader', 'dbatools', 'bcp', 'FastBCP')
 if ($Iterations -lt 1) {
     throw 'Iterations must be greater than zero.'
 }
 if ($WarmupCount -lt 0) {
     throw 'WarmupCount cannot be negative.'
+}
+if ($DbaClientXPartitionDegree -lt 0) {
+    throw 'DbaClientXPartitionDegree cannot be negative. Use 0 to default to the current processor count.'
 }
 
 Import-Module PSPublishModule -MinimumVersion 3.0.44 -ErrorAction Stop
@@ -89,6 +93,7 @@ $settings = {
     $fastBcpPath = $FastBcpPath
     $fastBcpParallelMethod = $FastBcpParallelMethod
     $fastBcpParallelDegree = $FastBcpParallelDegree
+    $dbaClientXPartitionDegree = $DbaClientXPartitionDegree
     $updateReadme = $UpdateReadme.IsPresent
     $keepArtifacts = $KeepArtifacts.IsPresent
     $rowCounts = $RowCount
@@ -116,6 +121,10 @@ $settings = {
 
     function Test-BcpCommand {
         return [bool] (Get-Command bcp -ErrorAction SilentlyContinue)
+    }
+
+    function Test-ThreadJobCommand {
+        return [bool] (Get-Command Start-ThreadJob -ErrorAction SilentlyContinue)
     }
 
     function Resolve-FastBcpCommand {
@@ -233,6 +242,7 @@ FROM numbers;
     $testOfficeCsvCommands = ${function:Test-DbaClientXCsvExportCommands}
     $testDbaToolsExportCommand = ${function:Test-DbaToolsExportCommand}
     $testBcpCommand = ${function:Test-BcpCommand}
+    $testThreadJobCommand = ${function:Test-ThreadJobCommand}
     $resolveFastBcpCommand = ${function:Resolve-FastBcpCommand}
     $getCreateTableQuery = ${function:Get-DbaClientXCsvExportCreateTableQuery}
     $getSeedQuery = ${function:Get-DbaClientXCsvExportSeedQuery}
@@ -258,16 +268,45 @@ FROM numbers;
             $run.Server = $server
             $run.Database = $database
             $run.KeepArtifacts = $keepArtifacts
+            $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
             $run.SourceTable = 'DbaClientXBench_CsvExport_{0}' -f ([guid]::NewGuid().ToString('N').Substring(0, 8))
             $run.FilePath = Join-Path $outputRootBase ('DbaClientXBench_CsvExport_{0}_{1}_{2}.csv' -f $case.Engine, $case.RowCount, ([guid]::NewGuid().ToString('N').Substring(0, 8)))
+            $run.PartitionDirectory = Join-Path $outputRootBase ('DbaClientXBench_CsvExport_DbaClientXPartitioned_{0}_{1}' -f $case.RowCount, ([guid]::NewGuid().ToString('N').Substring(0, 8)))
             $run.FastBcpDirectory = Join-Path $outputRootBase ('DbaClientXBench_CsvExport_FastBCP_{0}_{1}' -f $case.RowCount, ([guid]::NewGuid().ToString('N').Substring(0, 8)))
             $run.FastBcpFileName = 'DbaClientXBench_CsvExport_FastBCP.csv'
             $run.Query = "SELECT Id, DisplayName, Score, CreatedUtc FROM dbo.$($run.SourceTable) ORDER BY Id;"
+            $requestedPartitionDegree = if ($dbaClientXPartitionDegree -gt 0) { $dbaClientXPartitionDegree } else { [Environment]::ProcessorCount }
+            $run.PartitionDegree = [Math]::Max(1, [Math]::Min([int] $case.RowCount, [int] $requestedPartitionDegree))
+            $run.PartitionFiles = @(
+                for ($partition = 1; $partition -le $run.PartitionDegree; $partition++) {
+                    Join-Path $run.PartitionDirectory ('DbaClientXBench_CsvExport_Part{0:D4}.csv' -f $partition)
+                }
+            )
+            $run.PartitionQueries = @(
+                for ($partition = 1; $partition -le $run.PartitionDegree; $partition++) {
+                    @"
+WITH DbaXPartitioned AS
+(
+    SELECT
+        Id,
+        DisplayName,
+        Score,
+        CreatedUtc,
+        NTILE($($run.PartitionDegree)) OVER (ORDER BY Id) AS DbaXPartitionNumber
+    FROM dbo.$($run.SourceTable)
+)
+SELECT Id, DisplayName, Score, CreatedUtc
+FROM DbaXPartitioned
+WHERE DbaXPartitionNumber = $partition
+ORDER BY Id;
+"@
+                }
+            )
             $run.DropQuery = "IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run.SourceTable);"
 
             New-Item -ItemType Directory -Force -Path $outputRootBase | Out-Null
             Import-Module $modulePath -Global -Force -ErrorAction Stop
-            if ($case.Engine -in @('DbaClientX', 'DbaClientXStream', 'DbaClientXReader')) {
+            if ($case.Engine -in @('DbaClientX', 'DbaClientXStream', 'DbaClientXReader', 'DbaClientXPartitionedReader')) {
                 Import-Module $psWriteOfficeModulePath -Global -Force -ErrorAction Stop
             }
 
@@ -291,7 +330,11 @@ FROM numbers;
         skip {
             param($case)
 
-            if ($case.Engine -in @('DbaClientX', 'DbaClientXStream', 'DbaClientXReader')) {
+            if ($case.Engine -in @('DbaClientX', 'DbaClientXStream', 'DbaClientXReader', 'DbaClientXPartitionedReader')) {
+                if ($case.Engine -eq 'DbaClientXPartitionedReader' -and -not (& $testThreadJobCommand)) {
+                    return $true
+                }
+
                 return -not (& $testOfficeCsvCommands -ModulePath $psWriteOfficeModulePath)
             }
 
@@ -372,6 +415,59 @@ FROM numbers;
                     }
 
                     $client.Dispose()
+                }
+            }
+        }
+
+        engine DbaClientXPartitionedReader {
+            operation Export {
+                param($case, $run)
+
+                $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                New-Item -ItemType Directory -Force -Path $run.PartitionDirectory | Out-Null
+                $jobs = @(
+                    for ($index = 0; $index -lt $run.PartitionDegree; $index++) {
+                        Start-ThreadJob -Name ('DbaClientXCsvPartition{0}' -f ($index + 1)) -ArgumentList @(
+                            $modulePath,
+                            $psWriteOfficeModulePath,
+                            $run.ConnectionString,
+                            $run.PartitionQueries[$index],
+                            $run.PartitionFiles[$index]
+                        ) -ScriptBlock {
+                            param(
+                                [string] $ModulePath,
+                                [string] $PSWriteOfficeModulePath,
+                                [string] $ConnectionString,
+                                [string] $Query,
+                                [string] $Path
+                            )
+
+                            $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                            Import-Module $ModulePath -Global -Force -ErrorAction Stop
+                            Import-Module $PSWriteOfficeModulePath -Global -Force -ErrorAction Stop
+                            $client = [DBAClientX.SqlServer]::new()
+                            $reader = $null
+                            try {
+                                $reader = $client.QueryReader($ConnectionString, $Query)
+                                Export-OfficeCsv -InputObject $reader -Path $Path -NoHeader -ErrorAction Stop
+                            } finally {
+                                if ($null -ne $reader) {
+                                    $reader.Dispose()
+                                }
+
+                                $client.Dispose()
+                            }
+                        }
+                    }
+                )
+
+                try {
+                    $jobs | Wait-Job | Out-Null
+                    foreach ($job in $jobs) {
+                        Receive-Job -Job $job -ErrorAction Stop | Out-Null
+                    }
+                } finally {
+                    $jobs | Remove-Job -Force -ErrorAction SilentlyContinue
                 }
             }
         }
@@ -477,6 +573,12 @@ FROM numbers;
                 }
 
                 @(Get-ChildItem -LiteralPath $run.FastBcpDirectory -File -Filter '*.csv' -ErrorAction Stop | ForEach-Object FullName)
+            } elseif ($case.Engine -eq 'DbaClientXPartitionedReader') {
+                if (-not (Test-Path -LiteralPath $run.PartitionDirectory -PathType Container)) {
+                    throw "DbaClientXPartitionedReader did not create output directory '$($run.PartitionDirectory)'."
+                }
+
+                @(Get-ChildItem -LiteralPath $run.PartitionDirectory -File -Filter '*.csv' -ErrorAction Stop | ForEach-Object FullName)
             } else {
                 if (-not (Test-Path -LiteralPath $run.FilePath -PathType Leaf)) {
                     throw "$($case.Engine) did not create CSV file '$($run.FilePath)'."
@@ -512,6 +614,10 @@ FROM numbers;
 
                 if ($case.Engine -eq 'FastBCP' -and (Test-Path -LiteralPath $run.FastBcpDirectory -PathType Container)) {
                     Remove-Item -LiteralPath $run.FastBcpDirectory -Recurse -Force -ErrorAction SilentlyContinue
+                }
+
+                if ($case.Engine -eq 'DbaClientXPartitionedReader' -and (Test-Path -LiteralPath $run.PartitionDirectory -PathType Container)) {
+                    Remove-Item -LiteralPath $run.PartitionDirectory -Recurse -Force -ErrorAction SilentlyContinue
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -399,12 +399,13 @@ Use the CSV export benchmark when you want the ARPE-style export-only view: SQL 
     -Server localhost `
     -Database tempdb `
     -RowCount 100000 `
-    -Engine DbaClientX,DbaClientXReader,DbaClientXStream,dbatools,bcp,FastBCP `
+    -Engine DbaClientX,DbaClientXReader,DbaClientXStream,DbaClientXPartitionedReader,dbatools,bcp,FastBCP `
+    -DbaClientXPartitionDegree 4 `
     -Iterations 3 `
     -UpdateReadme
 ```
 
-The DbaClientX lane reads with `Invoke-DbaXQuery -ReturnType DataTable` and writes with PSWriteOffice `Export-OfficeCsv -NoHeader`. `DbaClientXReader` opens a DbaClientX-owned SQL Server `IDataReader` and writes it directly with `Export-OfficeCsv`, avoiding `DataTable` and `DataRow` materialization. `DbaClientXStream` uses the existing public stream shape, `Invoke-DbaXQuery -Stream -ReturnType DataRow`, then writes the streamed rows with `Export-OfficeCsv`. The dbatools lane uses `Export-DbaCsv`. The native lane uses `bcp queryout` with character mode, comma field terminators, LF row terminators, UTF-8 code page, and trusted authentication. The optional FastBCP lane uses the documented SQL Server table export shape with `--connectiontype mssql`, trusted authentication, UTF-8 CSV output, `--parallelmethod Ntile`, `--distributekeycolumn Id`, `--paralleldegree -2`, and split-file output. Successful lanes validate data-row count plus `Id` min/max/sum integrity and file size before cleanup.
+The DbaClientX lane reads with `Invoke-DbaXQuery -ReturnType DataTable` and writes with PSWriteOffice `Export-OfficeCsv -NoHeader`. `DbaClientXReader` opens a DbaClientX-owned SQL Server `IDataReader` and writes it directly with `Export-OfficeCsv`, avoiding `DataTable` and `DataRow` materialization. `DbaClientXStream` uses the existing public stream shape, `Invoke-DbaXQuery -Stream -ReturnType DataRow`, then writes the streamed rows with `Export-OfficeCsv`. `DbaClientXPartitionedReader` is the in-repo split-file lane: it partitions the SQL Server source with `NTILE` over `Id`, opens one DbaClientX reader per partition, and lets PSWriteOffice write each partition as a CSV file. The dbatools lane uses `Export-DbaCsv`. The native lane uses `bcp queryout` with character mode, comma field terminators, LF row terminators, UTF-8 code page, and trusted authentication. The optional FastBCP lane uses the documented SQL Server table export shape with `--connectiontype mssql`, trusted authentication, UTF-8 CSV output, `--parallelmethod Ntile`, `--distributekeycolumn Id`, `--paralleldegree -2`, and split-file output. Successful lanes validate data-row count plus `Id` min/max/sum integrity and file size before cleanup.
 
 Inspect the matrix without touching SQL Server:
 
@@ -412,9 +413,9 @@ Inspect the matrix without touching SQL Server:
 .\Module\Examples\Benchmark.SqlServerCsvExport.ps1 -Plan
 ```
 
-The benchmark skips unavailable optional engines. `bcp` must be on `PATH`, dbatools must expose `Connect-DbaInstance` and `Export-DbaCsv`, and the DbaClientX lanes require PSWriteOffice with `Export-OfficeCsv`. FastBCP must be on `PATH`, passed through `-FastBcpPath`, or provided through `$env:FASTBCP_PATH`; use `-FastBcpParallelMethod` and `-FastBcpParallelDegree` to change the FastBCP partitioning mode.
+The benchmark skips unavailable optional engines. `bcp` must be on `PATH`, dbatools must expose `Connect-DbaInstance` and `Export-DbaCsv`, and the DbaClientX lanes require PSWriteOffice with `Export-OfficeCsv`. `DbaClientXPartitionedReader` also requires `Start-ThreadJob`; use `-DbaClientXPartitionDegree` to set the split count, or leave it at `0` to use the current processor count. FastBCP must be on `PATH`, passed through `-FastBcpPath`, or provided through `$env:FASTBCP_PATH`; use `-FastBcpParallelMethod` and `-FastBcpParallelDegree` to change the FastBCP partitioning mode.
 
-The ARPE/FastBCP comparison is useful because it separates export-only throughput from a full file/database round trip. This benchmark covers the same local SQL Server to CSV shape for DbaClientX + PSWriteOffice, dbatools `Export-DbaCsv`, native `bcp queryout`, and FastBCP when the executable is locally available. The current snapshot shows the direct DbaClientX reader path ahead of dbatools and `bcp`; the older `DataTable` and `DataRow` lanes remain slower because they measure materialization and PowerShell row-shaping overhead in addition to file writing. FastBCP cloud-file targets and Parquet/JSON output remain product-scope gaps for this CSV/Excel benchmark story.
+The ARPE/FastBCP comparison is useful because it separates export-only throughput from a full file/database round trip. This benchmark covers the same local SQL Server to CSV shape for DbaClientX + PSWriteOffice, dbatools `Export-DbaCsv`, native `bcp queryout`, an in-repo DbaClientX partitioned split-file lane, and FastBCP when the executable is locally available. The current snapshot shows the direct DbaClientX reader path ahead of dbatools and `bcp`; the older `DataTable` and `DataRow` lanes remain slower because they measure materialization and PowerShell row-shaping overhead in addition to file writing. FastBCP cloud-file targets and Parquet/JSON output remain product-scope gaps for this CSV/Excel benchmark story.
 
 <!-- sqlserver-csv-export-benchmark:start -->
 | Scenario | Variables | Host | Operation | DbaClientXReader | bcp | DbaClientX | DbaClientXStream | dbatools | FastBCP | Result |
@@ -432,6 +433,7 @@ Use the office file round-trip benchmark when you want evidence for the combined
     -Database tempdb `
     -RowCount 1000,5000 `
     -FileKind Csv,CsvGZip,Excel `
+    -ColumnShape Default `
     -Iterations 3
 ```
 
@@ -443,11 +445,12 @@ Use the apples-to-apples CSV comparison when checking the same kind of lane dbat
     -Database tempdb `
     -RowCount 100000 `
     -FileKind Csv,CsvGZip,CsvTyped,CsvGZipTyped `
+    -ColumnShape Default,Mapped `
     -Engine DbaClientX,dbatools `
     -Iterations 3
 ```
 
-The default engine is `DbaClientX`. Add `-Engine DbaClientX,dbatools -FileKind Csv,CsvGZip,CsvTyped,CsvGZipTyped` to compare the DbaClientX + PSWriteOffice CSV round trip with dbatools' CSV fast path (`Export-DbaCsv` plus `Import-DbaCsv` into SQL Server bulk copy). `CsvGZip` and `CsvGZipTyped` use `.csv.gz` files so both sides exercise compressed CSV. `CsvTyped` and `CsvGZipTyped` exercise CSV type detection: PSWriteOffice uses `Import-OfficeCsv -AsDataReader -InferSchema` with a full-row schema sample for this benchmark, while dbatools uses `Import-DbaCsv -DetectColumnTypes`. The dbatools engine is CSV-only; Excel remains a DbaClientX + PSWriteOffice lane because dbatools does not own Excel import/export.
+The default engine is `DbaClientX`. Add `-Engine DbaClientX,dbatools -FileKind Csv,CsvGZip,CsvTyped,CsvGZipTyped` to compare the DbaClientX + PSWriteOffice CSV round trip with dbatools' CSV fast path (`Export-DbaCsv` plus `Import-DbaCsv` into SQL Server bulk copy). `CsvGZip` and `CsvGZipTyped` use `.csv.gz` files so both sides exercise compressed CSV. `CsvTyped` and `CsvGZipTyped` exercise CSV type detection: PSWriteOffice uses `Import-OfficeCsv -AsDataReader -InferSchema` with a full-row schema sample for this benchmark, while dbatools uses `Import-DbaCsv -DetectColumnTypes`. Add `-ColumnShape Mapped` to export aliased file columns and import them with `ColumnMap`/`Write-DbaXTableData -ColumnMap` back into the canonical SQL columns. The dbatools engine is CSV-only; Excel remains a DbaClientX + PSWriteOffice lane because dbatools does not own Excel import/export.
 
 ```powershell
 .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
@@ -455,6 +458,7 @@ The default engine is `DbaClientX`. Add `-Engine DbaClientX,dbatools -FileKind C
     -Database tempdb `
     -RowCount 1000,5000 `
     -FileKind Csv,CsvGZip,CsvTyped,CsvGZipTyped `
+    -ColumnShape Default,Mapped `
     -Engine DbaClientX,dbatools `
     -Iterations 3 `
     -UpdateReadme
@@ -468,7 +472,7 @@ To inspect the matrix without touching SQL Server:
 .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 -Plan
 ```
 
-If the imported PSWriteOffice module does not expose `Export-OfficeCsv` and `Import-OfficeCsv -AsDataReader`, the wrapper skips the DbaClientX CSV lane and runs any remaining file kinds. The compressed CSV lanes also require PSWriteOffice CSV compression parameters so the benchmark cannot accidentally measure an uncompressed `.csv.gz` file. The typed CSV lanes require `Import-OfficeCsv -InferSchema`. Use `-FileKind Excel` for installed PSWriteOffice versions without those CSV cmdlets. If dbatools is not installed or does not expose `Export-DbaCsv` and `Import-DbaCsv`, the wrapper skips the dbatools CSV lane. The compressed dbatools lane also requires `Export-DbaCsv -CompressionType`, and the typed dbatools lane requires `Import-DbaCsv -DetectColumnTypes`.
+If the imported PSWriteOffice module does not expose `Export-OfficeCsv` and `Import-OfficeCsv -AsDataReader`, the wrapper skips the DbaClientX CSV lane and runs any remaining file kinds. The compressed CSV lanes also require PSWriteOffice CSV compression parameters so the benchmark cannot accidentally measure an uncompressed `.csv.gz` file. The typed CSV lanes require `Import-OfficeCsv -InferSchema`. Use `-FileKind Excel` for installed PSWriteOffice versions without those CSV cmdlets. If dbatools is not installed or does not expose `Export-DbaCsv` and `Import-DbaCsv`, the wrapper skips the dbatools CSV lane. The compressed dbatools lane also requires `Export-DbaCsv -CompressionType`, the typed dbatools lane requires `Import-DbaCsv -DetectColumnTypes`, and the mapped-column dbatools lane requires `Import-DbaCsv -ColumnMap`.
 
 The benchmark is intentionally paired with feature coverage, because the useful target is not only the fastest happy path. dbatools documents a broad CSV-to-SQL surface in `Import-DbaCsv` and `Export-DbaCsv`; this table keeps the comparable DbaClientX + PSWriteOffice surface visible while the remaining gaps are closed in the owning libraries.
 
@@ -481,7 +485,7 @@ The benchmark is intentionally paired with feature coverage, because the useful 
 | Excel to or from SQL | Not a dbatools CSV feature | `Export-OfficeExcel` / `Import-OfficeExcel -AsDataTable` with `Write-DbaXTableData` | `Excel` round trip covers the direct Excel path |
 | Bulk-write knobs | `BatchSize`, `TableLock`, `CheckConstraints`, `FireTriggers`, `KeepIdentity`, `KeepNulls` | `Write-DbaXTableData` exposes the same SQL Server bulk-copy knobs | Covered by data-movement and office round-trip suites |
 | Auto-create destination table | `Import-DbaCsv -AutoCreateTable` with optional column optimization | `Write-DbaXTableData -AutoCreateTable`; typed columns come from the incoming `DataTable`, `IDataReader`, or object shape | Covered by round-trip suites |
-| Column mapping and selected columns | `Column`, `ColumnMap`, ordinal fallback | `Write-DbaXTableData -ColumnMap`; select or shape columns before the file/database boundary | Covered by command tests, not yet by office round-trip benchmark |
+| Column mapping and selected columns | `Column`, `ColumnMap`, ordinal fallback | `Write-DbaXTableData -ColumnMap`; select or shape columns before the file/database boundary | `-ColumnShape Mapped` covers aliased file columns in the office round-trip benchmark; command tests cover edge cases |
 | CSV dialect basics | Delimiter, no header, quote, encoding, null value, date format, UTC conversion, culture-oriented parsing | Delimiter, no header/header, quote mode, encoding, null value, date format, UTC conversion, culture, trimming, comments, W3C headers | Covered by PSWriteOffice CSV tests; round-trip benchmark uses the default dialect |
 | Messy CSV handling | Skip rows, comments, duplicate header behavior, mismatched rows, quote mode, static columns, parse-error collection | Skip rows, comments, W3C headers, duplicate header behavior, column-count mismatch policy, strict/lenient quote parsing, static columns, parse-error collection/skip-row, field-length limits, quote normalization, string interning | Mostly covered by PSWriteOffice CSV tests; round-trip benchmark keeps the default happy path |
 | Security limits | Max field length and decompression protection | OfficeIMO.CSV owns `MaxFieldLength` and `MaxDecompressedBytes`; PSWriteOffice exposes both on file-reading CSV cmdlets | Covered by OfficeIMO.CSV and PSWriteOffice CSV tests; not timed by default |
@@ -502,8 +506,9 @@ The comparison is split by ownership so the benchmark does not cherry-pick only 
 | Native `bcp queryout` SQL-to-CSV export | DbaClientX reader/DataTable/DataRow SQL read plus PSWriteOffice CSV write | `Benchmark.SqlServerCsvExport.ps1 -Engine DbaClientXReader,DbaClientX,DbaClientXStream,bcp` | `sqlserver-csv-export-benchmark` |
 | dbatools `Export-DbaCsv` SQL-to-CSV export | DbaClientX reader/DataTable/DataRow SQL read plus PSWriteOffice CSV write | `Benchmark.SqlServerCsvExport.ps1 -Engine DbaClientXReader,DbaClientX,DbaClientXStream,dbatools` | `sqlserver-csv-export-benchmark` |
 | ARPE/FastBCP single-purpose SQL-to-CSV export | DbaClientX reader/DataTable/DataRow SQL read plus PSWriteOffice CSV write | `Benchmark.SqlServerCsvExport.ps1 -Engine DbaClientXReader,DbaClientX,DbaClientXStream,FastBCP` | FastBCP lane is skipped unless the executable is available |
-| ARPE/FastBCP parallel partitioned export | Optional FastBCP split-file export with `Ntile` and `Id` distribution | `Benchmark.SqlServerCsvExport.ps1 -Engine FastBCP -FastBcpParallelMethod Ntile` | FastBCP lane is skipped unless the executable is available |
+| ARPE/FastBCP parallel partitioned export | DbaClientX partitioned SQL readers plus PSWriteOffice split-file CSV, and optional FastBCP split-file export with `Ntile` and `Id` distribution | `Benchmark.SqlServerCsvExport.ps1 -Engine DbaClientXPartitionedReader,FastBCP -DbaClientXPartitionDegree 4 -FastBcpParallelMethod Ntile` | DbaClientX partitioned lane is in-repo; FastBCP lane is skipped unless the executable is available |
 | dbatools `Export-DbaCsv` plus `Import-DbaCsv` SQL round trip | DbaClientX SQL read/write plus PSWriteOffice CSV | `Benchmark.OfficeFileRoundTrip.ps1 -Engine DbaClientX,dbatools -FileKind Csv` | `office-file-roundtrip-benchmark` |
+| dbatools mapped-column CSV import | DbaClientX SQL read/write plus PSWriteOffice CSV and `Write-DbaXTableData -ColumnMap` | `Benchmark.OfficeFileRoundTrip.ps1 -Engine DbaClientX,dbatools -FileKind Csv -ColumnShape Mapped` | Covered by the office round-trip benchmark when mapped lanes are selected |
 | dbatools compressed CSV round trip | DbaClientX SQL read/write plus PSWriteOffice `.csv.gz` | `Benchmark.OfficeFileRoundTrip.ps1 -Engine DbaClientX,dbatools -FileKind CsvGZip` | `office-file-roundtrip-benchmark` |
 | dbatools typed CSV import round trip | DbaClientX SQL read/write plus PSWriteOffice inferred CSV import | `Benchmark.OfficeFileRoundTrip.ps1 -Engine DbaClientX,dbatools -FileKind CsvTyped,CsvGZipTyped` | `office-file-roundtrip-benchmark` |
 | dbatools `Write-DbaDbTableData` client-side import | `Write-DbaXTableData` from `DataTable`, objects, classes, and `IDataReader` | `Benchmark.SqlServerDataMovement.ps1 -Operation Write` | `sqlserver-data-movement-write-benchmark` |


### PR DESCRIPTION
## Summary
- adds a DbaClientX partitioned CSV export benchmark lane that splits SQL Server reads with `NTILE` and writes partition files through PSWriteOffice CSV
- adds mapped-column office round-trip benchmark coverage for aliased CSV columns imported back into canonical SQL columns with `Write-DbaXTableData -ColumnMap`
- updates the README coverage map so the benchmark story now calls out mapped-column visibility and the in-repo partitioned export lane while keeping cloud/object storage, Parquet/JSON, and parallel CSV import as documented product gaps

## Validation
- `pwsh -NoLogo -NoProfile -File .\Module\Examples\Benchmark.SqlServerCsvExport.ps1 -Plan`
- `pwsh -NoLogo -NoProfile -File .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 -Plan`
- `pwsh -NoLogo -NoProfile -File .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 -Plan -FileKind Csv,CsvGZip,CsvTyped,CsvGZipTyped -ColumnShape Default,Mapped -Engine DbaClientX,dbatools`
- `git diff --check`

## Notes
This PR broadens the benchmark and documentation coverage for the next CSV parity targets. It does not claim full product parity for direct cloud/object-storage output, Parquet/JSON export, or parallel CSV-to-SQL import.
