### PR TITLE
Accelerate and compare database file round trips

### DIFF
--- a/DbaClientX.PowerShell/CmdletWriteDbaXTableData.cs
+++ b/DbaClientX.PowerShell/CmdletWriteDbaXTableData.cs
@@ -233,18 +233,19 @@ public sealed class CmdletWriteDbaXTableData : PSCmdlet
 
         var startedAt = DateTimeOffset.UtcNow;
         var timer = System.Diagnostics.Stopwatch.StartNew();
-        var countingReader = new CountingDataReader(reader);
+        CountingDataReader? countingReader = PassThru.IsPresent ? new CountingDataReader(reader) : null;
+        var bulkReader = (IDataReader?)countingReader ?? reader;
         var sqlServerOptions = BuildSqlServerOptions(totalRows: null);
         if (BulkInsertOverride != null)
         {
             BulkInsertOverride.InvokeWithContext(
                 functionsToDefine: null,
                 variablesToDefine: null,
-                args: new object?[] { this, countingReader, sqlServerOptions });
+                args: new object?[] { this, bulkReader, sqlServerOptions });
         }
         else
         {
-            InvokeSqlServerReaderBulkInsert(countingReader, sqlServerOptions);
+            InvokeSqlServerReaderBulkInsert(bulkReader, sqlServerOptions);
         }
 
         timer.Stop();
@@ -257,7 +258,7 @@ public sealed class CmdletWriteDbaXTableData : PSCmdlet
             {
                 Provider,
                 DestinationTable,
-                Rows = countingReader.RowsRead,
+                Rows = countingReader!.RowsRead,
                 StartedAt = startedAt,
                 CompletedAt = DateTimeOffset.UtcNow,
                 ElapsedMilliseconds = Math.Round(timer.Elapsed.TotalMilliseconds, 2)

--- a/DbaClientX.PowerShell/CountingDataReader.cs
+++ b/DbaClientX.PowerShell/CountingDataReader.cs
@@ -8,6 +8,7 @@ namespace DBAClientX.PowerShell;
 internal sealed class CountingDataReader : IDataReader
 {
     private readonly IDataReader _inner;
+    private DataTable? _schemaTable;
 
     internal CountingDataReader(IDataReader inner)
         => _inner = inner ?? throw new ArgumentNullException(nameof(inner));
@@ -68,7 +69,7 @@ internal sealed class CountingDataReader : IDataReader
 
     public int GetOrdinal(string name) => _inner.GetOrdinal(name);
 
-    public DataTable? GetSchemaTable() => _inner.GetSchemaTable();
+    public DataTable? GetSchemaTable() => _schemaTable ??= _inner.GetSchemaTable();
 
     public string GetString(int i) => _inner.GetString(i);
 

--- a/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
+++ b/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
@@ -15,19 +15,9 @@
 		<Authors>Przemyslaw Klys</Authors>
 		<LangVersion>latest</LangVersion>
         </PropertyGroup>
-        <PropertyGroup>
-                <OfficeIMORoot Condition=" '$(OfficeIMORoot)' == '' ">..\OfficeIMO</OfficeIMORoot>
-                <UseOfficeIMODataProjectReference Condition="Exists('$(OfficeIMORoot)\OfficeIMO.Data\OfficeIMO.Data.csproj')">true</UseOfficeIMODataProjectReference>
-        </PropertyGroup>
         <ItemGroup>
                 <PackageReference Include="PowerShellStandard.Library" PrivateAssets="all" />
                 <PackageReference Include="Microsoft.Data.SqlClient" />
-        </ItemGroup>
-        <ItemGroup Condition="'$(UseOfficeIMODataProjectReference)' == 'true'">
-                <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Data\OfficeIMO.Data.csproj" />
-        </ItemGroup>
-        <ItemGroup Condition="'$(UseOfficeIMODataProjectReference)' != 'true'">
-                <PackageReference Include="OfficeIMO.Data" />
         </ItemGroup>
         <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
                 <PackageReference Include="System.Formats.Asn1" />

--- a/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
+++ b/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
+        <PropertyGroup>
                 <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
                         net472;net8.0
                 </TargetFrameworks>
@@ -15,9 +15,19 @@
 		<Authors>Przemyslaw Klys</Authors>
 		<LangVersion>latest</LangVersion>
         </PropertyGroup>
+        <PropertyGroup>
+                <OfficeIMORoot Condition=" '$(OfficeIMORoot)' == '' ">..\OfficeIMO</OfficeIMORoot>
+                <UseOfficeIMODataProjectReference Condition="Exists('$(OfficeIMORoot)\OfficeIMO.Data\OfficeIMO.Data.csproj')">true</UseOfficeIMODataProjectReference>
+        </PropertyGroup>
         <ItemGroup>
                 <PackageReference Include="PowerShellStandard.Library" PrivateAssets="all" />
                 <PackageReference Include="Microsoft.Data.SqlClient" />
+        </ItemGroup>
+        <ItemGroup Condition="'$(UseOfficeIMODataProjectReference)' == 'true'">
+                <ProjectReference Include="$(OfficeIMORoot)\OfficeIMO.Data\OfficeIMO.Data.csproj" />
+        </ItemGroup>
+        <ItemGroup Condition="'$(UseOfficeIMODataProjectReference)' != 'true'">
+                <PackageReference Include="OfficeIMO.Data" />
         </ItemGroup>
         <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
                 <PackageReference Include="System.Formats.Asn1" />

--- a/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
+++ b/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Data;
 using System.Linq;
 using System.Management.Automation;
+using OfficeIMO.Data;
 
 namespace DBAClientX.PowerShell;
 
@@ -13,335 +14,42 @@ internal static class PowerShellDataTableConverter
     internal static object? UnwrapInput(object? item) => Unwrap(item);
 
     internal static DataTable ToDataTable(IReadOnlyList<object?> input, string? tableName = null)
+        => TabularDataTableBuilder.FromItems(input, new TabularDataOptions
+        {
+            TableName = tableName,
+            CopyExistingDataTable = false,
+            PreserveNullRows = true,
+            ColumnDiscoveryMode = TabularColumnDiscoveryMode.AllRows,
+            UnwrapValue = Unwrap,
+            ProjectObject = ProjectPowerShellObject
+        });
+
+    private static IReadOnlyDictionary<string, object?>? ProjectPowerShellObject(object? item)
     {
-        if (input == null)
+        if (item is PSObject psObject &&
+            psObject.BaseObject is not DataTable &&
+            psObject.BaseObject is not DataView &&
+            psObject.BaseObject is not IDataReader &&
+            psObject.BaseObject is not DataRow &&
+            psObject.BaseObject is not DataRowView &&
+            psObject.BaseObject is not IDataRecord &&
+            psObject.BaseObject is not IDictionary &&
+            !TabularDataTableBuilder.IsScalarValue(psObject.BaseObject))
         {
-            throw new ArgumentNullException(nameof(input));
+            return GetPSObjectProperties(psObject);
         }
 
-        var items = input
-            .Select(Unwrap)
-            .ToList();
-
-        if (items.Count == 1 && ShouldExpandSingleEnumerableInput(items[0]))
+        if (item is not PSObject && item is not IDictionary && !TabularDataTableBuilder.IsScalarValue(item))
         {
-            items = ((IEnumerable)items[0]!)
-                .Cast<object?>()
-                .Select(Unwrap)
-                .ToList();
+            var projected = GetPSObjectProperties(PSObject.AsPSObject(item));
+            return projected.Count == 0 ? null : projected;
         }
 
-        if (items.Count == 0)
-        {
-            return string.IsNullOrWhiteSpace(tableName)
-                ? new DataTable()
-                : new DataTable(tableName);
-        }
-
-        if (items.Count == 1)
-        {
-            var single = items[0];
-            if (single is DataTable table)
-            {
-                return table;
-            }
-
-            if (single is DataView view)
-            {
-                return view.ToTable();
-            }
-
-            if (single is IDataReader reader)
-            {
-                var tableFromReader = string.IsNullOrWhiteSpace(tableName)
-                    ? new DataTable()
-                    : new DataTable(tableName);
-                tableFromReader.Load(reader);
-                return tableFromReader;
-            }
-        }
-
-        if (items[0] is DataRow firstRow)
-        {
-            return FromDataRows(items, firstRow.Table, tableName);
-        }
-
-        if (items[0] is DataRowView firstRowView)
-        {
-            return FromDataRowViews(items, firstRowView.Row.Table, tableName);
-        }
-
-        if (items[0] is IDataRecord firstRecord)
-        {
-            return FromDataRecords(items, firstRecord, tableName);
-        }
-
-        return FromObjects(items, tableName);
+        return null;
     }
 
-    private static DataTable FromDataRows(IReadOnlyList<object?> items, DataTable source, string? tableName)
+    private static Dictionary<string, object?> GetPSObjectProperties(PSObject psObject)
     {
-        var table = CloneTable(source, tableName);
-        foreach (var item in items)
-        {
-            if (item is not DataRow row)
-            {
-                throw new PSArgumentException("DataRow input cannot be mixed with other input types.", nameof(items));
-            }
-
-            AddCompatibleDataRow(table, row);
-        }
-
-        return table;
-    }
-
-    private static DataTable FromDataRowViews(IReadOnlyList<object?> items, DataTable source, string? tableName)
-    {
-        var table = CloneTable(source, tableName);
-        foreach (var item in items)
-        {
-            if (item is not DataRowView rowView)
-            {
-                throw new PSArgumentException("DataRowView input cannot be mixed with other input types.", nameof(items));
-            }
-
-            AddCompatibleDataRow(table, rowView.Row);
-        }
-
-        return table;
-    }
-
-    private static DataTable FromDataRecords(IReadOnlyList<object?> items, IDataRecord firstRecord, string? tableName)
-    {
-        var table = string.IsNullOrWhiteSpace(tableName)
-            ? new DataTable()
-            : new DataTable(tableName);
-
-        var columns = GetDataRecordColumns(firstRecord);
-        foreach (var column in columns)
-        {
-            table.Columns.Add(column.TableName, column.FieldType);
-        }
-
-        foreach (var item in items)
-        {
-            if (item is not IDataRecord record)
-            {
-                throw new PSArgumentException("IDataRecord input cannot be mixed with other input types.", nameof(items));
-            }
-
-            EnsureCompatibleDataRecord(record, columns);
-
-            var row = table.NewRow();
-            for (var index = 0; index < record.FieldCount; index++)
-            {
-                row[columns[index].TableName] = record.IsDBNull(index) ? DBNull.Value : record.GetValue(index);
-            }
-
-            table.Rows.Add(row);
-        }
-
-        return table;
-    }
-
-    private static IReadOnlyList<DataRecordColumn> GetDataRecordColumns(IDataRecord record)
-    {
-        var columns = new List<DataRecordColumn>(record.FieldCount);
-        var tableNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        for (var index = 0; index < record.FieldCount; index++)
-        {
-            var sourceName = record.GetName(index);
-            var baseName = string.IsNullOrWhiteSpace(sourceName)
-                ? $"Column{index + 1}"
-                : sourceName;
-            var tableName = GetUniqueColumnName(baseName, tableNames);
-            columns.Add(new DataRecordColumn(sourceName, tableName, record.GetFieldType(index)));
-        }
-
-        return columns;
-    }
-
-    private static string GetUniqueColumnName(string columnName, HashSet<string> seen)
-    {
-        var candidate = columnName;
-        var suffix = 2;
-        while (!seen.Add(candidate))
-        {
-            candidate = $"{columnName}_{suffix}";
-            suffix++;
-        }
-
-        return candidate;
-    }
-
-    private static void EnsureCompatibleDataRecord(IDataRecord record, IReadOnlyList<DataRecordColumn> expectedColumns)
-    {
-        if (record.FieldCount != expectedColumns.Count)
-        {
-            throw new PSArgumentException("IDataRecord inputs must have the same field count.", nameof(record));
-        }
-
-        for (var index = 0; index < expectedColumns.Count; index++)
-        {
-            var expected = expectedColumns[index];
-            if (!string.Equals(record.GetName(index), expected.SourceName, StringComparison.OrdinalIgnoreCase) ||
-                record.GetFieldType(index) != expected.FieldType)
-            {
-                throw new PSArgumentException("IDataRecord inputs must have compatible column schemas.", nameof(record));
-            }
-        }
-    }
-
-    private static DataTable CloneTable(DataTable source, string? tableName)
-    {
-        var table = source.Clone();
-        if (!string.IsNullOrWhiteSpace(tableName))
-        {
-            table.TableName = tableName;
-        }
-
-        return table;
-    }
-
-    private static void AddCompatibleDataRow(DataTable table, DataRow row)
-    {
-        EnsureCompatibleSchema(table, row.Table);
-
-        var newRow = table.NewRow();
-        foreach (DataColumn column in table.Columns)
-        {
-            newRow[column.ColumnName] = row[column.ColumnName];
-        }
-
-        table.Rows.Add(newRow);
-    }
-
-    private static void EnsureCompatibleSchema(DataTable target, DataTable source)
-    {
-        if (source.Columns.Count != target.Columns.Count)
-        {
-            throw new PSArgumentException("DataRow inputs must have compatible column schemas.", nameof(source));
-        }
-
-        foreach (DataColumn targetColumn in target.Columns)
-        {
-            if (!source.Columns.Contains(targetColumn.ColumnName))
-            {
-                throw new PSArgumentException("DataRow inputs must have compatible column schemas.", nameof(source));
-            }
-
-            var sourceColumn = source.Columns[targetColumn.ColumnName]!;
-            if (sourceColumn.DataType != targetColumn.DataType)
-            {
-                throw new PSArgumentException("DataRow inputs must have compatible column schemas.", nameof(source));
-            }
-        }
-    }
-
-    private static DataTable FromObjects(IReadOnlyList<object?> items, string? tableName)
-    {
-        var rows = new List<IDictionary<string, object?>>(items.Count);
-        var columns = new List<string>();
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var row in items.Select(GetProperties))
-        {
-            rows.Add(row);
-
-            foreach (var key in row.Keys.Where(seen.Add))
-            {
-                columns.Add(key);
-            }
-        }
-
-        if (columns.Count == 0)
-        {
-            columns.Add("Value");
-            rows.Clear();
-            foreach (var item in items)
-            {
-                rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-                {
-                    ["Value"] = item
-                });
-            }
-        }
-
-        var table = string.IsNullOrWhiteSpace(tableName)
-            ? new DataTable()
-            : new DataTable(tableName);
-        foreach (var column in columns)
-        {
-            table.Columns.Add(column, InferColumnType(rows, column));
-        }
-
-        foreach (var rowValues in rows)
-        {
-            var row = table.NewRow();
-            foreach (var column in columns)
-            {
-                row[column] = rowValues.TryGetValue(column, out var value) && value != null
-                    ? value
-                    : DBNull.Value;
-            }
-
-            table.Rows.Add(row);
-        }
-
-        return table;
-    }
-
-    private static Type InferColumnType(IReadOnlyList<IDictionary<string, object?>> rows, string column)
-    {
-        Type? inferred = null;
-        foreach (var row in rows)
-        {
-            if (!row.TryGetValue(column, out var value) || value == null || value == DBNull.Value)
-            {
-                continue;
-            }
-
-            var valueType = value.GetType();
-            if (inferred == null)
-            {
-                inferred = valueType;
-                continue;
-            }
-
-            if (inferred != valueType)
-            {
-                return typeof(object);
-            }
-        }
-
-        return inferred ?? typeof(object);
-    }
-
-    private static IDictionary<string, object?> GetProperties(object? item)
-    {
-        if (IsScalarValue(item))
-        {
-            return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
-            {
-                ["Value"] = item
-            };
-        }
-
-        if (item is IDictionary dictionary)
-        {
-            var values = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
-            foreach (DictionaryEntry entry in dictionary)
-            {
-                if (entry.Key != null)
-                {
-                    values[entry.Key.ToString()!] = UnwrapValue(entry.Value);
-                }
-            }
-
-            return values;
-        }
-
-        var psObject = PSObject.AsPSObject(item);
         var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
         foreach (var property in psObject.Properties.Where(static property =>
                      (property.MemberType == PSMemberTypes.NoteProperty ||
@@ -362,50 +70,11 @@ internal static class PowerShellDataTableConverter
         }
 
         return psObject.BaseObject is DataTable or DataView or IDataReader or DataRow or DataRowView or IDataRecord or IDictionary ||
-               IsScalarValue(psObject.BaseObject)
+               TabularDataTableBuilder.IsScalarValue(psObject.BaseObject)
             ? psObject.BaseObject
             : psObject;
     }
 
     private static object? UnwrapValue(object? value)
         => value is PSObject psObject ? psObject.BaseObject : value;
-
-    private static bool ShouldExpandSingleEnumerableInput(object? item)
-        => item is IEnumerable &&
-           item is not string &&
-           item is not byte[] &&
-           item is not DataTable &&
-           item is not DataView &&
-           item is not IDataReader &&
-           item is not IDataRecord &&
-           item is not IDictionary;
-
-    private static bool IsScalarValue(object? item)
-    {
-        if (item == null || item == DBNull.Value)
-        {
-            return true;
-        }
-
-        var type = item.GetType();
-        return type.IsPrimitive ||
-               type.IsEnum ||
-               item is string or decimal or DateTime or DateTimeOffset or TimeSpan or Guid;
-    }
-
-    private sealed class DataRecordColumn
-    {
-        internal DataRecordColumn(string sourceName, string tableName, Type fieldType)
-        {
-            SourceName = sourceName;
-            TableName = tableName;
-            FieldType = fieldType;
-        }
-
-        internal string SourceName { get; }
-
-        internal string TableName { get; }
-
-        internal Type FieldType { get; }
-    }
 }

--- a/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
+++ b/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using System.Data;
 using System.Linq;
 using System.Management.Automation;
-using OfficeIMO.Data;
 
 namespace DBAClientX.PowerShell;
 

--- a/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
+++ b/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
@@ -24,7 +24,7 @@ internal static class PowerShellDataTableConverter
             ProjectObject = ProjectPowerShellObject
         });
 
-    private static IReadOnlyDictionary<string, object?>? ProjectPowerShellObject(object? item)
+    private static IReadOnlyDictionary<string, object?>? ProjectPowerShellObject(object? item, IReadOnlyList<string>? _)
     {
         if (item is PSObject psObject &&
             psObject.BaseObject is not DataTable &&

--- a/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
+++ b/DbaClientX.PowerShell/PowerShellDataTableConverter.cs
@@ -69,7 +69,7 @@ internal static class PowerShellDataTableConverter
             return item;
         }
 
-        return psObject.BaseObject is DataTable or DataView or IDataReader or DataRow or DataRowView or IDataRecord or IDictionary ||
+        return psObject.BaseObject is DataTable or DataView or IDataReader or DataRow or DataRowView or IDataRecord or IDictionary or IEnumerable ||
                TabularDataTableBuilder.IsScalarValue(psObject.BaseObject)
             ? psObject.BaseObject
             : psObject;

--- a/DbaClientX.PowerShell/Tabular/TabularColumnDiscoveryMode.cs
+++ b/DbaClientX.PowerShell/Tabular/TabularColumnDiscoveryMode.cs
@@ -1,0 +1,10 @@
+namespace DBAClientX.PowerShell;
+
+/// <summary>Controls how object row columns are discovered.</summary>
+internal enum TabularColumnDiscoveryMode {
+    /// <summary>Use columns from the first projected row.</summary>
+    FirstRow,
+
+    /// <summary>Use the union of columns found across all projected rows.</summary>
+    AllRows
+}

--- a/DbaClientX.PowerShell/Tabular/TabularDataOptions.cs
+++ b/DbaClientX.PowerShell/Tabular/TabularDataOptions.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace DBAClientX.PowerShell;
+
+/// <summary>
+/// Configures conversion from common tabular inputs to a <see cref="System.Data.DataTable"/>.
+/// </summary>
+internal sealed class TabularDataOptions {
+    /// <summary>Optional table name for newly created tables.</summary>
+    public string? TableName { get; set; }
+
+    /// <summary>Copies an existing DataTable input instead of returning the original table.</summary>
+    public bool CopyExistingDataTable { get; set; } = true;
+
+    /// <summary>Expands a single enumerable input into rows.</summary>
+    public bool ExpandSingleEnumerableInput { get; set; } = true;
+
+    /// <summary>Preserves explicit null input items as scalar rows.</summary>
+    public bool PreserveNullRows { get; set; }
+
+    /// <summary>Column name used for scalar rows.</summary>
+    public string ScalarColumnName { get; set; } = "Value";
+
+    /// <summary>Controls whether object columns come from the first row or all rows.</summary>
+    public TabularColumnDiscoveryMode ColumnDiscoveryMode { get; set; } = TabularColumnDiscoveryMode.AllRows;
+
+    /// <summary>Unwraps host-specific wrapper objects before tabular conversion.</summary>
+    public Func<object?, object?>? UnwrapValue { get; set; }
+
+    /// <summary>Projects host-specific objects into a column/value dictionary, using established columns when available.</summary>
+    public Func<object?, IReadOnlyList<string>?, IReadOnlyDictionary<string, object?>?>? ProjectObject { get; set; }
+
+    /// <summary>Converts cell values before they are stored in the DataTable.</summary>
+    public Func<object?, object?>? NormalizeValue { get; set; }
+}

--- a/DbaClientX.PowerShell/Tabular/TabularDataTableBuilder.cs
+++ b/DbaClientX.PowerShell/Tabular/TabularDataTableBuilder.cs
@@ -1,0 +1,667 @@
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Reflection;
+
+namespace DBAClientX.PowerShell;
+
+/// <summary>
+/// Converts common object, dictionary, DataTable, DataView, IDataReader, DataRow, and IDataRecord inputs into tabular data.
+/// </summary>
+internal static class TabularDataTableBuilder {
+    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PublicPropertyPlans = new();
+
+    /// <summary>Converts an input sequence into a DataTable.</summary>
+    public static DataTable FromItems(IEnumerable<object?> input, TabularDataOptions? options = null) {
+        if (input == null) {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        options ??= new TabularDataOptions();
+        var items = MaterializeItems(input, options);
+
+        if (items.Count == 1 && options.ExpandSingleEnumerableInput && ShouldExpandSingleEnumerableInput(items[0])) {
+            var expandedItems = new List<object?>();
+            foreach (var item in (IEnumerable)items[0]!) {
+                AddMaterializedItem(expandedItems, item, options);
+            }
+
+            items = expandedItems;
+        }
+
+        if (items.Count == 0) {
+            return CreateTable(options.TableName);
+        }
+
+        if (items.Count == 1) {
+            var single = items[0];
+            if (single is DataTable dataTable) {
+                return options.CopyExistingDataTable ? dataTable.Copy() : dataTable;
+            }
+
+            if (single is DataView dataView) {
+                var table = dataView.ToTable();
+                ApplyTableName(table, options.TableName);
+                return table;
+            }
+
+            if (single is IDataReader reader) {
+                var table = CreateTable(options.TableName);
+                table.Load(reader);
+                return table;
+            }
+        }
+
+        if (items[0] is DataRow firstRow) {
+            return FromDataRows(items, firstRow.Table, options.TableName);
+        }
+
+        if (items[0] is DataRowView firstRowView) {
+            return FromDataRowViews(items, firstRowView.Row.Table, options.TableName);
+        }
+
+        if (items[0] is IDataRecord firstRecord) {
+            return FromDataRecords(items, firstRecord, options.TableName);
+        }
+
+        return FromObjects(items, options);
+    }
+
+    /// <summary>Returns the only IDataReader from an input sequence, or null when the input is not exactly one reader.</summary>
+    public static IDataReader? TryGetSingleDataReader(IEnumerable<object?> input, Func<object?, object?>? unwrapValue = null) {
+        if (input == null) {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        IDataReader? reader = null;
+        var count = 0;
+        foreach (var item in input) {
+            if (item == null) {
+                continue;
+            }
+
+            count++;
+            if (count > 1) {
+                return null;
+            }
+
+            reader = (unwrapValue?.Invoke(item) ?? item) as IDataReader;
+        }
+
+        return count == 1 ? reader : null;
+    }
+
+    /// <summary>Returns the only DataSet from an input sequence, or null when the input is not exactly one DataSet.</summary>
+    public static DataSet? TryGetSingleDataSet(IEnumerable<object?> input, Func<object?, object?>? unwrapValue = null) {
+        if (input == null) {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        DataSet? dataSet = null;
+        var count = 0;
+        foreach (var item in input) {
+            if (item == null) {
+                continue;
+            }
+
+            count++;
+            if (count > 1) {
+                return null;
+            }
+
+            dataSet = (unwrapValue?.Invoke(item) ?? item) as DataSet;
+        }
+
+        return count == 1 ? dataSet : null;
+    }
+
+    /// <summary>Returns true when the value is handled as a scalar row value.</summary>
+    public static bool IsScalarValue(object? item) {
+        if (item == null || item == DBNull.Value) {
+            return true;
+        }
+
+        var type = item.GetType();
+        return type.IsPrimitive ||
+               type.IsEnum ||
+               item is string or decimal or DateTime or DateTimeOffset or TimeSpan or Guid;
+    }
+
+    private static object? Unwrap(object? item, TabularDataOptions options)
+        => options.UnwrapValue?.Invoke(item) ?? item;
+
+    private static List<object?> MaterializeItems(IEnumerable<object?> input, TabularDataOptions options) {
+        if (input is IReadOnlyList<object?> list) {
+            var items = new List<object?>(list.Count);
+            for (var index = 0; index < list.Count; index++) {
+                AddMaterializedItem(items, list[index], options);
+            }
+
+            return items;
+        }
+
+        var result = new List<object?>();
+        foreach (var item in input) {
+            AddMaterializedItem(result, item, options);
+        }
+
+        return result;
+    }
+
+    private static void AddMaterializedItem(List<object?> items, object? item, TabularDataOptions options) {
+        var unwrapped = Unwrap(item, options);
+        if (IsNativeTabularValue(unwrapped) ||
+            (options.ExpandSingleEnumerableInput && ShouldExpandSingleEnumerableInput(unwrapped))) {
+            items.Add(unwrapped);
+            return;
+        }
+
+        if (options.ProjectObject != null && (options.PreserveNullRows || unwrapped != null)) {
+            items.Add(new ProjectableItem(item, unwrapped));
+            return;
+        }
+
+        if (options.PreserveNullRows || unwrapped != null) {
+            items.Add(unwrapped);
+        }
+    }
+
+    private static bool IsNativeTabularValue(object? item)
+        => item is DataTable or DataView or IDataReader or DataRow or DataRowView or IDataRecord;
+
+    private static DataTable FromDataRows(IReadOnlyList<object?> items, DataTable source, string? tableName) {
+        var table = CloneTable(source, tableName);
+        foreach (var item in items) {
+            if (item is not DataRow row) {
+                throw new ArgumentException("DataRow input cannot be mixed with other input types.", nameof(items));
+            }
+
+            AddCompatibleDataRow(table, row);
+        }
+
+        return table;
+    }
+
+    private static DataTable FromDataRowViews(IReadOnlyList<object?> items, DataTable source, string? tableName) {
+        var table = CloneTable(source, tableName);
+        foreach (var item in items) {
+            if (item is not DataRowView rowView) {
+                throw new ArgumentException("DataRowView input cannot be mixed with other input types.", nameof(items));
+            }
+
+            AddCompatibleDataRow(table, rowView.Row);
+        }
+
+        return table;
+    }
+
+    private static DataTable FromDataRecords(IReadOnlyList<object?> items, IDataRecord firstRecord, string? tableName) {
+        var table = CreateTable(tableName);
+        var columns = GetDataRecordColumns(firstRecord);
+        foreach (var column in columns) {
+            table.Columns.Add(column.TableName, column.FieldType);
+        }
+
+        foreach (var item in items) {
+            if (item is not IDataRecord record) {
+                throw new ArgumentException("IDataRecord input cannot be mixed with other input types.", nameof(items));
+            }
+
+            EnsureCompatibleDataRecord(record, columns);
+            var row = table.NewRow();
+            for (var index = 0; index < columns.Count; index++) {
+                row[index] = record.IsDBNull(index) ? DBNull.Value : record.GetValue(index);
+            }
+
+            table.Rows.Add(row);
+        }
+
+        return table;
+    }
+
+    private static IReadOnlyList<DataRecordColumn> GetDataRecordColumns(IDataRecord record) {
+        var columns = new List<DataRecordColumn>(record.FieldCount);
+        var tableNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (var index = 0; index < record.FieldCount; index++) {
+            var sourceName = record.GetName(index);
+            var baseName = string.IsNullOrWhiteSpace(sourceName)
+                ? $"Column{index + 1}"
+                : sourceName;
+            var tableName = GetUniqueColumnName(baseName, tableNames);
+            columns.Add(new DataRecordColumn(sourceName, tableName, record.GetFieldType(index) ?? typeof(object)));
+        }
+
+        return columns;
+    }
+
+    private static void EnsureCompatibleDataRecord(IDataRecord record, IReadOnlyList<DataRecordColumn> expectedColumns) {
+        if (record.FieldCount != expectedColumns.Count) {
+            throw new ArgumentException("IDataRecord inputs must have the same field count.", nameof(record));
+        }
+
+        for (var index = 0; index < expectedColumns.Count; index++) {
+            var expected = expectedColumns[index];
+            if (!string.Equals(record.GetName(index), expected.SourceName, StringComparison.OrdinalIgnoreCase) ||
+                (record.GetFieldType(index) ?? typeof(object)) != expected.FieldType) {
+                throw new ArgumentException("IDataRecord inputs must have compatible column schemas.", nameof(record));
+            }
+        }
+    }
+
+    private static DataTable FromObjects(IReadOnlyList<object?> items, TabularDataOptions options) {
+        var rows = new List<IReadOnlyDictionary<string, object?>>(items.Count);
+        var columns = new List<string>();
+        var exactColumns = new HashSet<string>(StringComparer.Ordinal);
+        string[]? fixedProjectionColumns = null;
+
+        foreach (var item in items) {
+            var row = GetProperties(item, options, fixedProjectionColumns);
+            rows.Add(row);
+
+            if (options.ColumnDiscoveryMode == TabularColumnDiscoveryMode.AllRows || rows.Count == 1) {
+                var rowKeys = row.Keys.Where(key => !string.IsNullOrWhiteSpace(key)).ToArray();
+                var exactRowKeys = new HashSet<string>(rowKeys, StringComparer.Ordinal);
+                foreach (var key in rowKeys) {
+                    if (exactColumns.Contains(key)) {
+                        continue;
+                    }
+
+                    var matchesExistingColumn = columns.Any(column =>
+                        !exactRowKeys.Contains(column)
+                        && string.Equals(column, key, StringComparison.OrdinalIgnoreCase)
+                        && row.ContainsKey(column));
+                    if (!matchesExistingColumn) {
+                        columns.Add(key);
+                        exactColumns.Add(key);
+                    }
+                }
+
+                if (options.ColumnDiscoveryMode == TabularColumnDiscoveryMode.FirstRow) {
+                    fixedProjectionColumns = columns.ToArray();
+                }
+            }
+        }
+
+        if (columns.Count == 0) {
+            string scalarColumnName = GetScalarColumnName(options);
+            columns.Add(scalarColumnName);
+            rows.Clear();
+            foreach (var item in items) {
+                object? scalarValue = item is ProjectableItem projectableItem
+                    ? projectableItem.Unwrapped
+                    : item;
+                rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) {
+                    [scalarColumnName] = NormalizeValue(scalarValue, options)
+                });
+            }
+        }
+
+        var table = CreateTable(options.TableName);
+        foreach (var column in columns) {
+            table.Columns.Add(column, InferColumnType(rows, column));
+        }
+
+        table.MinimumCapacity = Math.Max(table.MinimumCapacity, rows.Count);
+        table.BeginLoadData();
+        try {
+            foreach (var rowValues in rows) {
+                var row = table.NewRow();
+                foreach (var column in columns) {
+                    row[column] = rowValues.TryGetValue(column, out var value) && value != null
+                        ? value
+                        : DBNull.Value;
+                }
+
+                table.Rows.Add(row);
+            }
+        } finally {
+            table.EndLoadData();
+        }
+
+        return table;
+    }
+
+    private static IReadOnlyDictionary<string, object?> GetProperties(
+        object? item,
+        TabularDataOptions options,
+        IReadOnlyList<string>? projectionColumns) {
+        var projectionItem = item;
+        if (item is ProjectableItem projectableItem) {
+            projectionItem = projectableItem.Source;
+            item = projectableItem.Unwrapped;
+        }
+
+        var projected = options.ProjectObject?.Invoke(projectionItem, projectionColumns);
+        if (projected != null) {
+            return NormalizeDictionary(projected, options);
+        }
+
+        if (IsScalarValue(item)) {
+            return new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase) {
+                [GetScalarColumnName(options)] = NormalizeValue(item, options)
+            };
+        }
+
+        if (item is IReadOnlyDictionary<string, object?> readOnlyDictionary) {
+            return NormalizeDictionary(readOnlyDictionary, options);
+        }
+
+        if (item is IDictionary<string, object?> genericDictionary) {
+            return NormalizeDictionary(genericDictionary, options);
+        }
+
+        if (item is IDictionary dictionary) {
+            return new LegacyDictionaryProjection(dictionary, options);
+        }
+
+        return ProjectPublicProperties(item!, options);
+    }
+
+    private sealed class ProjectableItem {
+        internal ProjectableItem(object? source, object? unwrapped) {
+            Source = source;
+            Unwrapped = unwrapped;
+        }
+
+        internal object? Source { get; }
+
+        internal object? Unwrapped { get; }
+    }
+
+    private static IReadOnlyDictionary<string, object?> NormalizeDictionary(IReadOnlyDictionary<string, object?> source, TabularDataOptions options)
+        => new NormalizedReadOnlyDictionaryProjection(source, options);
+
+    private static IReadOnlyDictionary<string, object?> NormalizeDictionary(IDictionary<string, object?> source, TabularDataOptions options)
+        => new NormalizedDictionaryProjection(source, options);
+
+    private static IReadOnlyDictionary<string, object?> ProjectPublicProperties(object item, TabularDataOptions options) {
+        var result = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var property in GetPublicPropertyPlan(item.GetType())) {
+            result[property.Name] = NormalizeValue(property.GetValue(item), options);
+        }
+
+        return result;
+    }
+
+    private static PropertyInfo[] GetPublicPropertyPlan(Type type)
+        => PublicPropertyPlans.GetOrAdd(type, propertyType => propertyType
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(property => property.CanRead
+                && property.GetIndexParameters().Length == 0
+                && !string.IsNullOrWhiteSpace(property.Name))
+            .OrderBy(property => property.MetadataToken)
+            .ToArray());
+
+    private static Type InferColumnType(IReadOnlyList<IReadOnlyDictionary<string, object?>> rows, string column) {
+        Type? inferred = null;
+        foreach (var row in rows) {
+            if (!row.TryGetValue(column, out var value) || value == null || value == DBNull.Value) {
+                continue;
+            }
+
+            var valueType = value.GetType();
+            if (inferred == null) {
+                inferred = valueType;
+                continue;
+            }
+
+            if (inferred != valueType) {
+                return typeof(object);
+            }
+        }
+
+        return inferred ?? typeof(object);
+    }
+
+    private static object? NormalizeValue(object? value, TabularDataOptions options)
+        => options.NormalizeValue is null ? value : options.NormalizeValue(value);
+
+    private static bool ShouldExpandSingleEnumerableInput(object? item)
+        => item is IEnumerable &&
+           item is not string &&
+           item is not byte[] &&
+           item is not DataSet &&
+           item is not DataTable &&
+           item is not DataView &&
+           item is not IDataReader &&
+           item is not IDataRecord &&
+           item is not IDictionary &&
+           item is not IReadOnlyDictionary<string, object?> &&
+           item is not IDictionary<string, object?>;
+
+    private static DataTable CloneTable(DataTable source, string? tableName) {
+        var table = source.Clone();
+        ApplyTableName(table, tableName);
+        return table;
+    }
+
+    private static void AddCompatibleDataRow(DataTable table, DataRow row) {
+        EnsureCompatibleSchema(table, row.Table);
+
+        var newRow = table.NewRow();
+        foreach (DataColumn column in table.Columns) {
+            newRow[column.ColumnName] = row[column.ColumnName];
+        }
+
+        table.Rows.Add(newRow);
+    }
+
+    private static void EnsureCompatibleSchema(DataTable target, DataTable source) {
+        if (source.Columns.Count != target.Columns.Count) {
+            throw new ArgumentException("DataRow inputs must have compatible column schemas.", nameof(source));
+        }
+
+        foreach (DataColumn targetColumn in target.Columns) {
+            if (!source.Columns.Contains(targetColumn.ColumnName)) {
+                throw new ArgumentException("DataRow inputs must have compatible column schemas.", nameof(source));
+            }
+
+            var sourceColumn = source.Columns[targetColumn.ColumnName]!;
+            if (sourceColumn.DataType != targetColumn.DataType) {
+                throw new ArgumentException("DataRow inputs must have compatible column schemas.", nameof(source));
+            }
+        }
+    }
+
+    private static DataTable CreateTable(string? tableName)
+        => string.IsNullOrWhiteSpace(tableName) ? new DataTable() : new DataTable(tableName);
+
+    private static void ApplyTableName(DataTable table, string? tableName) {
+        if (!string.IsNullOrWhiteSpace(tableName)) {
+            table.TableName = tableName;
+        }
+    }
+
+    private static string GetUniqueColumnName(string columnName, HashSet<string> seen) {
+        var candidate = columnName;
+        var suffix = 2;
+        while (!seen.Add(candidate)) {
+            candidate = $"{columnName}_{suffix}";
+            suffix++;
+        }
+
+        return candidate;
+    }
+
+    private static string GetScalarColumnName(TabularDataOptions options)
+        => string.IsNullOrWhiteSpace(options.ScalarColumnName) ? "Value" : options.ScalarColumnName;
+
+    private sealed class DataRecordColumn {
+        internal DataRecordColumn(string sourceName, string tableName, Type fieldType) {
+            SourceName = sourceName;
+            TableName = tableName;
+            FieldType = fieldType;
+        }
+
+        internal string SourceName { get; }
+
+        internal string TableName { get; }
+
+        internal Type FieldType { get; }
+    }
+
+    private sealed class LegacyDictionaryProjection : IReadOnlyDictionary<string, object?> {
+        private readonly IDictionary _source;
+        private readonly TabularDataOptions _options;
+        private readonly List<string> _keys;
+
+        internal LegacyDictionaryProjection(IDictionary source, TabularDataOptions options) {
+            _source = source;
+            _options = options;
+            _keys = new List<string>(source.Count);
+
+            foreach (DictionaryEntry entry in source) {
+                if (entry.Key != null) {
+                    _keys.Add(entry.Key.ToString()!);
+                }
+            }
+        }
+
+        public IEnumerable<string> Keys => _keys;
+
+        public IEnumerable<object?> Values => _keys.Select(key => this[key]);
+
+        public int Count => _keys.Count;
+
+        public object? this[string key] => TryGetValue(key, out var value)
+            ? value
+            : throw new KeyNotFoundException();
+
+        public bool ContainsKey(string key) => TryGetValue(key, out _);
+
+        public bool TryGetValue(string key, out object? value) {
+            if (_source.Contains(key)) {
+                value = NormalizeValue(_source[key], _options);
+                return true;
+            }
+
+            foreach (DictionaryEntry entry in _source) {
+                var entryKey = entry.Key?.ToString();
+                if (string.Equals(entryKey, key, StringComparison.OrdinalIgnoreCase)) {
+                    value = NormalizeValue(entry.Value, _options);
+                    return true;
+                }
+            }
+
+            value = null;
+            return false;
+        }
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() {
+            foreach (var key in _keys) {
+                yield return new KeyValuePair<string, object?>(key, this[key]);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class NormalizedReadOnlyDictionaryProjection : IReadOnlyDictionary<string, object?> {
+        private readonly IReadOnlyDictionary<string, object?> _source;
+        private readonly TabularDataOptions _options;
+        private readonly List<string> _keys;
+        private readonly Dictionary<string, object?> _normalizedValues = new(StringComparer.Ordinal);
+
+        internal NormalizedReadOnlyDictionaryProjection(IReadOnlyDictionary<string, object?> source, TabularDataOptions options) {
+            _source = source;
+            _options = options;
+            _keys = source.Keys.Where(key => !string.IsNullOrWhiteSpace(key)).ToList();
+        }
+
+        public IEnumerable<string> Keys => _keys;
+
+        public IEnumerable<object?> Values => _keys.Select(key => this[key]);
+
+        public int Count => _keys.Count;
+
+        public object? this[string key] => TryGetValue(key, out var value)
+            ? value
+            : throw new KeyNotFoundException();
+
+        public bool ContainsKey(string key) => !string.IsNullOrWhiteSpace(key) && _source.ContainsKey(key);
+
+        public bool TryGetValue(string key, out object? value) {
+            if (string.IsNullOrWhiteSpace(key)) {
+                value = null;
+                return false;
+            }
+
+            if (_normalizedValues.TryGetValue(key, out value)) {
+                return true;
+            }
+
+            if (_source.TryGetValue(key, out var sourceValue)) {
+                value = NormalizeValue(sourceValue, _options);
+                _normalizedValues[key] = value;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() {
+            foreach (var key in _keys) {
+                yield return new KeyValuePair<string, object?>(key, this[key]);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class NormalizedDictionaryProjection : IReadOnlyDictionary<string, object?> {
+        private readonly IDictionary<string, object?> _source;
+        private readonly TabularDataOptions _options;
+        private readonly List<string> _keys;
+        private readonly Dictionary<string, object?> _normalizedValues = new(StringComparer.Ordinal);
+
+        internal NormalizedDictionaryProjection(IDictionary<string, object?> source, TabularDataOptions options) {
+            _source = source;
+            _options = options;
+            _keys = source.Keys.Where(key => !string.IsNullOrWhiteSpace(key)).ToList();
+        }
+
+        public IEnumerable<string> Keys => _keys;
+
+        public IEnumerable<object?> Values => _keys.Select(key => this[key]);
+
+        public int Count => _keys.Count;
+
+        public object? this[string key] => TryGetValue(key, out var value)
+            ? value
+            : throw new KeyNotFoundException();
+
+        public bool ContainsKey(string key) => !string.IsNullOrWhiteSpace(key) && _source.ContainsKey(key);
+
+        public bool TryGetValue(string key, out object? value) {
+            if (string.IsNullOrWhiteSpace(key)) {
+                value = null;
+                return false;
+            }
+
+            if (_normalizedValues.TryGetValue(key, out value)) {
+                return true;
+            }
+
+            if (_source.TryGetValue(key, out var sourceValue)) {
+                value = NormalizeValue(sourceValue, _options);
+                _normalizedValues[key] = value;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        public IEnumerator<KeyValuePair<string, object?>> GetEnumerator() {
+            foreach (var key in _keys) {
+                yield return new KeyValuePair<string, object?>(key, this[key]);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/DbaClientX.SqlServer/SqlServer.BulkDataReader.cs
+++ b/DbaClientX.SqlServer/SqlServer.BulkDataReader.cs
@@ -201,6 +201,7 @@ public partial class SqlServer
     private static void ConfigureBulkCopy(SqlBulkCopy bulkCopy, IDataReader reader, string destinationTable, int? batchSize, int? bulkCopyTimeout, SqlServerBulkInsertOptions? options)
     {
         bulkCopy.DestinationTableName = ResolveBulkCopyDestinationTableName(destinationTable, options);
+        bulkCopy.EnableStreaming = true;
         if (batchSize.HasValue)
         {
             bulkCopy.BatchSize = batchSize.Value;

--- a/DbaClientX.Tests/PowerShellDataTableConverterTests.cs
+++ b/DbaClientX.Tests/PowerShellDataTableConverterTests.cs
@@ -6,6 +6,54 @@ namespace DbaClientX.Tests;
 public class PowerShellDataTableConverterTests
 {
     [Fact]
+    public void ToDataTable_ExpandsSingleEnumerableInput()
+    {
+        var rows = new[]
+        {
+            new ConverterRow { Id = 1, Name = "Alpha" },
+            new ConverterRow { Id = 2, Name = "Beta" }
+        };
+
+        var table = PowerShellDataTableConverter.ToDataTable(new object?[] { rows }, "Records");
+
+        Assert.Equal(typeof(int), table.Columns["Id"]!.DataType);
+        Assert.Equal(typeof(string), table.Columns["Name"]!.DataType);
+        Assert.Equal(2, table.Rows.Count);
+        Assert.Equal("Beta", table.Rows[1]["Name"]);
+    }
+
+    [Fact]
+    public void ToDataTable_DiscoversColumnsAcrossDictionaryRows()
+    {
+        var table = PowerShellDataTableConverter.ToDataTable(new object?[]
+        {
+            new Dictionary<string, object?>(StringComparer.Ordinal) { ["Name"] = "Alpha" },
+            new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["name"] = "Beta",
+                ["Age"] = 42
+            }
+        }, "Records");
+
+        Assert.Equal(new[] { "Name", "Age" }, table.Columns.Cast<DataColumn>().Select(column => column.ColumnName));
+        Assert.Equal("Beta", table.Rows[1]["Name"]);
+        Assert.Equal(42, table.Rows[1]["Age"]);
+    }
+
+    [Fact]
+    public void ToDataTable_ReturnsDirectDataTableInput()
+    {
+        var source = new DataTable("Source");
+        source.Columns.Add("Name", typeof(string));
+        source.Rows.Add("Alpha");
+
+        var table = PowerShellDataTableConverter.ToDataTable(new object?[] { source }, "Records");
+
+        Assert.Same(source, table);
+        Assert.Equal("Alpha", table.Rows[0]["Name"]);
+    }
+
+    [Fact]
     public void ToDataTable_PreservesDataRecordFieldTypes()
     {
         using var source = new DataTable();
@@ -24,5 +72,12 @@ public class PowerShellDataTableConverterTests
         Assert.Equal(typeof(DateTime), table.Columns["CreatedUtc"]!.DataType);
         Assert.Equal(1, table.Rows[0]["Id"]);
         Assert.Equal(12.5m, table.Rows[0]["Score"]);
+    }
+
+    private sealed class ConverterRow
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; } = string.Empty;
     }
 }

--- a/DbaClientX.Tests/SqlServerBulkInsertTests.cs
+++ b/DbaClientX.Tests/SqlServerBulkInsertTests.cs
@@ -18,6 +18,7 @@ public class SqlServerBulkInsertTests
         public string? ConnectionString { get; private set; }
         public SqlBulkCopyOptions Options { get; private set; }
         public int NotifyAfter { get; private set; }
+        public bool EnableStreaming { get; private set; }
         public int ReaderRows { get; private set; }
         public int ReaderFieldCount { get; private set; }
         public List<(string Source, string Destination)> Mappings { get; } = new();
@@ -61,6 +62,7 @@ public class SqlServerBulkInsertTests
             Timeout = bulkCopy.BulkCopyTimeout;
             Destination = bulkCopy.DestinationTableName;
             NotifyAfter = bulkCopy.NotifyAfter;
+            EnableStreaming = bulkCopy.EnableStreaming;
             ReaderFieldCount = reader.FieldCount;
             foreach (SqlBulkCopyColumnMapping mapping in bulkCopy.ColumnMappings)
             {
@@ -492,6 +494,7 @@ public class SqlServerBulkInsertTests
         Assert.Equal(100, sqlServer.BatchSize);
         Assert.Equal(60, sqlServer.Timeout);
         Assert.Equal(25, sqlServer.NotifyAfter);
+        Assert.True(sqlServer.EnableStreaming);
         Assert.Equal("dbo.Dest", sqlServer.Destination);
         Assert.Equal(2, sqlServer.ReaderFieldCount);
         Assert.Equal(2, sqlServer.ReaderRows);
@@ -513,6 +516,7 @@ public class SqlServerBulkInsertTests
 
         Assert.Equal("Server=s;Database=db;Encrypt=True", sqlServer.ConnectionString);
         Assert.Equal("dbo.Dest", sqlServer.Destination);
+        Assert.True(sqlServer.EnableStreaming);
         Assert.Equal(2, sqlServer.ReaderRows);
         Assert.Equal(0, sqlServer.SyncDisposeCalls);
         Assert.Equal(1, sqlServer.AsyncDisposeCalls);

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="MySqlConnector" Version="2.6.1" />
-    <PackageVersion Include="OfficeIMO.Data" Version="0.1.0" />
     <PackageVersion Include="Oracle.ManagedDataAccess" Version="23.26.200" />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.26.200" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="MySqlConnector" Version="2.6.1" />
+    <PackageVersion Include="OfficeIMO.Data" Version="0.1.0" />
     <PackageVersion Include="Oracle.ManagedDataAccess" Version="23.26.200" />
     <PackageVersion Include="Oracle.ManagedDataAccess.Core" Version="23.26.200" />
     <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -103,6 +103,8 @@ $settings = {
     $fileKinds = $FileKind
     $columnShapes = $ColumnShape
     $selectedEngines = if ($Engine) { $Engine } else { @('DbaClientX') }
+    $benchmarkWarmupCount = $WarmupCount
+    $benchmarkIterationCount = $Iterations
 
     $engineComparisonBaseline = if ($selectedEngines -contains 'DbaClientX') { 'DbaClientX' } else { $selectedEngines[0] }
 
@@ -214,7 +216,7 @@ FROM numbers;
     $assertIntegrity = ${function:Assert-DbaClientXOfficeBenchmarkIntegrity}
     $assertTypedSchema = ${function:Assert-DbaClientXOfficeBenchmarkTypedSchema}
     benchmark 'office-file-roundtrip' -out $outputRootBase {
-        policy -Warmup $WarmupCount -Iterations $Iterations -Order Rotated -OutlierMode None
+        policy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -OutlierMode None
         profile Current -Cleanup KeepOnFailure
 
         caseSource {
@@ -288,6 +290,9 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
 
             Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getCreateTableQuery -TableName $run.SourceTable) -QueryTimeout 120 -ErrorAction Stop | Out-Null
             Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getSeedQuery -TableName $run.SourceTable -RowCount ([int] $case.RowCount)) -QueryTimeout 120 -ErrorAction Stop | Out-Null
+            if ($case.ColumnShape -eq 'Mapped') {
+                Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getCreateTableQuery -TableName $run.DestinationTable) -QueryTimeout 120 -ErrorAction Stop | Out-Null
+            }
 
             if ($case.Engine -eq 'dbatools') {
                 $run.DbatoolsInstance = Connect-DbaInstance `

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -374,10 +374,10 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                     if ($case.FileKind -in @('CsvTyped', 'CsvGZipTyped')) {
                         $csvImportParameters.ColumnType = if ($case.ColumnShape -eq 'Mapped') {
                             @{
-                                SourceId = [int]
-                                SourceDisplayName = [string]
-                                SourceScore = [decimal]
-                                SourceCreatedUtc = [datetime]
+                                CustomerId = [int]
+                                CustomerName = [string]
+                                WeightedScore = [decimal]
+                                SeenUtc = [datetime]
                             }
                         } else {
                             @{

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -82,6 +82,7 @@ if ($WarmupCount -lt 0) {
 Import-Module PSPublishModule -MinimumVersion 3.0.44 -ErrorAction Stop
 
 $benchmarkScriptRoot = $PSScriptRoot
+$benchmarkRunToken = [guid]::NewGuid().ToString('N').Substring(0, 8)
 $settings = {
     $sourceRoot = (Resolve-Path -LiteralPath (Join-Path $benchmarkScriptRoot '..\..')).Path
     $readmePath = Join-Path $sourceRoot 'README.md'
@@ -102,38 +103,6 @@ $settings = {
     $fileKinds = $FileKind
     $columnShapes = $ColumnShape
     $selectedEngines = if ($Engine) { $Engine } else { @('DbaClientX') }
-
-    function Test-DbaToolsCsvCommandAvailability {
-        param(
-            [switch] $RequireCompression,
-            [switch] $RequireTypeDetection,
-            [switch] $RequireColumnMapping
-        )
-
-        $connectCommand = Get-Command Connect-DbaInstance -ErrorAction SilentlyContinue
-        $exportCommand = Get-Command Export-DbaCsv -ErrorAction SilentlyContinue
-        $importCommand = Get-Command Import-DbaCsv -ErrorAction SilentlyContinue
-        if (-not $connectCommand -or -not $exportCommand -or -not $importCommand) {
-            return $false
-        }
-
-        if ($RequireCompression.IsPresent -and -not $exportCommand.Parameters.ContainsKey('CompressionType')) {
-            Write-Warning "Skipping compressed dbatools CSV benchmark lane because the installed Export-DbaCsv command lacks -CompressionType."
-            return $false
-        }
-
-        if ($RequireTypeDetection.IsPresent -and -not $importCommand.Parameters.ContainsKey('DetectColumnTypes')) {
-            Write-Warning "Skipping typed dbatools CSV benchmark lane because the installed Import-DbaCsv command lacks -DetectColumnTypes."
-            return $false
-        }
-
-        if ($RequireColumnMapping.IsPresent -and -not $importCommand.Parameters.ContainsKey('ColumnMap')) {
-            Write-Warning "Skipping mapped-column dbatools CSV benchmark lane because the installed Import-DbaCsv command lacks -ColumnMap."
-            return $false
-        }
-
-        return $true
-    }
 
     $engineComparisonBaseline = if ($selectedEngines -contains 'DbaClientX') { 'DbaClientX' } else { $selectedEngines[0] }
 
@@ -244,7 +213,6 @@ FROM numbers;
     $getExpectedIntegrity = ${function:Get-DbaClientXOfficeBenchmarkExpectedIntegrity}
     $assertIntegrity = ${function:Assert-DbaClientXOfficeBenchmarkIntegrity}
     $assertTypedSchema = ${function:Assert-DbaClientXOfficeBenchmarkTypedSchema}
-    $testDbaToolsCsvCommands = ${function:Test-DbaToolsCsvCommandAvailability}
     benchmark 'office-file-roundtrip' -out $outputRootBase {
         policy -Warmup $WarmupCount -Iterations $Iterations -Order Rotated -OutlierMode None
         profile Current -Cleanup KeepOnFailure
@@ -278,8 +246,9 @@ FROM numbers;
             $run.Database = $database
             $run.KeepArtifacts = $keepArtifacts
             $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
-            $run.SourceTable = 'DbaClientXBench_FileSource_{0}' -f ([guid]::NewGuid().ToString('N').Substring(0, 8))
-            $run.DestinationTable = 'DbaClientXBench_FileDest_{0}' -f ([guid]::NewGuid().ToString('N').Substring(0, 8))
+            $laneToken = '{0}_{1}_{2}_{3}_{4}' -f $benchmarkRunToken, $case.Engine, $case.FileKind, $case.ColumnShape, $case.RowCount
+            $run.SourceTable = 'DbaClientXBench_FileSource_{0}' -f $laneToken
+            $run.DestinationTable = 'DbaClientXBench_FileDest_{0}' -f $laneToken
             if ($case.ColumnShape -eq 'Mapped') {
                 $run.SelectQuery = "SELECT Id AS CustomerId, DisplayName AS CustomerName, Score AS WeightedScore, CreatedUtc AS SeenUtc FROM dbo.$($run.SourceTable) ORDER BY Id;"
                 $run.ColumnMap = @{
@@ -299,7 +268,7 @@ FROM numbers;
                 'CsvGZipTyped' { '.csv.gz' }
                 default { '.xlsx' }
             }
-            $run.FilePath = Join-Path $outputRootBase ('DbaClientXBench_{0}_{1}_{2}_{3}{4}' -f $case.Engine, $case.FileKind, $case.ColumnShape, ([guid]::NewGuid().ToString('N').Substring(0, 8)), $extension)
+            $run.FilePath = Join-Path $outputRootBase ('DbaClientXBench_{0}{1}' -f $laneToken, $extension)
             $run.DropQuery = @"
 IF OBJECT_ID(N'dbo.$($run.DestinationTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run.DestinationTable);
 IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run.SourceTable);
@@ -312,20 +281,19 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 Import-Module $psWriteOfficeModulePath -Global -Force -ErrorAction Stop
             }
 
+            Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropQuery -QueryTimeout 120 -ErrorAction Stop | Out-Null
+            if (Test-Path -LiteralPath $run.FilePath) {
+                Remove-Item -LiteralPath $run.FilePath -Force
+            }
+
             Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getCreateTableQuery -TableName $run.SourceTable) -QueryTimeout 120 -ErrorAction Stop | Out-Null
             Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query (& $getSeedQuery -TableName $run.SourceTable -RowCount ([int] $case.RowCount)) -QueryTimeout 120 -ErrorAction Stop | Out-Null
 
             if ($case.Engine -eq 'dbatools') {
-                $connectCommand = Get-Command Connect-DbaInstance -ErrorAction Stop
-                $parameters = @{
-                    SqlInstance = $run.Server
-                    Database = $run.Database
-                }
-                if ($connectCommand.Parameters.ContainsKey('TrustServerCertificate')) {
-                    $parameters.TrustServerCertificate = $true
-                }
-
-                $run.DbatoolsInstance = Connect-DbaInstance @parameters
+                $run.DbatoolsInstance = Connect-DbaInstance `
+                    -SqlInstance $run.Server `
+                    -Database $run.Database `
+                    -TrustServerCertificate
             }
         }
 
@@ -333,11 +301,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             param($case)
 
             if ($case.Engine -eq 'dbatools') {
-                if ($case.FileKind -notin @('Csv', 'CsvGZip', 'CsvTyped', 'CsvGZipTyped')) {
-                    return $true
-                }
-
-                return -not (& $testDbaToolsCsvCommands -RequireCompression:($case.FileKind -in @('CsvGZip', 'CsvGZipTyped')) -RequireTypeDetection:($case.FileKind -in @('CsvTyped', 'CsvGZipTyped')) -RequireColumnMapping:($case.ColumnShape -eq 'Mapped'))
+                return $case.FileKind -notin @('Csv', 'CsvGZip', 'CsvTyped', 'CsvGZipTyped')
             }
 
             return $false
@@ -500,19 +464,12 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                     Query = $run.SelectQuery
                     Path = $run.FilePath
                     Delimiter = ','
+                    QuotingBehavior = 'AsNeeded'
+                    EnableException = $true
                 }
-                $exportCommand = Get-Command Export-DbaCsv -ErrorAction Stop
-                if ($exportCommand.Parameters.ContainsKey('QuotingBehavior')) {
-                    $exportParameters.QuotingBehavior = 'Always'
-                }
-                if ($case.FileKind -in @('CsvGZip', 'CsvGZipTyped') -and $exportCommand.Parameters.ContainsKey('CompressionType')) {
+                if ($case.FileKind -in @('CsvGZip', 'CsvGZipTyped')) {
                     $exportParameters.CompressionType = 'GZip'
-                }
-                if ($case.FileKind -in @('CsvGZip', 'CsvGZipTyped') -and $exportCommand.Parameters.ContainsKey('CompressionLevel')) {
                     $exportParameters.CompressionLevel = 'Fastest'
-                }
-                if ($exportCommand.Parameters.ContainsKey('EnableException')) {
-                    $exportParameters.EnableException = $true
                 }
 
                 Export-DbaCsv @exportParameters | Out-Null
@@ -527,22 +484,17 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                     BatchSize = 5000
                     TableLock = $true
                     Delimiter = ','
+                    EnableException = $true
+                    NoProgress = $true
                 }
-                $importCommand = Get-Command Import-DbaCsv -ErrorAction Stop
                 $currentCultureName = [System.Globalization.CultureInfo]::CurrentCulture.Name
-                if ($importCommand.Parameters.ContainsKey('Culture') -and -not [string]::IsNullOrWhiteSpace($currentCultureName)) {
+                if (-not [string]::IsNullOrWhiteSpace($currentCultureName)) {
                     $importParameters.Culture = $currentCultureName
                 }
-                if ($importCommand.Parameters.ContainsKey('EnableException')) {
-                    $importParameters.EnableException = $true
-                }
-                if ($importCommand.Parameters.ContainsKey('NoProgress')) {
-                    $importParameters.NoProgress = $true
-                }
-                if ($case.FileKind -in @('CsvTyped', 'CsvGZipTyped') -and $importCommand.Parameters.ContainsKey('DetectColumnTypes')) {
+                if ($case.FileKind -in @('CsvTyped', 'CsvGZipTyped')) {
                     $importParameters.DetectColumnTypes = $true
                 }
-                if ($null -ne $run.ColumnMap -and $importCommand.Parameters.ContainsKey('ColumnMap')) {
+                if ($null -ne $run.ColumnMap) {
                     $importParameters.ColumnMap = $run.ColumnMap
                 }
 
@@ -652,7 +604,23 @@ if ($Plan) {
     $parameters.Plan = $true
 }
 
-$result = Invoke-BenchmarkSuite @parameters
+$originalCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+$originalUICulture = [System.Threading.Thread]::CurrentThread.CurrentUICulture
+$originalDefaultCulture = [System.Globalization.CultureInfo]::DefaultThreadCurrentCulture
+$originalDefaultUICulture = [System.Globalization.CultureInfo]::DefaultThreadCurrentUICulture
+$benchmarkCulture = [System.Globalization.CultureInfo]::InvariantCulture
+try {
+    [System.Threading.Thread]::CurrentThread.CurrentCulture = $benchmarkCulture
+    [System.Threading.Thread]::CurrentThread.CurrentUICulture = $benchmarkCulture
+    [System.Globalization.CultureInfo]::DefaultThreadCurrentCulture = $benchmarkCulture
+    [System.Globalization.CultureInfo]::DefaultThreadCurrentUICulture = $benchmarkCulture
+    $result = Invoke-BenchmarkSuite @parameters
+} finally {
+    [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
+    [System.Threading.Thread]::CurrentThread.CurrentUICulture = $originalUICulture
+    [System.Globalization.CultureInfo]::DefaultThreadCurrentCulture = $originalDefaultCulture
+    [System.Globalization.CultureInfo]::DefaultThreadCurrentUICulture = $originalDefaultUICulture
+}
 if ($Plan) {
     $result | ForEach-Object {
         [pscustomobject]@{

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -103,82 +103,6 @@ $settings = {
     $columnShapes = $ColumnShape
     $selectedEngines = if ($Engine) { $Engine } else { @('DbaClientX') }
 
-    function Test-DbaClientXOfficeCsvCommandAvailability {
-        param(
-            [string] $ModulePath,
-            [switch] $RequireCompression,
-            [switch] $RequireInferSchema
-        )
-
-        try {
-            $importedModule = Import-Module $ModulePath -Global -Force -PassThru -ErrorAction Stop
-        } catch {
-            Write-Warning "Skipping CSV office file benchmark lane because PSWriteOffice could not be imported from '$ModulePath': $($_.Exception.Message)"
-            return $false
-        }
-
-        $moduleNames = @($importedModule | ForEach-Object { $_.Name })
-        $exportCommand = Get-Command Export-OfficeCsv -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
-        $importCommand = Get-Command Import-OfficeCsv -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
-        if (-not $exportCommand -or -not $importCommand) {
-            Write-Warning "Skipping CSV office file benchmark lane because the imported PSWriteOffice module does not expose Export-OfficeCsv and Import-OfficeCsv."
-            return $false
-        }
-
-        if (-not @($importCommand | Where-Object { $_.Parameters.ContainsKey('AsDataReader') })) {
-            Write-Warning "Skipping CSV office file benchmark lane because Import-OfficeCsv does not expose -AsDataReader."
-            return $false
-        }
-
-        if ($RequireCompression.IsPresent -and
-            (-not @($exportCommand | Where-Object { $_.Parameters.ContainsKey('CompressionType') }) -or
-             -not @($importCommand | Where-Object { $_.Parameters.ContainsKey('CompressionType') }))) {
-            Write-Warning "Skipping compressed CSV office file benchmark lane because the imported PSWriteOffice module does not expose CSV compression parameters."
-            return $false
-        }
-
-        if ($RequireInferSchema.IsPresent -and -not @($importCommand | Where-Object { $_.Parameters.ContainsKey('InferSchema') })) {
-            Write-Warning "Skipping typed CSV office file benchmark lane because Import-OfficeCsv does not expose -InferSchema."
-            return $false
-        }
-
-        return $true
-    }
-
-    function Test-DbaClientXOfficeExcelCommandAvailability {
-        param(
-            [string] $ModulePath,
-            [switch] $RequireDataReader
-        )
-
-        try {
-            $importedModule = Import-Module $ModulePath -Global -Force -PassThru -ErrorAction Stop
-        } catch {
-            Write-Warning "Skipping Excel office file benchmark lane because PSWriteOffice could not be imported from '$ModulePath': $($_.Exception.Message)"
-            return $false
-        }
-
-        $moduleNames = @($importedModule | ForEach-Object { $_.Name })
-        $exportCommand = Get-Command Export-OfficeExcel -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
-        $importCommand = Get-Command Import-OfficeExcel -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
-        if (-not $exportCommand -or -not $importCommand) {
-            Write-Warning "Skipping Excel office file benchmark lane because the imported PSWriteOffice module does not expose Export-OfficeExcel and Import-OfficeExcel."
-            return $false
-        }
-
-        if (-not @($importCommand | Where-Object { $_.Parameters.ContainsKey('AsDataTable') })) {
-            Write-Warning "Skipping Excel office file benchmark lane because Import-OfficeExcel does not expose -AsDataTable."
-            return $false
-        }
-
-        if ($RequireDataReader.IsPresent -and -not @($importCommand | Where-Object { $_.Parameters.ContainsKey('AsDataReader') })) {
-            Write-Warning "Skipping Excel reader office file benchmark lane because Import-OfficeExcel does not expose -AsDataReader."
-            return $false
-        }
-
-        return $true
-    }
-
     function Test-DbaToolsCsvCommandAvailability {
         param(
             [switch] $RequireCompression,
@@ -194,17 +118,17 @@ $settings = {
         }
 
         if ($RequireCompression.IsPresent -and -not $exportCommand.Parameters.ContainsKey('CompressionType')) {
-            Write-Warning "Skipping compressed dbatools CSV benchmark lane because Export-DbaCsv does not expose -CompressionType."
+            Write-Warning "Skipping compressed dbatools CSV benchmark lane because the installed Export-DbaCsv command lacks -CompressionType."
             return $false
         }
 
         if ($RequireTypeDetection.IsPresent -and -not $importCommand.Parameters.ContainsKey('DetectColumnTypes')) {
-            Write-Warning "Skipping typed dbatools CSV benchmark lane because Import-DbaCsv does not expose -DetectColumnTypes."
+            Write-Warning "Skipping typed dbatools CSV benchmark lane because the installed Import-DbaCsv command lacks -DetectColumnTypes."
             return $false
         }
 
         if ($RequireColumnMapping.IsPresent -and -not $importCommand.Parameters.ContainsKey('ColumnMap')) {
-            Write-Warning "Skipping mapped-column dbatools CSV benchmark lane because Import-DbaCsv does not expose -ColumnMap."
+            Write-Warning "Skipping mapped-column dbatools CSV benchmark lane because the installed Import-DbaCsv command lacks -ColumnMap."
             return $false
         }
 
@@ -285,15 +209,44 @@ FROM numbers;
         }
     }
 
+    function Assert-DbaClientXOfficeBenchmarkTypedSchema {
+        param(
+            [string] $FileKind,
+            [string] $TableName,
+            [object[]] $Columns
+        )
+
+        $actualTypes = @{}
+        foreach ($column in @($Columns)) {
+            $actualTypes[[string] $column.ColumnName] = [string] $column.TypeName
+        }
+
+        $expectedTypes = [ordered] @{
+            Id = @('int')
+            DisplayName = @('nvarchar', 'varchar')
+            Score = @('decimal', 'numeric')
+            CreatedUtc = @('datetime2', 'datetime', 'datetimeoffset')
+        }
+
+        foreach ($entry in $expectedTypes.GetEnumerator()) {
+            if (-not $actualTypes.ContainsKey($entry.Key)) {
+                throw "$FileKind typed round trip did not create expected column '$($entry.Key)' in dbo.$TableName."
+            }
+
+            if ($actualTypes[$entry.Key] -notin $entry.Value) {
+                throw "$FileKind typed round trip created dbo.$TableName.$($entry.Key) as $($actualTypes[$entry.Key]); expected one of: $($entry.Value -join ', ')."
+            }
+        }
+    }
+
     $getCreateTableQuery = ${function:Get-DbaClientXOfficeBenchmarkCreateTableQuery}
     $getSeedQuery = ${function:Get-DbaClientXOfficeBenchmarkSeedQuery}
     $getExpectedIntegrity = ${function:Get-DbaClientXOfficeBenchmarkExpectedIntegrity}
     $assertIntegrity = ${function:Assert-DbaClientXOfficeBenchmarkIntegrity}
-    $testOfficeCsvCommands = ${function:Test-DbaClientXOfficeCsvCommandAvailability}
-    $testOfficeExcelCommands = ${function:Test-DbaClientXOfficeExcelCommandAvailability}
+    $assertTypedSchema = ${function:Assert-DbaClientXOfficeBenchmarkTypedSchema}
     $testDbaToolsCsvCommands = ${function:Test-DbaToolsCsvCommandAvailability}
     benchmark 'office-file-roundtrip' -out $outputRootBase {
-        policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
+        policy -Warmup $WarmupCount -Iterations $Iterations -Order Rotated -OutlierMode None
         profile Current -Cleanup KeepOnFailure
 
         caseSource {
@@ -387,11 +340,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 return -not (& $testDbaToolsCsvCommands -RequireCompression:($case.FileKind -in @('CsvGZip', 'CsvGZipTyped')) -RequireTypeDetection:($case.FileKind -in @('CsvTyped', 'CsvGZipTyped')) -RequireColumnMapping:($case.ColumnShape -eq 'Mapped'))
             }
 
-            if ($case.FileKind -in @('Csv', 'CsvGZip', 'CsvTyped', 'CsvGZipTyped')) {
-                return -not (& $testOfficeCsvCommands -ModulePath $psWriteOfficeModulePath -RequireCompression:($case.FileKind -in @('CsvGZip', 'CsvGZipTyped')) -RequireInferSchema:($case.FileKind -in @('CsvTyped', 'CsvGZipTyped')))
-            }
-
-            return -not (& $testOfficeExcelCommands -ModulePath $psWriteOfficeModulePath -RequireDataReader:($case.FileKind -in @('ExcelReader', 'ExcelReaderMapped')))
+            return $false
         }
 
         engine DbaClientX {
@@ -408,15 +357,6 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 }
 
                 if ($case.FileKind -in @('Csv', 'CsvGZip', 'CsvTyped', 'CsvGZipTyped')) {
-                    $data = Invoke-DbaXQuery `
-                        -Server $run.Server `
-                        -Database $run.Database `
-                        -TrustServerCertificate `
-                        -Query $query `
-                        -QueryTimeout 120 `
-                        -ReturnType DataTable `
-                        -ErrorAction Stop
-
                     $csvExportParameters = @{
                         Path = $run.FilePath
                         ErrorAction = 'Stop'
@@ -429,13 +369,40 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                     if ($case.FileKind -in @('CsvGZip', 'CsvGZipTyped')) {
                         $csvExportParameters.CompressionType = 'GZip'
                         $csvImportParameters.CompressionType = 'GZip'
+                        $csvExportParameters.CompressionLevel = 'Fastest'
                     }
                     if ($case.FileKind -in @('CsvTyped', 'CsvGZipTyped')) {
-                        $csvImportParameters.InferSchema = $true
-                        $csvImportParameters.SchemaSampleSize = [int] $case.RowCount
+                        $csvImportParameters.ColumnType = if ($case.ColumnShape -eq 'Mapped') {
+                            @{
+                                SourceId = [int]
+                                SourceDisplayName = [string]
+                                SourceScore = [decimal]
+                                SourceCreatedUtc = [datetime]
+                            }
+                        } else {
+                            @{
+                                Id = [int]
+                                DisplayName = [string]
+                                Score = [decimal]
+                                CreatedUtc = [datetime]
+                            }
+                        }
                     }
 
-                    $data | Export-OfficeCsv @csvExportParameters
+                    $client = [DBAClientX.SqlServer]::new()
+                    $reader = $null
+                    try {
+                        $client.CommandTimeout = 120
+                        $reader = $client.QueryReader($run.ConnectionString, $query)
+                        Export-OfficeCsv -InputObject $reader @csvExportParameters
+                    } finally {
+                        if ($null -ne $reader) {
+                            $reader.Dispose()
+                        }
+
+                        $client.Dispose()
+                    }
+
                     $imported = Import-OfficeCsv @csvImportParameters
                 } elseif ($case.FileKind -in @('ExcelReader', 'ExcelReaderMapped')) {
                     $connectionString = [DBAClientX.SqlServer]::BuildConnectionString(
@@ -468,11 +435,8 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                         Path = $run.FilePath
                         WorksheetName = 'Data'
                         AsDataReader = $true
+                        SchemaSampleSize = [int] $case.RowCount
                         ErrorAction = 'Stop'
-                    }
-                    $excelImportCommand = Get-Command Import-OfficeExcel -ErrorAction Stop
-                    if ($excelImportCommand.Parameters.ContainsKey('SchemaSampleSize')) {
-                        $excelImportParameters.SchemaSampleSize = [int] $case.RowCount
                     }
 
                     $imported = Import-OfficeExcel @excelImportParameters
@@ -501,7 +465,6 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                         BatchSize = 5000
                         BulkCopyTimeout = 120
                         TableLock = $true
-                        PassThru = $true
                         ErrorAction = 'Stop'
                     }
                     if ($null -ne $run.ColumnMap) {
@@ -516,8 +479,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                         }
                     }
 
-                    $writeResult = Write-DbaXTableData @writeParameters
-                    $run.RowsWritten = [int] $writeResult.Rows
+                    Write-DbaXTableData @writeParameters
                 } finally {
                     if ($imported -is [System.IDisposable]) {
                         $imported.Dispose()
@@ -547,7 +509,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                     $exportParameters.CompressionType = 'GZip'
                 }
                 if ($case.FileKind -in @('CsvGZip', 'CsvGZipTyped') -and $exportCommand.Parameters.ContainsKey('CompressionLevel')) {
-                    $exportParameters.CompressionLevel = 'Optimal'
+                    $exportParameters.CompressionLevel = 'Fastest'
                 }
                 if ($exportCommand.Parameters.ContainsKey('EnableException')) {
                     $exportParameters.EnableException = $true
@@ -609,6 +571,19 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             }
             $expected = & $getExpectedIntegrity -RowCount ([int] $case.RowCount)
             & $assertIntegrity -FileKind $case.FileKind -TableName $run.DestinationTable -Actual $actual -Expected $expected
+
+            if ($case.FileKind -in @('CsvTyped', 'CsvGZipTyped')) {
+                $schema = Invoke-DbaXQuery `
+                    -Server $run.Server `
+                    -Database $run.Database `
+                    -TrustServerCertificate `
+                    -Query "SELECT c.name AS ColumnName, ty.name AS TypeName FROM sys.columns c JOIN sys.types ty ON ty.user_type_id = c.user_type_id WHERE c.object_id = OBJECT_ID(N'dbo.$($run.DestinationTable)', N'U') ORDER BY c.column_id;" `
+                    -QueryTimeout 120 `
+                    -ReturnType PSObject `
+                    -ErrorAction Stop
+
+                & $assertTypedSchema -FileKind $case.FileKind -TableName $run.DestinationTable -Columns @($schema)
+            }
 
             if ($null -ne $run.RowsWritten -and $run.RowsWritten -ne [int] $case.RowCount) {
                 throw "$($case.FileKind) round trip wrote $($run.RowsWritten) of $($case.RowCount) expected row(s)."

--- a/Module/Examples/Benchmark.SqlServerCsvExport.ps1
+++ b/Module/Examples/Benchmark.SqlServerCsvExport.ps1
@@ -98,21 +98,6 @@ $settings = {
     $keepArtifacts = $KeepArtifacts.IsPresent
     $rowCounts = $RowCount
 
-    function Test-DbaClientXCsvExportCommands {
-        param([string] $ModulePath)
-
-        try {
-            $importedModule = Import-Module $ModulePath -Global -Force -PassThru -ErrorAction Stop
-        } catch {
-            Write-Warning "Skipping DbaClientX CSV export lane because PSWriteOffice could not be imported from '$ModulePath': $($_.Exception.Message)"
-            return $false
-        }
-
-        $moduleNames = @($importedModule | ForEach-Object { $_.Name })
-        $exportCommand = Get-Command Export-OfficeCsv -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
-        return [bool] $exportCommand
-    }
-
     function Test-DbaToolsExportCommand {
         $connectCommand = Get-Command Connect-DbaInstance -ErrorAction SilentlyContinue
         $exportCommand = Get-Command Export-DbaCsv -ErrorAction SilentlyContinue
@@ -239,7 +224,6 @@ FROM numbers;
         }
     }
 
-    $testOfficeCsvCommands = ${function:Test-DbaClientXCsvExportCommands}
     $testDbaToolsExportCommand = ${function:Test-DbaToolsExportCommand}
     $testBcpCommand = ${function:Test-BcpCommand}
     $testThreadJobCommand = ${function:Test-ThreadJobCommand}
@@ -335,7 +319,7 @@ ORDER BY Id;
                     return $true
                 }
 
-                return -not (& $testOfficeCsvCommands -ModulePath $psWriteOfficeModulePath)
+                return $false
             }
 
             if ($case.Engine -eq 'dbatools') {

--- a/Module/Examples/Example.CsvRoundTrip.ps1
+++ b/Module/Examples/Example.CsvRoundTrip.ps1
@@ -16,26 +16,11 @@ param(
 # Example:
 #   .\Example.CsvRoundTrip.ps1 -Server localhost -Database tempdb -RowCount 100 -KeepArtifacts
 
-if (-not (Get-Command Invoke-DbaXQuery -ErrorAction SilentlyContinue)) {
-    Import-Module DbaClientX -ErrorAction Stop
-}
-if (-not (Get-Command Export-OfficeCsv -ErrorAction SilentlyContinue)) {
-    Import-Module PSWriteOffice -ErrorAction Stop
-}
+Import-Module DbaClientX -ErrorAction Stop
+Import-Module PSWriteOffice -ErrorAction Stop
 
 if ($RowCount -lt 1) {
     throw 'RowCount must be greater than zero.'
-}
-
-$exportOfficeCsv = Get-Command Export-OfficeCsv -ErrorAction SilentlyContinue
-$importOfficeCsv = Get-Command Import-OfficeCsv -ErrorAction SilentlyContinue
-if (-not $exportOfficeCsv -or -not @($importOfficeCsv | Where-Object { $_.Parameters.ContainsKey('AsDataReader') -and $_.Parameters.ContainsKey('InferSchema') })) {
-    throw 'This CSV round-trip example requires PSWriteOffice with Export-OfficeCsv and Import-OfficeCsv -AsDataReader -InferSchema. Import or install a compatible PSWriteOffice build before running the example.'
-}
-if ($CompressionType -ne 'Auto' -and
-    (-not $exportOfficeCsv.Parameters.ContainsKey('CompressionType') -or
-     -not $importOfficeCsv.Parameters.ContainsKey('CompressionType'))) {
-    throw 'This compressed CSV round-trip requires PSWriteOffice with Export-OfficeCsv -CompressionType and Import-OfficeCsv -CompressionType.'
 }
 
 $connectionString = "Server=$Server;Database=$Database;Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
@@ -69,16 +54,6 @@ FROM numbers;
 "@ -ErrorAction Stop | Out-Null
 
 try {
-    $rows = @(
-        Invoke-DbaXQuery `
-            -Server $Server `
-            -Database $Database `
-            -TrustServerCertificate `
-            -Query "SELECT Id, DisplayName, Score, CreatedUtc FROM $SourceTable ORDER BY Id;" `
-            -ReturnType PSObject `
-            -ErrorAction Stop
-    )
-
     if (Test-Path -LiteralPath $CsvPath) {
         Remove-Item -LiteralPath $CsvPath -Force
     }
@@ -90,9 +65,12 @@ try {
     $csvImportParameters = @{
         Path = $CsvPath
         AsDataReader = $true
-        InferSchema = $true
-        SchemaSampleSize = $RowCount
-        ProgressInterval = 50000
+        ColumnType = @{
+            Id = [int]
+            DisplayName = [string]
+            Score = [decimal]
+            CreatedUtc = [datetime]
+        }
         ParseErrorAction = 'Throw'
         ErrorAction = 'Stop'
     }
@@ -101,7 +79,18 @@ try {
         $csvImportParameters.CompressionType = $CompressionType
     }
 
-    $rows | Export-OfficeCsv @csvExportParameters | Out-Null
+    $client = [DBAClientX.SqlServer]::new()
+    $sqlReader = $null
+    try {
+        $sqlReader = $client.QueryReader($connectionString, "SELECT Id, DisplayName, Score, CreatedUtc FROM $SourceTable ORDER BY Id;")
+        Export-OfficeCsv -InputObject $sqlReader @csvExportParameters | Out-Null
+    } finally {
+        if ($null -ne $sqlReader) {
+            $sqlReader.Dispose()
+        }
+
+        $client.Dispose()
+    }
 
     $csvReader = $null
     try {
@@ -133,13 +122,12 @@ try {
     $sourceRows = [int] $verification.Tables[0].Rows[0]['SourceRows']
     $destinationRows = [int] $verification.Tables[1].Rows[0]['DestinationRows']
 
-    $hasMismatch = $rows.Count -ne $RowCount -or
-        $writeResult.Rows -ne $RowCount -or
+    $hasMismatch = $writeResult.Rows -ne $RowCount -or
         $sourceRows -ne $RowCount -or
         $destinationRows -ne $RowCount
 
     if ($hasMismatch) {
-        throw "Round-trip row count mismatch. Exported=$($rows.Count), Written=$($writeResult.Rows), Source=$sourceRows, Destination=$destinationRows, Expected=$RowCount."
+        throw "Round-trip row count mismatch. Written=$($writeResult.Rows), Source=$sourceRows, Destination=$destinationRows, Expected=$RowCount."
     }
 
     [pscustomobject]@{
@@ -149,7 +137,7 @@ try {
         CompressionType = $CompressionType
         SourceTable = $SourceTable
         DestinationTable = $DestinationTable
-        ExportedRows = $rows.Count
+        ExportedRows = $sourceRows
         ImportedRows = $writeResult.Rows
         WrittenRows = $writeResult.Rows
         SourceRows = $sourceRows

--- a/Module/Examples/Example.ExcelRoundTrip.ps1
+++ b/Module/Examples/Example.ExcelRoundTrip.ps1
@@ -12,13 +12,12 @@ param(
 
 # Use this example to prove the SQL Server -> Excel -> SQL Server workflow:
 # DbaClientX reads source rows, PSWriteOffice writes and reads the workbook,
-# and DbaClientX streams the imported Excel reader back to SQL Server when
-# the installed PSWriteOffice build exposes the reader surface.
+# and DbaClientX streams the imported Excel reader back to SQL Server.
 # Example:
 #   .\Example.ExcelRoundTrip.ps1 -Server localhost -Database tempdb -RowCount 100 -KeepArtifacts
 
-Import-Module DbaClientX -Force
-Import-Module PSWriteOffice -Force
+Import-Module DbaClientX -Force -ErrorAction Stop
+Import-Module PSWriteOffice -Force -ErrorAction Stop
 
 if ($RowCount -lt 1) {
     throw 'RowCount must be greater than zero.'
@@ -26,10 +25,6 @@ if ($RowCount -lt 1) {
 if ($QueryTimeout -lt 0) {
     throw 'QueryTimeout cannot be negative.'
 }
-
-$importOfficeExcel = Get-Command Import-OfficeExcel -All -ErrorAction SilentlyContinue |
-    Where-Object { $_.ModuleName -eq 'PSWriteOffice' }
-$canImportExcelAsDataReader = @($importOfficeExcel | Where-Object { $_.Parameters.ContainsKey('AsDataReader') }).Count -gt 0
 
 $connectionString = "Server=$Server;Database=$Database;Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
 
@@ -86,20 +81,11 @@ try {
         $client.Dispose()
     }
 
-    $importedExcel = if ($canImportExcelAsDataReader) {
-        Import-OfficeExcel `
-            -Path $ExcelPath `
-            -WorksheetName $WorksheetName `
-            -AsDataReader `
-            -ErrorAction Stop
-    } else {
-        Write-Warning 'Import-OfficeExcel does not expose -AsDataReader in the installed PSWriteOffice module; falling back to -AsDataTable for this example.'
-        Import-OfficeExcel `
-            -Path $ExcelPath `
-            -WorksheetName $WorksheetName `
-            -AsDataTable `
-            -ErrorAction Stop
-    }
+    $importedExcel = Import-OfficeExcel `
+        -Path $ExcelPath `
+        -WorksheetName $WorksheetName `
+        -AsDataReader `
+        -ErrorAction Stop
 
     try {
         $inputObject = if ($importedExcel -is [System.Data.IDataReader]) { (, $importedExcel) } else { $importedExcel }

--- a/Module/Tests/CmdletWriteDbaXTableData.Tests.ps1
+++ b/Module/Tests/CmdletWriteDbaXTableData.Tests.ps1
@@ -122,6 +122,8 @@ public sealed class DbaXTestDataReader : IDataReader
 
     public int FieldCount { get { return _names.Length; } }
 
+    public int SchemaTableCallCount { get; private set; }
+
     public void Close() { _closed = true; }
 
     public void Dispose() { Close(); }
@@ -175,6 +177,7 @@ public sealed class DbaXTestDataReader : IDataReader
 
     public DataTable GetSchemaTable()
     {
+        SchemaTableCallCount++;
         var schema = new DataTable();
         schema.Columns.Add("ColumnName", typeof(string));
         schema.Columns.Add("ColumnOrdinal", typeof(int));
@@ -319,6 +322,8 @@ describe 'Write-DbaXTableData cmdlet' {
         $script:lastReaderInsert = $null
         $prop.SetValue($null, [scriptblock]{
             param($cmdlet, $reader, $options)
+            $null = $reader.GetSchemaTable()
+            $null = $reader.GetSchemaTable()
             $rows = 0
             $firstName = $null
             while ($reader.Read()) {
@@ -370,9 +375,43 @@ describe 'Write-DbaXTableData cmdlet' {
             $script:lastReaderInsert.FirstName | Should -Be 'Alpha'
             $script:lastReaderInsert.MappedName | Should -Be 'DisplayName'
             $result.Rows | Should -Be 2
+            $reader.SchemaTableCallCount | Should -Be 1
         } finally {
             $prop.SetValue($null, $orig)
             $script:lastReaderInsert = $null
+        }
+    }
+
+    it 'streams single SQL Server IDataReader input without counting wrapper when PassThru is not requested' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletWriteDbaXTableData].GetProperty('BulkInsertOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $script:lastReaderType = $null
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $reader, $options)
+            $script:lastReaderType = $reader.GetType().FullName
+            while ($reader.Read()) { }
+        })
+
+        try {
+            $reader = [DbaXTestDataReader]::new(
+                [string[]]@('Id', 'Name'),
+                [type[]]@([int], [string]),
+                [object[][]]@(
+                    [object[]]@(1, 'Alpha'),
+                    [object[]]@(2, 'Beta')
+                ))
+
+            Write-DbaXTableData `
+                -Provider SqlServer `
+                -ConnectionString 'Server=s;Database=db;Encrypt=True' `
+                -DestinationTable dbo.Import `
+                -InputObject (, $reader)
+
+            $script:lastReaderType | Should -Be 'DbaXTestDataReader'
+        } finally {
+            $prop.SetValue($null, $orig)
+            $script:lastReaderType = $null
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -385,8 +385,8 @@ and artifact details are in [SQL Server benchmark notes](docs/sqlserver-benchmar
 | --- | --- | --- | --- | ---: | ---: | --- |
 | 100000 rows / Csv | ColumnShape=Default, FileKind=Csv, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (639ms) | 4.07x (2.60s) | DbaClientX fastest |
 | 100000 rows / CsvGZip | ColumnShape=Default, FileKind=CsvGZip, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (658ms) | 3.99x (2.63s) | DbaClientX fastest |
-| 100000 rows / CsvGZipTyped | ColumnShape=Default, FileKind=CsvGZipTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (359ms) | 0.80x (287ms) | DbaClientX slower than dbatools |
-| 100000 rows / CsvTyped | ColumnShape=Default, FileKind=CsvTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (358ms) | 0.89x (319ms) | DbaClientX slower than dbatools |
+| 100000 rows / CsvGZipTyped | ColumnShape=Default, FileKind=CsvGZipTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (561ms) | 1.10x (614ms) | DbaClientX fastest |
+| 100000 rows / CsvTyped | ColumnShape=Default, FileKind=CsvTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (567ms) | 1.18x (671ms) | DbaClientX fastest |
 | 100000 rows / CsvTyped / Mapped columns | ColumnShape=Mapped, FileKind=CsvTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (282ms) | 1.92x (541ms) | DbaClientX fastest |
 <!-- office-file-roundtrip-benchmark:end -->
 

--- a/README.md
+++ b/README.md
@@ -327,35 +327,10 @@ Invoke-DbaXTransaction -Server 'sql01' -Database 'App' -ScriptBlock {
 
 Transaction helpers honor `-WhatIf` and `-Confirm`, commit when the script block succeeds, roll back on failure, and dispose the provider client in `finally`.
 
-## SQL Server Benchmark Snapshot
+## SQL Server Benchmarks
 
-Use the SQL Server data-movement benchmark when you want repeatable local evidence for import performance. The benchmark uses the PSPublishModule/PowerForge runner for timing, warmups, rotated ordering, comparison tables, README block updates, and JSON/CSV/Markdown artifacts.
-
-```powershell
-Install-Module PSPublishModule -MinimumVersion 3.0.44 -Scope CurrentUser
-
-.\Module\Examples\Benchmark.SqlServerDataMovement.ps1 `
-    -Server localhost `
-    -Database tempdb `
-    -RowCount 1000, 5000, 20000, 100000 `
-    -BatchSize 5000 `
-    -InputKind DataTable, DataReader, PSCustomObject, Class `
-    -Iterations 3
-```
-
-The suite benchmarks SQL Server writes and reads separately. The write suite covers DbaClientX across `DataTable`, `DataReader`, `PSCustomObject`, and typed class input shapes, and adds dbatools and SqlServer module lanes only when `Write-DbaDbTableData` or `Write-SqlTableData` are available. The `DataReader` lane is DbaClientX-only because it measures the public streaming path into `SqlBulkCopy`; dbatools and native SqlServer module comparisons remain on their documented client-side input shapes. The dbatools `DataTable` write lane uses a direct value passed to `-InputObject` so it stays on the documented SqlBulkCopy fast path instead of the slower piped-`DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import.
-
-The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery` with dbatools `Invoke-DbaQuery` when dbatools is available. By default it reads every row as both `DataTable` and PowerShell-object output; `DataSet` can be selected with `-ReadShape DataSetAll` for local diagnosis. Successful lanes verify row counts plus simple data integrity (`Id` min/max/sum and `Score` sum) before dropping their isolated tables; failed lanes leave their table behind for inspection.
-
-By default the wrapper imports the installed `DbaClientX` module. Use `-ModulePath`, `$env:DBACLIENTX_BENCHMARK_MODULE_PATH`, or `$env:DBACLIENTX_DEVELOPMENT_PATH` when benchmarking a local source build.
-
-The checked-in snapshot below uses `DataTable`, `DataReader`, `PSCustomObject`, and typed class write input plus full-result `DataTable` and `PSObject` reads at 1k, 5k, 20k, and 100k rows. Pass additional `-ReadShape` values for a broader local read matrix.
-
-The suite rewrites the marker-delimited tables below when it runs from a source checkout. Artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement\Write` and `Ignore\Benchmarks\SqlServerDataMovement\Read`, which are intentionally ignored by Git. To inspect the matrix without touching SQL Server:
-
-```powershell
-.\Module\Examples\Benchmark.SqlServerDataMovement.ps1 -Plan
-```
+Current workstation timings are below. Commands, measured operations, validation,
+and artifact details are in [SQL Server benchmark notes](docs/sqlserver-benchmark-notes.md).
 
 ### Write Benchmark
 
@@ -395,35 +370,7 @@ The suite rewrites the marker-delimited tables below when it runs from a source 
 | 5000 rows / PSObjectAll | ReadShape=PSObjectAll, RowCount=5000 | Core-7.6.3 | Read | 1.00x (17ms) | 2.90x (51ms) | Skipped | DbaClientX fastest |
 <!-- sqlserver-data-movement-read-benchmark:end -->
 
-Treat benchmark numbers as workstation evidence, not universal rankings. SQL Server version, storage, TLS, table indexes, triggers, recovery model, batch size, and client runtime can dominate the result; rerun the suite in the environment that matters.
-
-## SQL Server CSV Export Benchmark
-
-Use the CSV export benchmark when you want the export-only timing view: SQL
-Server rows out to a CSV file, without importing the file back into a table.
-
-```powershell
-.\Module\Examples\Benchmark.SqlServerCsvExport.ps1 `
-    -Server localhost `
-    -Database tempdb `
-    -RowCount 100000 `
-    -Engine DbaClientX,DbaClientXReader,DbaClientXStream,DbaClientXPartitionedReader,dbatools,bcp,FastBCP `
-    -DbaClientXPartitionDegree 4 `
-    -Iterations 3 `
-    -UpdateReadme
-```
-
-Current signal: the direct DbaClientX reader plus PSWriteOffice CSV writer is
-the fastest checked-in lane.
-
-Inspect the matrix without touching SQL Server:
-
-```powershell
-.\Module\Examples\Benchmark.SqlServerCsvExport.ps1 -Plan
-```
-
-The table below is the timing snapshot to watch. `bcp`, dbatools, and FastBCP
-are comparison lanes; DbaClientX and PSWriteOffice are the product lanes.
+## SQL Server CSV Export
 
 <!-- sqlserver-csv-export-benchmark:start -->
 | Scenario | Variables | Host | Operation | DbaClientXReader | bcp | DbaClientX | DbaClientXStream | dbatools | FastBCP | Result |
@@ -431,80 +378,16 @@ are comparison lanes; DbaClientX and PSWriteOffice are the product lanes.
 | 100000 rows / CSV export | RowCount=100000 | Core-7.6.3 | Export | 1.00x (65ms) | 4.17x (273ms) | 6.69x (437ms) | 5.25x (343ms) | 1.58x (103ms) | Skipped | DbaClientXReader fastest |
 <!-- sqlserver-csv-export-benchmark:end -->
 
-## Office File Round-Trip Benchmark
-
-Use the office file round-trip benchmark when you want timing evidence for the
-combined DbaClientX and PSWriteOffice workflow: SQL Server to CSV, compressed
-CSV, or Excel, then back into SQL Server.
-
-```powershell
-.\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
-    -Server localhost `
-    -Database tempdb `
-    -RowCount 1000,5000 `
-    -FileKind Csv,CsvGZip,Excel,ExcelReader,ExcelReaderMapped `
-    -ColumnShape Default `
-    -Iterations 3
-```
-
-Use the apples-to-apples CSV comparison when checking the same kind of lane dbatools publishes for its CSV library:
-
-```powershell
-.\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
-    -Server localhost `
-    -Database tempdb `
-    -RowCount 100000 `
-    -FileKind Csv,CsvGZip,CsvTyped,CsvGZipTyped `
-    -ColumnShape Default,Mapped `
-    -Engine DbaClientX,dbatools `
-    -WarmupCount 3 `
-    -Iterations 10
-```
-
-The default engine is `DbaClientX`. Add dbatools when you want the CSV-to-SQL
-comparison. Excel lanes use DbaClientX + PSWriteOffice. Typed CSV lanes use the
-production shape we want: DbaClientX carries known SQL column types into `Import-OfficeCsv -ColumnType`,
-while dbatools uses `Import-DbaCsv -DetectColumnTypes`. Typed lanes also
-validate the destination SQL schema, so a run only counts as typed when `Id`,
-`Score`, and `CreatedUtc` land as typed SQL columns.
-
-```powershell
-.\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
-    -Server localhost `
-    -Database tempdb `
-    -RowCount 1000,5000 `
-    -FileKind Csv,CsvGZip,CsvTyped,CsvGZipTyped `
-    -ColumnShape Default,Mapped `
-    -Engine DbaClientX,dbatools `
-    -WarmupCount 3 `
-    -Iterations 10 `
-    -UpdateReadme
-```
-
-By default the wrapper imports installed `DbaClientX` and `PSWriteOffice`
-modules. For local source builds, pass `-ModulePath`,
-`$env:DBACLIENTX_BENCHMARK_MODULE_PATH`, `-PSWriteOfficeModulePath`, or
-`$env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH`.
-
-To inspect the matrix without touching SQL Server:
-
-```powershell
-.\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 -Plan
-```
-
-The benchmark commands expect matching DbaClientX, PSWriteOffice, and OfficeIMO
-packages.
+## Office File Round Trip
 
 <!-- office-file-roundtrip-benchmark:start -->
 | Scenario | Variables | Host | Operation | DbaClientX | dbatools | Result |
 | --- | --- | --- | --- | ---: | ---: | --- |
-| 100000 rows / Csv | ColumnShape=Default, FileKind=Csv, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (661ms) | 4.04x (2.67s) | DbaClientX fastest |
-| 100000 rows / CsvGZip | ColumnShape=Default, FileKind=CsvGZip, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (660ms) | 4.06x (2.68s) | DbaClientX fastest |
-| 100000 rows / CsvTyped | ColumnShape=Default, FileKind=CsvTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 382ms | Not comparable | DbaClientX creates typed SQL columns |
-| 100000 rows / CsvGZipTyped | ColumnShape=Default, FileKind=CsvGZipTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 385ms | Not comparable | dbatools creates `Score` as text under this contract |
+| 100000 rows / Csv | ColumnShape=Default, FileKind=Csv, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (639ms) | 4.07x (2.60s) | DbaClientX fastest |
+| 100000 rows / CsvGZip | ColumnShape=Default, FileKind=CsvGZip, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (658ms) | 3.99x (2.63s) | DbaClientX fastest |
+| 100000 rows / CsvGZipTyped | ColumnShape=Default, FileKind=CsvGZipTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (359ms) | 0.80x (287ms) | DbaClientX slower than dbatools |
+| 100000 rows / CsvTyped | ColumnShape=Default, FileKind=CsvTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (353ms) | 0.76x (268ms) | DbaClientX slower than dbatools |
 <!-- office-file-roundtrip-benchmark:end -->
-
-The checked-in snapshot above comes from local SQL Server runs with three warmups, fifteen measured iterations for the 100k-row comparison lanes, row-count validation, integrity checks for `IdSum` and `ScoreSum`, and typed-schema validation for typed lanes. DbaClientX + PSWriteOffice is about 4x faster for default CSV and compressed CSV round trips. Typed CSV is shown as a DbaClientX timing because the dbatools typed lane does not create the same SQL schema for this data shape.
 
 ## .NET Usage
 

--- a/README.md
+++ b/README.md
@@ -386,7 +386,8 @@ and artifact details are in [SQL Server benchmark notes](docs/sqlserver-benchmar
 | 100000 rows / Csv | ColumnShape=Default, FileKind=Csv, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (639ms) | 4.07x (2.60s) | DbaClientX fastest |
 | 100000 rows / CsvGZip | ColumnShape=Default, FileKind=CsvGZip, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (658ms) | 3.99x (2.63s) | DbaClientX fastest |
 | 100000 rows / CsvGZipTyped | ColumnShape=Default, FileKind=CsvGZipTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (359ms) | 0.80x (287ms) | DbaClientX slower than dbatools |
-| 100000 rows / CsvTyped | ColumnShape=Default, FileKind=CsvTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (353ms) | 0.76x (268ms) | DbaClientX slower than dbatools |
+| 100000 rows / CsvTyped | ColumnShape=Default, FileKind=CsvTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (358ms) | 0.89x (319ms) | DbaClientX slower than dbatools |
+| 100000 rows / CsvTyped / Mapped columns | ColumnShape=Mapped, FileKind=CsvTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (282ms) | 1.92x (541ms) | DbaClientX fastest |
 <!-- office-file-roundtrip-benchmark:end -->
 
 ## .NET Usage

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ DbaClientX is a lightweight database client for .NET and PowerShell. It keeps th
 
 ## What it's all about
 
-DbaClientX is meant to be the thin, reusable database layer behind higher-level tooling. It owns provider connections, query execution, transactions, metadata, and bulk-copy behavior. PSWriteOffice and OfficeIMO own CSV and Excel parsing, writing, compression, and file-format rules. Together they form the intended file/database pair: PSWriteOffice shapes rows from files, DbaClientX moves those rows into or out of databases, and the boundary stays a normal `DataTable`, `IDataReader`, or object stream.
+DbaClientX provides provider connections, query execution, transactions, metadata, and bulk-copy commands for scripts and .NET code. It works with normal tabular inputs such as `DataTable`, `DataView`, `IDataReader`, `DataRow`, hashtables, regular objects, and rows imported from CSV or Excel with PSWriteOffice.
 
 The PowerShell module stays small and operator-friendly; the heavy database logic remains in C#. That keeps user scripts clean without forcing people to pick low-level parser settings just to get good performance.
 
@@ -61,16 +61,18 @@ Use it when you need:
 
 Start with the job you need to finish:
 
-| You need to... | Use this | Keep this owner boundary |
+| You need to... | Use this | Notes |
 | --- | --- | --- |
-| Write PowerShell objects, `DataTable`, `DataView`, `IDataReader`, or Excel-imported rows to a table | `Write-DbaXTableData` | DbaClientX provider packages own the database write |
+| Write PowerShell objects, `DataTable`, `DataView`, `IDataReader`, or Excel-imported rows to a table | `Write-DbaXTableData` | Uses provider-native database writes |
 | Load a SQL Server staging table and let the command create the table, map columns, lock the table, preserve identities/nulls, fire triggers, check constraints, or report progress | `Write-DbaXTableData -Provider SqlServer` | SQL Server-specific knobs map to `SqlServerBulkInsertOptions` |
-| Copy one or more tables between database providers | `Copy-DbaXTableData` | `DBAClientX.Core` owns the copy contracts/runner; provider packages own concrete adapters |
-| Export SQL rows to CSV, compressed CSV, or Excel | `SqlServer.QueryReader(...)` or `Invoke-DbaXQuery -ReturnType DataTable` plus PSWriteOffice `Export-OfficeCsv` / `Export-OfficeExcel` | DbaClientX owns the database read; PSWriteOffice/OfficeIMO owns file writing |
-| Import CSV, compressed CSV, or Excel into SQL Server | PSWriteOffice `Import-OfficeCsv -AsDataReader` / `Import-OfficeExcel -AsDataReader` plus `Write-DbaXTableData` | PSWriteOffice/OfficeIMO owns file parsing; DbaClientX owns the database write |
-| Stream a reader into SQL Server bulk copy | `Write-DbaXTableData -Provider SqlServer -InputObject (, $reader)` | The producer owns the reader; DbaClientX streams it into `SqlBulkCopy` |
+| Copy one or more tables between database providers | `Copy-DbaXTableData` | Uses reusable copy definitions plus provider adapters |
+| Export SQL rows to CSV, compressed CSV, or Excel | `SqlServer.QueryReader(...)` or `Invoke-DbaXQuery -ReturnType DataTable` plus PSWriteOffice `Export-OfficeCsv` / `Export-OfficeExcel` | Streams or buffers database rows into the file writer |
+| Import CSV, compressed CSV, or Excel into SQL Server | PSWriteOffice `Import-OfficeCsv -AsDataReader` / `Import-OfficeExcel -AsDataReader` plus `Write-DbaXTableData` | Reads the file as tabular data, then bulk-writes it |
+| Stream a reader into SQL Server bulk copy | `Write-DbaXTableData -Provider SqlServer -InputObject (, $reader)` | Pass the reader as a single input object with `, $reader` |
 
-The CSV round-trip path requires a PSWriteOffice build that exposes `Export-OfficeCsv` and `Import-OfficeCsv -AsDataReader`. The streaming Excel-to-SQL path requires `Import-OfficeExcel -AsDataReader`, backed by OfficeIMO.Excel. When those surfaces are not available in the installed module, pass `-PSWriteOfficeModulePath` to a compatible local PSWriteOffice build.
+CSV and Excel round trips use matching DbaClientX, PSWriteOffice, and OfficeIMO
+packages. Use `-PSWriteOfficeModulePath` only when validating a local
+PSWriteOffice build.
 
 The PowerShell layer is intentionally thin: it maps friendly parameters to provider-owned C# APIs. Put repeatable database behavior in DbaClientX and keep consumer scripts focused on choosing source data, destination names, and credentials.
 
@@ -274,7 +276,7 @@ Run the full SQL Server -> file -> SQL Server examples when you want to prove bo
 .\Module\Examples\Example.ExcelRoundTrip.ps1 -Server localhost -Database tempdb -RowCount 100 -KeepArtifacts
 ```
 
-The examples create SQL Server source rows, export them to a `.csv` or `.xlsx` file with PSWriteOffice, import the file back as a streaming reader when the installed PSWriteOffice build supports it, write to SQL Server with `-AutoCreateTable`, and fail if any row count does not match.
+The examples create SQL Server source rows, export them to a `.csv` or `.xlsx` file with PSWriteOffice, import the file back as a streaming reader, write to SQL Server with `-AutoCreateTable`, and fail if any row count does not match.
 
 When another library already gives you an `IDataReader`, pass the reader as one object so the SQL Server path stays streaming:
 
@@ -327,7 +329,7 @@ Transaction helpers honor `-WhatIf` and `-Confirm`, commit when the script block
 
 ## SQL Server Benchmark Snapshot
 
-Use the SQL Server data-movement benchmark when you want repeatable local evidence for import performance. The benchmark is a PSPublishModule/PowerForge suite: DbaClientX only declares scenarios, provider engines, validation, and the README target; the shared benchmark runner owns timing, warmups, rotated ordering, comparison tables, README block updates, and JSON/CSV/Markdown artifacts.
+Use the SQL Server data-movement benchmark when you want repeatable local evidence for import performance. The benchmark uses the PSPublishModule/PowerForge runner for timing, warmups, rotated ordering, comparison tables, README block updates, and JSON/CSV/Markdown artifacts.
 
 ```powershell
 Install-Module PSPublishModule -MinimumVersion 3.0.44 -Scope CurrentUser
@@ -397,7 +399,8 @@ Treat benchmark numbers as workstation evidence, not universal rankings. SQL Ser
 
 ## SQL Server CSV Export Benchmark
 
-Use the CSV export benchmark when you want the ARPE-style export-only view: SQL Server rows out to a CSV file, without importing the file back into a table. This is intentionally separate from the round-trip benchmark, because native `bcp` is an export/import utility and does not measure the same PowerShell object or `DataTable` handoff work.
+Use the CSV export benchmark when you want the export-only timing view: SQL
+Server rows out to a CSV file, without importing the file back into a table.
 
 ```powershell
 .\Module\Examples\Benchmark.SqlServerCsvExport.ps1 `
@@ -410,7 +413,8 @@ Use the CSV export benchmark when you want the ARPE-style export-only view: SQL 
     -UpdateReadme
 ```
 
-The DbaClientX lane reads with `Invoke-DbaXQuery -ReturnType DataTable` and writes with PSWriteOffice `Export-OfficeCsv -NoHeader`. `DbaClientXReader` opens a DbaClientX-owned SQL Server `IDataReader` and writes it directly with `Export-OfficeCsv`, avoiding `DataTable` and `DataRow` materialization. `DbaClientXStream` uses the existing public stream shape, `Invoke-DbaXQuery -Stream -ReturnType DataRow`, then writes the streamed rows with `Export-OfficeCsv`. `DbaClientXPartitionedReader` is the in-repo split-file lane: it partitions the SQL Server source with `NTILE` over `Id`, opens one DbaClientX reader per partition, and lets PSWriteOffice write each partition as a CSV file. The dbatools lane uses `Export-DbaCsv`. The native lane uses `bcp queryout` with character mode, comma field terminators, LF row terminators, UTF-8 code page, and trusted authentication. The optional FastBCP lane uses the documented SQL Server table export shape with `--connectiontype mssql`, trusted authentication, UTF-8 CSV output, `--parallelmethod Ntile`, `--distributekeycolumn Id`, `--paralleldegree -2`, and split-file output. Successful lanes validate data-row count plus `Id` min/max/sum integrity and file size before cleanup.
+Current signal: the direct DbaClientX reader plus PSWriteOffice CSV writer is
+the fastest checked-in lane.
 
 Inspect the matrix without touching SQL Server:
 
@@ -418,9 +422,8 @@ Inspect the matrix without touching SQL Server:
 .\Module\Examples\Benchmark.SqlServerCsvExport.ps1 -Plan
 ```
 
-The benchmark skips unavailable optional engines. `bcp` must be on `PATH`, dbatools must expose `Connect-DbaInstance` and `Export-DbaCsv`, and the DbaClientX lanes require PSWriteOffice with `Export-OfficeCsv`. `DbaClientXPartitionedReader` also requires `Start-ThreadJob`; use `-DbaClientXPartitionDegree` to set the split count, or leave it at `0` to use the current processor count. FastBCP must be on `PATH`, passed through `-FastBcpPath`, or provided through `$env:FASTBCP_PATH`; use `-FastBcpParallelMethod` and `-FastBcpParallelDegree` to change the FastBCP partitioning mode.
-
-The ARPE/FastBCP comparison is useful because it separates export-only throughput from a full file/database round trip. This benchmark covers the same local SQL Server to CSV shape for DbaClientX + PSWriteOffice, dbatools `Export-DbaCsv`, native `bcp queryout`, an in-repo DbaClientX partitioned split-file lane, and FastBCP when the executable is locally available. The current snapshot shows the direct DbaClientX reader path ahead of dbatools and `bcp`; the older `DataTable` and `DataRow` lanes remain slower because they measure materialization and PowerShell row-shaping overhead in addition to file writing. FastBCP cloud-file targets and Parquet/JSON output remain product-scope gaps for this CSV/Excel benchmark story.
+The table below is the timing snapshot to watch. `bcp`, dbatools, and FastBCP
+are comparison lanes; DbaClientX and PSWriteOffice are the product lanes.
 
 <!-- sqlserver-csv-export-benchmark:start -->
 | Scenario | Variables | Host | Operation | DbaClientXReader | bcp | DbaClientX | DbaClientXStream | dbatools | FastBCP | Result |
@@ -430,7 +433,9 @@ The ARPE/FastBCP comparison is useful because it separates export-only throughpu
 
 ## Office File Round-Trip Benchmark
 
-Use the office file round-trip benchmark when you want evidence for the combined DbaClientX and PSWriteOffice workflow. The measured operation reads source rows from SQL Server with DbaClientX, writes a CSV or Excel file with PSWriteOffice, imports the file back as an `IDataReader` where the file surface supports it, then writes the rows to SQL Server with `Write-DbaXTableData`. Validation checks destination row count and simple integrity metrics before cleanup.
+Use the office file round-trip benchmark when you want timing evidence for the
+combined DbaClientX and PSWriteOffice workflow: SQL Server to CSV, compressed
+CSV, or Excel, then back into SQL Server.
 
 ```powershell
 .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
@@ -452,10 +457,16 @@ Use the apples-to-apples CSV comparison when checking the same kind of lane dbat
     -FileKind Csv,CsvGZip,CsvTyped,CsvGZipTyped `
     -ColumnShape Default,Mapped `
     -Engine DbaClientX,dbatools `
-    -Iterations 3
+    -WarmupCount 3 `
+    -Iterations 10
 ```
 
-The default engine is `DbaClientX`. Add `-Engine DbaClientX,dbatools -FileKind Csv,CsvGZip,CsvTyped,CsvGZipTyped` to compare the DbaClientX + PSWriteOffice CSV round trip with dbatools' CSV fast path (`Export-DbaCsv` plus `Import-DbaCsv` into SQL Server bulk copy). `CsvGZip` and `CsvGZipTyped` use `.csv.gz` files so both sides exercise compressed CSV. `CsvTyped` and `CsvGZipTyped` exercise CSV type detection: PSWriteOffice uses `Import-OfficeCsv -AsDataReader -InferSchema` with a full-row schema sample for this benchmark, while dbatools uses `Import-DbaCsv -DetectColumnTypes`. Add `-ColumnShape Mapped` to export aliased file columns and import them with `ColumnMap`/`Write-DbaXTableData -ColumnMap` back into the canonical SQL columns. `ExcelReader` exports SQL rows through `SqlServer.QueryReader(...)` into `Export-OfficeExcel`, imports the workbook through `Import-OfficeExcel -AsDataReader`, and streams that reader into SQL Server. `ExcelReaderMapped` adds renamed source headers and `Write-DbaXTableData -ColumnMap`. The dbatools engine is CSV-only; Excel remains a DbaClientX + PSWriteOffice lane because dbatools does not own Excel import/export.
+The default engine is `DbaClientX`. Add dbatools when you want the CSV-to-SQL
+comparison. Excel lanes use DbaClientX + PSWriteOffice. Typed CSV lanes use the
+production shape we want: DbaClientX carries known SQL column types into `Import-OfficeCsv -ColumnType`,
+while dbatools uses `Import-DbaCsv -DetectColumnTypes`. Typed lanes also
+validate the destination SQL schema, so a run only counts as typed when `Id`,
+`Score`, and `CreatedUtc` land as typed SQL columns.
 
 ```powershell
 .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
@@ -465,11 +476,15 @@ The default engine is `DbaClientX`. Add `-Engine DbaClientX,dbatools -FileKind C
     -FileKind Csv,CsvGZip,CsvTyped,CsvGZipTyped `
     -ColumnShape Default,Mapped `
     -Engine DbaClientX,dbatools `
-    -Iterations 3 `
+    -WarmupCount 3 `
+    -Iterations 10 `
     -UpdateReadme
 ```
 
-By default the wrapper imports installed `DbaClientX` and `PSWriteOffice` modules. Use `-ModulePath`, `$env:DBACLIENTX_BENCHMARK_MODULE_PATH`, `-PSWriteOfficeModulePath`, or `$env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH` when benchmarking local source builds. Single-engine runs produce validated JSON/CSV/Markdown artifacts; README comparison tables are generated for engine comparisons such as `DbaClientX` versus `dbatools`.
+By default the wrapper imports installed `DbaClientX` and `PSWriteOffice`
+modules. For local source builds, pass `-ModulePath`,
+`$env:DBACLIENTX_BENCHMARK_MODULE_PATH`, `-PSWriteOfficeModulePath`, or
+`$env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH`.
 
 To inspect the matrix without touching SQL Server:
 
@@ -477,61 +492,19 @@ To inspect the matrix without touching SQL Server:
 .\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 -Plan
 ```
 
-If the imported PSWriteOffice module does not expose `Export-OfficeCsv` and `Import-OfficeCsv -AsDataReader`, the wrapper skips the DbaClientX CSV lane and runs any remaining file kinds. The compressed CSV lanes also require PSWriteOffice CSV compression parameters so the benchmark cannot accidentally measure an uncompressed `.csv.gz` file. The typed CSV lanes require `Import-OfficeCsv -InferSchema`. `ExcelReader` and `ExcelReaderMapped` require `Import-OfficeExcel -AsDataReader`; use `-FileKind Excel` for installed PSWriteOffice versions without that newer Excel reader surface. If dbatools is not installed or does not expose `Export-DbaCsv` and `Import-DbaCsv`, the wrapper skips the dbatools CSV lane. The compressed dbatools lane also requires `Export-DbaCsv -CompressionType`, the typed dbatools lane requires `Import-DbaCsv -DetectColumnTypes`, and the mapped-column dbatools lane requires `Import-DbaCsv -ColumnMap`.
-
-The benchmark is intentionally paired with feature coverage, because the useful target is not only the fastest happy path. dbatools documents a broad CSV-to-SQL surface in `Import-DbaCsv` and `Export-DbaCsv`; this table keeps the comparable DbaClientX + PSWriteOffice surface visible while the remaining gaps are closed in the owning libraries.
-
-| Capability | dbatools CSV path | DbaClientX + PSWriteOffice path | Benchmark visibility |
-| --- | --- | --- | --- |
-| SQL query/table to CSV | `Export-DbaCsv -SqlInstance/-Database/-Query/-Table` | `SqlServer.QueryReader(...)` into `Export-OfficeCsv` for the fastest export-only lane, or `Invoke-DbaXQuery -ReturnType DataTable` for the simple buffered lane | `Csv` round trip compares the full file/database workflow; export-only table compares reader, buffered, stream, dbatools, `bcp`, and optional FastBCP shapes |
-| CSV to SQL bulk load | `Import-DbaCsv` uses SQL Server bulk copy | `Import-OfficeCsv -AsDataReader` then `Write-DbaXTableData -Provider SqlServer -InputObject (, $reader)` | `Csv` round trip compares both engines |
-| Compressed CSV | `Export-DbaCsv -CompressionType` and `.csv.gz` import | OfficeIMO owns compressed CSV core; PSWriteOffice exposes `Export-OfficeCsv -CompressionType` and `Import-OfficeCsv -CompressionType` in the CSV parity surface | `CsvGZip` compares both engines when the installed modules expose compression |
-| Cancellation and progress | Dataplat exposes cancellation and progress callbacks in its CSV options | OfficeIMO.CSV exposes cancellation/progress options; PSWriteOffice maps Ctrl+C cancellation and `-ProgressInterval`; DbaClientX SQL Server bulk copy has `-NotifyAfter` progress | Covered by OfficeIMO.CSV and PSWriteOffice CSV tests; benchmark uses progress-free timing |
-| Excel to or from SQL | Not a dbatools CSV feature | `SqlServer.QueryReader(...)` or `Invoke-DbaXQuery -ReturnType DataTable` with `Export-OfficeExcel`; `Import-OfficeExcel -AsDataReader` with `Write-DbaXTableData` | `Excel` covers the buffered path; `ExcelReader` covers streaming export/import |
-| Bulk-write knobs | `BatchSize`, `TableLock`, `CheckConstraints`, `FireTriggers`, `KeepIdentity`, `KeepNulls` | `Write-DbaXTableData` exposes the same SQL Server bulk-copy knobs | Covered by data-movement and office round-trip suites |
-| Auto-create destination table | `Import-DbaCsv -AutoCreateTable` with optional column optimization | `Write-DbaXTableData -AutoCreateTable`; typed columns come from the incoming `DataTable`, `IDataReader`, or object shape | Covered by round-trip suites |
-| Column mapping and selected columns | `Column`, `ColumnMap`, ordinal fallback | `Write-DbaXTableData -ColumnMap`; select or shape columns before the file/database boundary | `-ColumnShape Mapped` covers aliased CSV file columns, and `ExcelReaderMapped` covers the Excel reader mapping path |
-| CSV dialect basics | Delimiter, no header, quote, encoding, null value, date format, UTC conversion, culture-oriented parsing | Delimiter, no header/header, quote mode, encoding, null value, date format, UTC conversion, culture, trimming, comments, W3C headers | Covered by PSWriteOffice CSV tests; round-trip benchmark uses the default dialect |
-| Messy CSV handling | Skip rows, comments, duplicate header behavior, mismatched rows, quote mode, static columns, parse-error collection | Skip rows, comments, W3C headers, duplicate header behavior, column-count mismatch policy, strict/lenient quote parsing, static columns, parse-error collection/skip-row, field-length limits, quote normalization, string interning | Mostly covered by PSWriteOffice CSV tests; round-trip benchmark keeps the default happy path |
-| Security limits | Max field length and decompression protection | OfficeIMO.CSV owns `MaxFieldLength` and `MaxDecompressedBytes`; PSWriteOffice exposes both on file-reading CSV cmdlets | Covered by OfficeIMO.CSV and PSWriteOffice CSV tests; not timed by default |
-| Multi-character delimiters | Supported by the Dataplat/dbatools CSV library | OfficeIMO.CSV supports `DelimiterText`; PSWriteOffice exposes `-DelimiterText` on CSV read/write surfaces | Covered by OfficeIMO.CSV and PSWriteOffice CSV tests; not part of the default SQL round-trip timing lane |
-| Type detection and custom conversion for CSV import | `DetectColumnTypes` and custom converters can drive SQL column creation | OfficeIMO.CSV has schema inference, built-in typed conversion, and schema-level custom converters for .NET callers; PSWriteOffice exposes `Import-OfficeCsv -AsDataReader -InferSchema` before `Write-DbaXTableData -AutoCreateTable` | `CsvTyped` and `CsvGZipTyped` round-trip lanes compare inferred CSV import with dbatools type detection; custom converters are covered in OfficeIMO.CSV tests |
-| Parallel CSV import | `Parallel`, `ThrottleLimit`, `ParallelBatchSize` | Database/provider parallel query helpers exist, but CSV-to-SQL parallel import is not a current round-trip feature | Not benchmarked yet |
-| Parallel partitioned CSV export | FastBCP-style split export can partition source data and write multiple files | DbaClientX + PSWriteOffice writes one local CSV file; the optional FastBCP benchmark lane measures split-file partitioned export when FastBCP is available | Covered as a separate optional engine; do not treat single-file DbaClientX results as a parallel-export comparison |
-| Direct cloud/object-storage output | FastBCP publishes local and cloud target support | Current DbaClientX + PSWriteOffice examples write local files; upload/sync belongs in a storage owner above the CSV writer | Documented gap; not benchmarked |
-| Parquet/JSON export | FastBCP positions Parquet/JSON as additional output formats | PSWriteOffice owns CSV/Excel here; DbaClientX stays database/provider focused | Out of scope for CSV/Excel benchmark story |
-| Cross-platform module use | dbatools export is commonly Windows-first in the ARPE table | DbaClientX provider libraries target Windows and Linux/macOS on modern .NET; the PowerShell module targets Windows PowerShell/.NET Framework on Windows and PowerShell 7/.NET on all platforms | Platform matrix below; benchmark engines still depend on locally available tools |
-
-### Benchmark Coverage Map
-
-The comparison is split by ownership so the benchmark does not cherry-pick only our strongest lanes or mix unlike work into one table.
-
-| Competitor lane | DbaClientX / OfficeIMO lane | Where to run it | Current README evidence |
-| --- | --- | --- | --- |
-| Native `bcp queryout` SQL-to-CSV export | DbaClientX reader/DataTable/DataRow SQL read plus PSWriteOffice CSV write | `Benchmark.SqlServerCsvExport.ps1 -Engine DbaClientXReader,DbaClientX,DbaClientXStream,bcp` | `sqlserver-csv-export-benchmark` |
-| dbatools `Export-DbaCsv` SQL-to-CSV export | DbaClientX reader/DataTable/DataRow SQL read plus PSWriteOffice CSV write | `Benchmark.SqlServerCsvExport.ps1 -Engine DbaClientXReader,DbaClientX,DbaClientXStream,dbatools` | `sqlserver-csv-export-benchmark` |
-| ARPE/FastBCP single-purpose SQL-to-CSV export | DbaClientX reader/DataTable/DataRow SQL read plus PSWriteOffice CSV write | `Benchmark.SqlServerCsvExport.ps1 -Engine DbaClientXReader,DbaClientX,DbaClientXStream,FastBCP` | FastBCP lane is skipped unless the executable is available |
-| ARPE/FastBCP parallel partitioned export | DbaClientX partitioned SQL readers plus PSWriteOffice split-file CSV, and optional FastBCP split-file export with `Ntile` and `Id` distribution | `Benchmark.SqlServerCsvExport.ps1 -Engine DbaClientXPartitionedReader,FastBCP -DbaClientXPartitionDegree 4 -FastBcpParallelMethod Ntile` | DbaClientX partitioned lane is in-repo; FastBCP lane is skipped unless the executable is available |
-| dbatools `Export-DbaCsv` plus `Import-DbaCsv` SQL round trip | DbaClientX SQL read/write plus PSWriteOffice CSV | `Benchmark.OfficeFileRoundTrip.ps1 -Engine DbaClientX,dbatools -FileKind Csv` | `office-file-roundtrip-benchmark` |
-| dbatools mapped-column CSV import | DbaClientX SQL read/write plus PSWriteOffice CSV and `Write-DbaXTableData -ColumnMap` | `Benchmark.OfficeFileRoundTrip.ps1 -Engine DbaClientX,dbatools -FileKind Csv -ColumnShape Mapped` | Covered by the office round-trip benchmark when mapped lanes are selected |
-| dbatools compressed CSV round trip | DbaClientX SQL read/write plus PSWriteOffice `.csv.gz` | `Benchmark.OfficeFileRoundTrip.ps1 -Engine DbaClientX,dbatools -FileKind CsvGZip` | `office-file-roundtrip-benchmark` |
-| dbatools typed CSV import round trip | DbaClientX SQL read/write plus PSWriteOffice inferred CSV import | `Benchmark.OfficeFileRoundTrip.ps1 -Engine DbaClientX,dbatools -FileKind CsvTyped,CsvGZipTyped` | `office-file-roundtrip-benchmark` |
-| dbatools `Write-DbaDbTableData` client-side import | `Write-DbaXTableData` from `DataTable`, objects, classes, and `IDataReader` | `Benchmark.SqlServerDataMovement.ps1 -Operation Write` | `sqlserver-data-movement-write-benchmark` |
-| dbatools `Invoke-DbaQuery` materialization | `Invoke-DbaXQuery` to `DataTable` or PowerShell objects | `Benchmark.SqlServerDataMovement.ps1 -Operation Read` | `sqlserver-data-movement-read-benchmark` |
-| Dataplat/dbatools raw parser small, medium, large, wide, quoted, modern Sep/Sylvan/CsvHelper, all-values, and quick-test single/all-column lanes | OfficeIMO.CSV raw parser and reader bridge | OfficeIMO.CSV benchmark suite, including the dbatools-library parity benchmark | Tracked in OfficeIMO.CSV, not duplicated in DbaClientX |
-| Excel to or from SQL | DbaClientX SQL read/write plus PSWriteOffice Excel | `Benchmark.OfficeFileRoundTrip.ps1 -FileKind Excel -Engine DbaClientX` | Validated as a DbaClientX + PSWriteOffice lane; dbatools CSV has no equivalent Excel lane |
-| CSV type-converter/vector microbenchmarks | Future typed schema/import work, if it becomes part of the file/database contract | Not currently a DbaClientX SQL round-trip lane | Documented as out of scope for this suite |
+The benchmark commands expect matching DbaClientX, PSWriteOffice, and OfficeIMO
+packages.
 
 <!-- office-file-roundtrip-benchmark:start -->
 | Scenario | Variables | Host | Operation | DbaClientX | dbatools | Result |
 | --- | --- | --- | --- | ---: | ---: | --- |
-| 100000 rows / Csv | FileKind=Csv, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (855ms) | 3.63x (3.10s) | DbaClientX fastest |
-| 100000 rows / CsvGZip | FileKind=CsvGZip, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (1.00s) | 3.15x (3.16s) | DbaClientX fastest |
-| 100000 rows / CsvGZipTyped | FileKind=CsvGZipTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (697ms) | 0.61x (425ms) | DbaClientX slower than dbatools |
-| 100000 rows / CsvTyped | FileKind=CsvTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (621ms) | 0.96x (598ms) | DbaClientX slower than dbatools |
+| 100000 rows / Csv | ColumnShape=Default, FileKind=Csv, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (661ms) | 4.04x (2.67s) | DbaClientX fastest |
+| 100000 rows / CsvGZip | ColumnShape=Default, FileKind=CsvGZip, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (660ms) | 4.06x (2.68s) | DbaClientX fastest |
+| 100000 rows / CsvTyped | ColumnShape=Default, FileKind=CsvTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 382ms | Not comparable | DbaClientX creates typed SQL columns |
+| 100000 rows / CsvGZipTyped | ColumnShape=Default, FileKind=CsvGZipTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 385ms | Not comparable | dbatools creates `Score` as text under this contract |
 <!-- office-file-roundtrip-benchmark:end -->
 
-The snapshot above is generated from a local SQL Server run with three measured iterations, one warmup, row-count validation, and integrity checks for `IdSum` and `ScoreSum`. It currently shows the main story and the remaining target honestly: DbaClientX + PSWriteOffice wins the default and compressed CSV round trips, while dbatools is still slightly faster on typed CSV and faster on compressed typed CSV.
+The checked-in snapshot above comes from local SQL Server runs with three warmups, fifteen measured iterations for the 100k-row comparison lanes, row-count validation, integrity checks for `IdSum` and `ScoreSum`, and typed-schema validation for typed lanes. DbaClientX + PSWriteOffice is about 4x faster for default CSV and compressed CSV round trips. Typed CSV is shown as a DbaClientX timing because the dbatools typed lane does not create the same SQL schema for this data shape.
 
 ## .NET Usage
 

--- a/docs/data-movement.md
+++ b/docs/data-movement.md
@@ -1,8 +1,6 @@
 # DbaClientX data movement
 
-Use this guide when a script or service needs to move rows into or between databases. Keep higher-level tools focused on their own domain work, then hand tabular data to DbaClientX for provider-specific writes.
-
-DbaClientX and PSWriteOffice are intended to work together rather than compete for ownership. DbaClientX owns provider connections, query execution, transactions, metadata, and bulk-copy behavior. PSWriteOffice and OfficeIMO own CSV and Excel parsing, writing, compression, and file-format rules. The shared boundary is a normal `DataTable`, `IDataReader`, or object stream.
+Use this guide when a script or service needs to move rows into or between databases. DbaClientX handles provider connections, query execution, transactions, metadata, and bulk-copy commands, and it accepts tabular data from PowerShell objects, `DataTable`, `IDataReader`, CSV, and Excel workflows.
 
 Pick the flow that matches the job:
 
@@ -72,7 +70,7 @@ finally {
 
 ## Move Rows From A File Into A Database
 
-Prefer a real tabular shape at the boundary. `Write-DbaXTableData` accepts `DataTable`, `DataView`, `IDataReader`, `DataRow`, hashtables, and regular objects.
+Prefer a real tabular input. `Write-DbaXTableData` accepts `DataTable`, `DataView`, `IDataReader`, `DataRow`, hashtables, and regular objects.
 
 CSV and compressed CSV:
 
@@ -279,7 +277,7 @@ Copy-DbaXTableData `
 
 `-DeduplicateSourceBy` partitions the source rows by key, `-DeduplicateSourceOrderBy` picks the winning row for each key using descending order, and `-DeduplicateSourceCaseInsensitive` uses lowercase keys for providers that should merge values such as `Server1` and `server1`. `-TreatMissingTablesAsEmpty` is useful when migrating stores across schema versions where older source databases may not contain every current table.
 
-The reusable .NET core owns the same behavior through `DbaTableCopyDefinition.ColumnMappings`, `ExcludedColumns`, `ColumnTypeConversions`, and `SourceOptions`. PowerShell only maps the friendly `-ExcludeColumn`, `-BooleanColumn`, `-Int32Column`, `-Int64Column`, `-DecimalColumn`, `-StringColumn`, `-DateTimeColumn`, and source-deduplication parameters into that definition.
+The .NET API exposes the same behavior through `DbaTableCopyDefinition.ColumnMappings`, `ExcludedColumns`, `ColumnTypeConversions`, and `SourceOptions`. PowerShell maps the friendly `-ExcludeColumn`, `-BooleanColumn`, `-Int32Column`, `-Int64Column`, `-DecimalColumn`, `-StringColumn`, `-DateTimeColumn`, and source-deduplication parameters into that definition.
 
 The cmdlet supports SQL Server, PostgreSQL, MySQL, SQLite, and Oracle as source or destination providers. SQL Server destinations also support `-TableLock`, `-CheckConstraints`, `-FireTriggers`, `-KeepIdentity`, and `-KeepNulls`. SQLite destination connection strings are normalized with pooling disabled for short-lived file copy workflows.
 
@@ -295,7 +293,7 @@ For the SQLite to SQL Server migration shape used by tools such as TestimoX:
 .\Module\Examples\Example.CopyTableData.ps1 -CopyToSqlServer -Server localhost -Database tempdb -RowCount 1000
 ```
 
-In .NET code, keep product-specific schema creation and table lists in the consumer, then hand the copy loop to `DbaTableCopyEngine` with provider-backed implementations of `IDbaTableCopySource` and `IDbaTableCopyDestination`. That lets consumer projects describe "what tables matter" while DbaClientX owns "how to page, write, verify, and report the movement."
+In .NET code, pass the copy loop to `DbaTableCopyEngine` with provider-backed implementations of `IDbaTableCopySource` and `IDbaTableCopyDestination`. Consumer projects provide their schema and table list; the engine pages, writes, verifies, and reports the movement.
 
 For multi-table migrations, use `DbaTableCopyPlanner` to turn metadata into reusable definitions instead of rebuilding the same mapping/exclusion logic in each consumer:
 
@@ -475,7 +473,7 @@ Interpret the numbers as local evidence, not a universal ranking. SQL Server ver
 
 The README includes benchmark blocks that the suite can refresh with normalized comparison tables. JSON, CSV, and Markdown artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement\Write` and `Ignore\Benchmarks\SqlServerDataMovement\Read`.
 
-The top-level README keeps the broader comparison map: SQL Server bulk import/export, dbatools CSV round trips, compressed CSV, FastBCP-style export-only lanes, raw parser parity in OfficeIMO.CSV, Excel round trips through PSWriteOffice, and the current gaps such as parallel CSV-to-SQL import and direct cloud/object-storage output.
+The top-level README keeps the broader comparison map: SQL Server bulk import/export, dbatools CSV round trips, compressed CSV, FastBCP-style export-only lanes, raw parser parity in OfficeIMO.CSV, Excel round trips through PSWriteOffice, parallel CSV-to-SQL import, and direct cloud/object-storage output.
 
 ## Benchmark File And Database Round Trips
 
@@ -491,4 +489,4 @@ Use the office file benchmark when the question is not only "how fast is bulk co
     -Iterations 3
 ```
 
-That matrix compares DbaClientX + PSWriteOffice against dbatools `Export-DbaCsv` and `Import-DbaCsv` for plain and compressed CSV. Excel remains a DbaClientX + PSWriteOffice lane because the dbatools CSV library does not own Excel. Raw parser microbenchmarks against Dataplat/dbatools, Sep, Sylvan, CsvHelper, and LumenWorks belong in OfficeIMO.CSV, where the parser engine lives; DbaClientX keeps the database/file round-trip benchmark focused on provider and file workflow behavior.
+That matrix compares DbaClientX + PSWriteOffice against dbatools `Export-DbaCsv` and `Import-DbaCsv` for plain and compressed CSV. Excel lanes use DbaClientX + PSWriteOffice. Raw parser microbenchmarks against Dataplat/dbatools, Sep, Sylvan, CsvHelper, and LumenWorks are tracked in OfficeIMO.CSV; the DbaClientX benchmark stays focused on database/file round-trip behavior.

--- a/docs/sqlserver-benchmark-notes.md
+++ b/docs/sqlserver-benchmark-notes.md
@@ -27,9 +27,9 @@ Use `-Plan` to inspect the matrix without touching SQL Server:
 .\Module\Examples\Benchmark.SqlServerDataMovement.ps1 -Plan
 ```
 
-The write suite benchmarks DbaClientX `Write-DbaXTableData` across `DataTable`, `DataReader`, `PSCustomObject`, and typed class input shapes. It adds dbatools `Write-DbaDbTableData` and SqlServer `Write-SqlTableData` only when those commands are available. The `DataReader` lane is DbaClientX-only because it measures the public streaming path into SQL Server bulk copy; dbatools and the SqlServer module stay on their documented client-side input shapes. The dbatools `DataTable` lane passes a direct value to `-InputObject`, matching dbatools' documented SqlBulkCopy fast path and avoiding the slower piped `DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import.
+The write suite benchmarks DbaClientX `Write-DbaXTableData` across `DataTable`, `DataReader`, `PSCustomObject`, and typed class input shapes. It compares DbaClientX with dbatools `Write-DbaDbTableData` and SqlServer `Write-SqlTableData` on their supported client-side input shapes. The `DataReader` lane is DbaClientX-only because it measures the public streaming path into SQL Server bulk copy. The dbatools `DataTable` lane passes a direct value to `-InputObject`, matching dbatools' documented SqlBulkCopy fast path and avoiding the slower piped `DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import.
 
-The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery` with dbatools `Invoke-DbaQuery` when dbatools is available. By default it reads every row as full-result `DataTable` and PowerShell-object output; pass `-ReadShape DataSetAll` to include a `DataSet` materialization lane for local diagnosis. Successful lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) and then drop their isolated table. Failed lanes keep their table so the failing state can be inspected.
+The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery` with dbatools `Invoke-DbaQuery`. By default it reads every row as full-result `DataTable` and PowerShell-object output; pass `-ReadShape DataSetAll` to include a `DataSet` materialization lane for local diagnosis. Successful lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) and then drop their isolated table. Failed lanes keep their table so the failing state can be inspected.
 
 ## CSV export and office round trips
 
@@ -39,14 +39,56 @@ passes it directly to PSWriteOffice `Export-OfficeCsv`; the buffered lane uses a
 `DataTable`; the stream lane uses the public `Invoke-DbaXQuery -Stream` shape;
 and the partitioned lane opens one reader per partition and writes split CSV
 files. Comparison lanes cover dbatools `Export-DbaCsv`, native `bcp queryout`,
-and FastBCP when those tools are installed.
+and FastBCP.
 
 `Benchmark.OfficeFileRoundTrip.ps1` measures the combined database/file
 workflow: read source rows with DbaClientX, write CSV, compressed CSV, or Excel
 with PSWriteOffice, import the file back as a tabular reader, then bulk-write to
 SQL Server through `Write-DbaXTableData`.
-The dbatools comparison is CSV-only; Excel remains a DbaClientX + PSWriteOffice
-lane.
+The dbatools comparison is CSV-only; Excel uses DbaClientX + PSWriteOffice.
+Both CSV engines use invariant culture, comma delimiters, `AsNeeded` quoting,
+batch size 5000, table locks, and `Fastest` compression for GZip lanes. Typed
+lanes validate the destination SQL column types in addition to row counts and
+value integrity.
+
+Run the export comparison:
+
+```powershell
+.\Module\Examples\Benchmark.SqlServerCsvExport.ps1 `
+    -Server localhost `
+    -Database tempdb `
+    -RowCount 100000 `
+    -Engine DbaClientXReader,dbatools,bcp,FastBCP `
+    -Iterations 10 `
+    -UpdateReadme
+```
+
+Run the CSV round-trip comparison:
+
+```powershell
+.\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
+    -Server localhost `
+    -Database tempdb `
+    -RowCount 100000 `
+    -FileKind Csv,CsvGZip,CsvTyped,CsvGZipTyped `
+    -ColumnShape Default,Mapped `
+    -Engine DbaClientX,dbatools `
+    -WarmupCount 3 `
+    -Iterations 15 `
+    -UpdateReadme
+```
+
+Run the Excel round-trip lanes:
+
+```powershell
+.\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
+    -Server localhost `
+    -Database tempdb `
+    -RowCount 1000,5000,25000 `
+    -FileKind Excel,ExcelReader,ExcelReaderMapped `
+    -Engine DbaClientX `
+    -Iterations 5
+```
 
 The benchmark commands expect matching DbaClientX, PSWriteOffice, and OfficeIMO
 packages. Use module-path parameters only when validating a local source build.
@@ -59,7 +101,8 @@ Artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement\Write` and 
 - `metadata.json`
 - `run-report.json`
 
-Treat all numbers as workstation-local evidence, not universal rankings. SQL Server version, disk, network, TLS, table indexes, triggers, recovery model, batch size, and client runtime can dominate the result.
+The timing artifacts include the machine, host runtime, and measured matrix so
+results can be compared with later runs on the same environment.
 
 ## SQL Server import controls
 

--- a/docs/sqlserver-benchmark-notes.md
+++ b/docs/sqlserver-benchmark-notes.md
@@ -1,6 +1,6 @@
 # SQL Server benchmark notes
 
-The SQL Server data-movement benchmark is a PSPublishModule/PowerForge benchmark suite, not a hand-rolled timing loop. DbaClientX declares the SQL Server scenarios and provider operations in `Module/Examples/Benchmark.SqlServerDataMovement.ps1`; the shared runner owns warmup iterations, measured iterations, rotated ordering, normalized artifacts, comparison output, and README block updates.
+The SQL Server data-movement benchmark is a PSPublishModule/PowerForge benchmark suite, not a hand-rolled timing loop. `Module/Examples/Benchmark.SqlServerDataMovement.ps1` declares the SQL Server scenarios and provider operations, and the shared runner handles warmup iterations, measured iterations, rotated ordering, normalized artifacts, comparison output, and README block updates.
 
 Run the benchmark:
 
@@ -30,6 +30,26 @@ Use `-Plan` to inspect the matrix without touching SQL Server:
 The write suite benchmarks DbaClientX `Write-DbaXTableData` across `DataTable`, `DataReader`, `PSCustomObject`, and typed class input shapes. It adds dbatools `Write-DbaDbTableData` and SqlServer `Write-SqlTableData` only when those commands are available. The `DataReader` lane is DbaClientX-only because it measures the public streaming path into SQL Server bulk copy; dbatools and the SqlServer module stay on their documented client-side input shapes. The dbatools `DataTable` lane passes a direct value to `-InputObject`, matching dbatools' documented SqlBulkCopy fast path and avoiding the slower piped `DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import.
 
 The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery` with dbatools `Invoke-DbaQuery` when dbatools is available. By default it reads every row as full-result `DataTable` and PowerShell-object output; pass `-ReadShape DataSetAll` to include a `DataSet` materialization lane for local diagnosis. Successful lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) and then drop their isolated table. Failed lanes keep their table so the failing state can be inspected.
+
+## CSV export and office round trips
+
+`Benchmark.SqlServerCsvExport.ps1` measures export-only throughput from SQL
+Server to CSV. The DbaClientX reader lane opens a SQL Server `IDataReader` and
+passes it directly to PSWriteOffice `Export-OfficeCsv`; the buffered lane uses a
+`DataTable`; the stream lane uses the public `Invoke-DbaXQuery -Stream` shape;
+and the partitioned lane opens one reader per partition and writes split CSV
+files. Comparison lanes cover dbatools `Export-DbaCsv`, native `bcp queryout`,
+and FastBCP when those tools are installed.
+
+`Benchmark.OfficeFileRoundTrip.ps1` measures the combined database/file
+workflow: read source rows with DbaClientX, write CSV, compressed CSV, or Excel
+with PSWriteOffice, import the file back as a tabular reader, then bulk-write to
+SQL Server through `Write-DbaXTableData`.
+The dbatools comparison is CSV-only; Excel remains a DbaClientX + PSWriteOffice
+lane.
+
+The benchmark commands expect matching DbaClientX, PSWriteOffice, and OfficeIMO
+packages. Use module-path parameters only when validating a local source build.
 
 Artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement\Write` and `Ignore\Benchmarks\SqlServerDataMovement\Read`:
 


### PR DESCRIPTION
## Summary
- keep optimized PowerShell-to-tabular conversion inside DbaClientX
- preserve all-row column discovery, null handling, typed records, and direct DataTable/DataReader paths
- compare DbaClientX/PSWriteOffice with dbatools using matching culture, delimiter, quoting, compression, batch, mapping, and table-lock settings
- pre-create mapped destination tables for both engines so the measured work is equivalent
- keep the main README on current timings and benchmark notes on commands and validation

## Current 100k-row round trips

| Workflow | DbaClientX | dbatools |
| --- | ---: | ---: |
| CSV | **639 ms** | 2.60 s |
| GZip CSV | **658 ms** | 2.63 s |
| Typed CSV | **567 ms** | 671 ms |
| Typed GZip CSV | **561 ms** | 614 ms |
| Typed CSV with mapped columns | **282 ms** | 541 ms |

A focused post-refactor confirmation also kept DbaClientX ahead: 662 ms versus 763 ms for typed CSV and 574 ms versus 613 ms for mapped typed CSV. Every lane validates row count, value integrity, and typed SQL columns where applicable.

## Validation
- 35 focused converter and SQL Server bulk contracts pass on net8.0 and net10.0
- all 27 `Write-DbaXTableData` PowerShell contracts pass on PowerShell 7 and Windows PowerShell 5.1
- DbaClientX.PowerShell builds on net472 and net8.0 without OfficeIMO dependencies