### PR TITLE
Add managed SQLite sessions and connection options

### DIFF
--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX SQLite provider</Description>
     <AssemblyName>DbaClientX.SQLite</AssemblyName>
     <AssemblyTitle>DbaClientX.SQLite</AssemblyTitle>
-    <VersionPrefix>0.11.0</VersionPrefix>
+    <VersionPrefix>0.12.0</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.SQLite/SQLite.AsyncSession.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncSession.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+
+namespace DBAClientX;
+
+public partial class SQLite {
+    /// <summary>Opens a managed asynchronous SQLite session using one provider connection.</summary>
+    public virtual async Task<SQLiteAsyncSession> OpenSessionAsync(
+        string database,
+        CancellationToken cancellationToken = default) {
+        var connectionString = BuildOperationalConnectionString(database);
+        SqliteConnection? connection = null;
+        try {
+            (connection, _, _) = await ResolveConnectionAsync(
+                connectionString,
+                useTransaction: false,
+                cancellationToken).ConfigureAwait(false);
+            return new SQLiteAsyncSession(this, connection);
+        } catch {
+            if (connection is not null) {
+                await DisposeSQLiteConnectionAsync(connection).ConfigureAwait(false);
+            }
+            throw;
+        }
+    }
+
+    internal async Task<int> ExecuteSessionNonQueryAsync(
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        string query,
+        IDictionary<string, object?>? parameters,
+        CancellationToken cancellationToken) {
+        ValidateCommandText(query);
+        try {
+            return await base.ExecuteNonQueryAsync(
+                connection,
+                transaction,
+                query,
+                parameters,
+                cancellationToken).ConfigureAwait(false);
+        } catch (Exception ex) when (ex is SqliteException or InvalidOperationException) {
+            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+        }
+    }
+
+    internal async Task<object?> ExecuteSessionScalarAsync(
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        string query,
+        IDictionary<string, object?>? parameters,
+        CancellationToken cancellationToken) {
+        ValidateCommandText(query);
+        try {
+            return await base.ExecuteScalarAsync(
+                connection,
+                transaction,
+                query,
+                parameters,
+                cancellationToken).ConfigureAwait(false);
+        } catch (Exception ex) when (ex is SqliteException or InvalidOperationException) {
+            throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
+        }
+    }
+
+    internal async Task<IReadOnlyList<T>> ExecuteSessionQueryAsListAsync<T>(
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters,
+        Action<IDataRecord>? initialize,
+        CancellationToken cancellationToken) {
+        ValidateCommandText(query);
+        if (map is null) {
+            throw new ArgumentNullException(nameof(map));
+        }
+
+        try {
+            return await ExecuteMappedQueryAsync(
+                connection,
+                transaction,
+                query,
+                map,
+                initialize,
+                parameters,
+                cancellationToken).ConfigureAwait(false);
+        } catch (Exception ex) when (ex is SqliteException or InvalidOperationException) {
+            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
+        }
+    }
+
+    internal async Task<TResult> ExecuteSessionTransactionAsync<TResult>(
+        SqliteConnection connection,
+        Func<SQLiteAsyncSession, CancellationToken, Task<TResult>> operation,
+        CancellationToken cancellationToken) {
+        if (operation is null) {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+        await using var transaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
+            .ConfigureAwait(false);
+#else
+        using var transaction = connection.BeginTransaction();
+#endif
+        var transactionSession = new SQLiteAsyncSession(this, connection, transaction);
+        try {
+            var result = await operation(transactionSession, cancellationToken).ConfigureAwait(false);
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+#else
+            transaction.Commit();
+#endif
+            return result;
+        } catch (Exception ex) {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+            await HandleTransactionFailureAsync(
+                ex,
+                token => transaction.RollbackAsync(token),
+                static () => true,
+                cancellationToken).ConfigureAwait(false);
+#else
+            HandleTransactionFailure(ex, transaction.Rollback, static () => true);
+#endif
+            throw new InvalidOperationException("Transaction failure handling returned unexpectedly.", ex);
+        }
+    }
+}

--- a/DbaClientX.SQLite/SQLite.ManagedConnection.cs
+++ b/DbaClientX.SQLite/SQLite.ManagedConnection.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+
+namespace DBAClientX;
+
+public partial class SQLite
+{
+    /// <summary>
+    /// Opens a provider-managed connection for a domain workflow that still needs direct ADO.NET commands.
+    /// </summary>
+    /// <remarks>
+    /// Prefer the command and session APIs when possible. This method keeps provider creation and operational
+    /// pragmas inside DBAClientX while allowing consumers to own domain schema and SQL migrations.
+    /// </remarks>
+    public virtual DbConnection OpenDbConnection(string database, SQLiteConnectionOptions? options = null)
+    {
+        options ??= new SQLiteConnectionOptions();
+        var connectionString = BuildOperationalConnectionString(database, options.ReadOnly);
+        var connection = new SqliteConnection(connectionString);
+        try
+        {
+            connection.Open();
+            ApplyManagedConnectionOptions(connection, options);
+            return connection;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
+    }
+
+    private void ApplyManagedConnectionOptions(SqliteConnection connection, SQLiteConnectionOptions options)
+    {
+        int busyTimeout = ResolveBusyTimeoutMs(options.BusyTimeoutMs);
+        using var command = connection.CreateCommand();
+        var sql = new System.Text.StringBuilder();
+        if (busyTimeout > 0)
+        {
+            sql.Append("PRAGMA busy_timeout = ").Append(busyTimeout).AppendLine(";");
+        }
+        if (!options.ReadOnly && options.EnableWriteAheadLogging)
+        {
+            sql.AppendLine("PRAGMA journal_mode = WAL;");
+        }
+        if (!options.ReadOnly && options.UseNormalSynchronousMode)
+        {
+            sql.AppendLine("PRAGMA synchronous = NORMAL;");
+        }
+        if (!options.ReadOnly && options.WalAutoCheckpointPages > 0)
+        {
+            sql.Append("PRAGMA wal_autocheckpoint = ").Append(options.WalAutoCheckpointPages).AppendLine(";");
+        }
+        if (options.UseMemoryTempStore)
+        {
+            sql.AppendLine("PRAGMA temp_store = MEMORY;");
+        }
+        if (options.CacheSize != 0)
+        {
+            sql.Append("PRAGMA cache_size = ").Append(options.CacheSize).AppendLine(";");
+        }
+        sql.Append("PRAGMA foreign_keys = ").Append(options.EnableForeignKeys ? "ON" : "OFF").AppendLine(";");
+        command.CommandText = sql.ToString();
+        command.ExecuteNonQuery();
+    }
+}

--- a/DbaClientX.SQLite/SQLiteAsyncSession.cs
+++ b/DbaClientX.SQLite/SQLiteAsyncSession.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+
+namespace DBAClientX;
+
+/// <summary>
+/// Represents an asynchronous SQLite connection session owned and managed by <see cref="SQLite"/>.
+/// </summary>
+/// <remarks>
+/// Provider-specific connection and transaction objects remain internal to DBAClientX. Consumers
+/// provide domain SQL, parameter values, and provider-neutral <see cref="IDataRecord"/> projections.
+/// </remarks>
+public sealed class SQLiteAsyncSession : IAsyncDisposable {
+    private readonly SQLite _client;
+    private readonly SqliteConnection _connection;
+    private readonly SqliteTransaction? _transaction;
+    private readonly bool _ownsConnection;
+    private bool _disposed;
+
+    internal SQLiteAsyncSession(SQLite client, SqliteConnection connection)
+        : this(client, connection, transaction: null, ownsConnection: true) {
+    }
+
+    internal SQLiteAsyncSession(SQLite client, SqliteConnection connection, SqliteTransaction transaction)
+        : this(client, connection, transaction, ownsConnection: false) {
+    }
+
+    private SQLiteAsyncSession(
+        SQLite client,
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        bool ownsConnection) {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _connection = connection ?? throw new ArgumentNullException(nameof(connection));
+        _transaction = transaction;
+        _ownsConnection = ownsConnection;
+    }
+
+    /// <summary>Executes a statement that does not return rows.</summary>
+    public Task<int> ExecuteNonQueryAsync(
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        return _client.ExecuteSessionNonQueryAsync(_connection, _transaction, query, parameters, cancellationToken);
+    }
+
+    /// <summary>Executes a statement and returns the first column of the first row.</summary>
+    public Task<object?> ExecuteScalarAsync(
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        return _client.ExecuteSessionScalarAsync(_connection, _transaction, query, parameters, cancellationToken);
+    }
+
+    /// <summary>Executes a query and maps every row through a provider-neutral record.</summary>
+    public Task<IReadOnlyList<T>> QueryAsListAsync<T>(
+        string query,
+        Func<IDataRecord, T> map,
+        IDictionary<string, object?>? parameters = null,
+        Action<IDataRecord>? initialize = null,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        return _client.ExecuteSessionQueryAsListAsync(
+            _connection,
+            _transaction,
+            query,
+            map,
+            parameters,
+            initialize,
+            cancellationToken);
+    }
+
+    /// <summary>Runs related operations inside one SQLite transaction.</summary>
+    public Task<TResult> RunInTransactionAsync<TResult>(
+        Func<SQLiteAsyncSession, CancellationToken, Task<TResult>> operation,
+        CancellationToken cancellationToken = default) {
+        ThrowIfDisposed();
+        if (_transaction is not null) {
+            throw new DbaTransactionException("A session transaction is already active.");
+        }
+
+        return _client.ExecuteSessionTransactionAsync(_connection, operation, cancellationToken);
+    }
+
+    /// <summary>Runs related operations inside one SQLite transaction.</summary>
+    public async Task RunInTransactionAsync(
+        Func<SQLiteAsyncSession, CancellationToken, Task> operation,
+        CancellationToken cancellationToken = default) {
+        if (operation is null) {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+        await RunInTransactionAsync(async (session, token) => {
+            await operation(session, token).ConfigureAwait(false);
+            return true;
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync() {
+        if (_disposed) {
+            return;
+        }
+
+        if (_ownsConnection) {
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+            await _connection.DisposeAsync().ConfigureAwait(false);
+#else
+            _connection.Dispose();
+            await Task.CompletedTask.ConfigureAwait(false);
+#endif
+        }
+
+        _disposed = true;
+    }
+
+    private void ThrowIfDisposed() {
+        if (_disposed) {
+            throw new ObjectDisposedException(nameof(SQLiteAsyncSession));
+        }
+    }
+}

--- a/DbaClientX.SQLite/SQLiteConnectionOptions.cs
+++ b/DbaClientX.SQLite/SQLiteConnectionOptions.cs
@@ -1,0 +1,29 @@
+namespace DBAClientX;
+
+/// <summary>Configures provider-managed SQLite connections opened for domain storage workflows.</summary>
+public sealed class SQLiteConnectionOptions
+{
+    /// <summary>Gets or sets whether the connection is opened read-only.</summary>
+    public bool ReadOnly { get; set; }
+
+    /// <summary>Gets or sets whether write connections use write-ahead logging.</summary>
+    public bool EnableWriteAheadLogging { get; set; } = true;
+
+    /// <summary>Gets or sets whether write connections use NORMAL synchronous durability.</summary>
+    public bool UseNormalSynchronousMode { get; set; } = true;
+
+    /// <summary>Gets or sets the optional busy timeout override in milliseconds.</summary>
+    public int? BusyTimeoutMs { get; set; }
+
+    /// <summary>Gets or sets the WAL auto-checkpoint page count. Zero leaves the provider default.</summary>
+    public int WalAutoCheckpointPages { get; set; } = 1000;
+
+    /// <summary>Gets or sets whether temporary storage uses memory.</summary>
+    public bool UseMemoryTempStore { get; set; } = true;
+
+    /// <summary>Gets or sets the SQLite cache size pragma. Negative values represent kibibytes.</summary>
+    public int CacheSize { get; set; } = -2000;
+
+    /// <summary>Gets or sets whether foreign-key enforcement is enabled.</summary>
+    public bool EnableForeignKeys { get; set; } = true;
+}

--- a/DbaClientX.Tests/SQLiteAsyncSessionTests.cs
+++ b/DbaClientX.Tests/SQLiteAsyncSessionTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using DBAClientX;
+
+namespace DbaClientX.Tests;
+
+public class SQLiteAsyncSessionTests
+{
+    [Fact]
+    public async Task OpenSessionAsync_ExecutesMappedQueriesOnOneConnection()
+    {
+        string path = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}.db");
+        try
+        {
+            using var sqlite = new SQLite { BusyTimeoutMs = 15000, MaxRetryAttempts = 5 };
+            await using SQLiteAsyncSession session = await sqlite.OpenSessionAsync(path);
+            await session.ExecuteNonQueryAsync("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL);");
+            await session.ExecuteNonQueryAsync(
+                "INSERT INTO items (name) VALUES ($name);",
+                new Dictionary<string, object?> { ["$name"] = "one" });
+
+            IReadOnlyList<string> rows = await session.QueryAsListAsync(
+                "SELECT name FROM items ORDER BY id;",
+                static record => record.GetString(0));
+
+            Assert.Equal(["one"], rows);
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    [Fact]
+    public async Task RunInTransactionAsync_RollsBackWhenOperationFails()
+    {
+        string path = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}.db");
+        try
+        {
+            using var sqlite = new SQLite();
+            await using SQLiteAsyncSession session = await sqlite.OpenSessionAsync(path);
+            await session.ExecuteNonQueryAsync("CREATE TABLE items (name TEXT NOT NULL);");
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => session.RunInTransactionAsync<int>(async (tx, token) =>
+            {
+                await tx.ExecuteNonQueryAsync("INSERT INTO items (name) VALUES ('temp');", cancellationToken: token);
+                throw new InvalidOperationException("stop");
+            }));
+
+            object? count = await session.ExecuteScalarAsync("SELECT COUNT(*) FROM items;");
+            Assert.Equal(0L, count);
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    [Fact]
+    public async Task RunInTransactionAsync_PreservesOperationAndRollbackFailures()
+    {
+        string path = Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}.db");
+        try
+        {
+            using var sqlite = new SQLite();
+            await using SQLiteAsyncSession session = await sqlite.OpenSessionAsync(path);
+
+            AggregateException error = await Assert.ThrowsAsync<AggregateException>(() =>
+                session.RunInTransactionAsync<int>(async (transaction, token) =>
+                {
+                    var field = typeof(SQLiteAsyncSession).GetField("_transaction", BindingFlags.Instance | BindingFlags.NonPublic)!;
+                    var providerTransaction = (DbTransaction)field.GetValue(transaction)!;
+                    await providerTransaction.DisposeAsync();
+                    throw new InvalidOperationException("operation failed");
+                }));
+
+            Assert.Collection(
+                error.InnerExceptions,
+                original => Assert.Equal("operation failed", original.Message),
+                rollback => Assert.NotNull(rollback));
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    [Fact]
+    public async Task OpenSessionAsync_ObservesCancellation()
+    {
+        using var sqlite = new SQLite();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            sqlite.OpenSessionAsync(Path.Join(Path.GetTempPath(), $"{Guid.NewGuid():N}.db"), cancellation.Token));
+    }
+
+    private static void Cleanup(string path)
+    {
+        TryDelete(path);
+        TryDelete(path + "-wal");
+        TryDelete(path + "-shm");
+    }
+
+    private static void TryDelete(string path)
+    {
+        if (File.Exists(path))
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/DbaClientX.Tests/SQLiteSessionTests.cs
+++ b/DbaClientX.Tests/SQLiteSessionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.IO;
 using DBAClientX;
 
@@ -7,6 +8,30 @@ namespace DbaClientX.Tests;
 
 public class SQLiteSessionTests
 {
+    [Fact]
+    public void OpenDbConnection_AppliesManagedOptions()
+    {
+        string path = Path.Join(Path.GetTempPath(), Path.GetFileName($"{Guid.NewGuid():N}.db"));
+        try
+        {
+            using var sqlite = new SQLite();
+            using DbConnection connection = sqlite.OpenDbConnection(path, new SQLiteConnectionOptions
+            {
+                BusyTimeoutMs = 4321,
+                EnableForeignKeys = true,
+                EnableWriteAheadLogging = true
+            });
+
+            Assert.Equal(4321L, ReadPragma(connection, "busy_timeout"));
+            Assert.Equal(1L, ReadPragma(connection, "foreign_keys"));
+            Assert.Equal("wal", ReadPragma(connection, "journal_mode"));
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
     [Fact]
     public void OpenSession_ReusesConnectionForAttachedDatabase()
     {
@@ -68,6 +93,13 @@ public class SQLiteSessionTests
         TryDelete(path);
         TryDelete(path + "-wal");
         TryDelete(path + "-shm");
+    }
+
+    private static object ReadPragma(DbConnection connection, string name)
+    {
+        using DbCommand command = connection.CreateCommand();
+        command.CommandText = $"PRAGMA {name};";
+        return command.ExecuteScalar()!;
     }
 
     private static void TryDelete(string path)


### PR DESCRIPTION
## Summary

- add managed SQLite connection options for read-only mode, WAL, synchronous mode, busy timeout, checkpointing, cache, temp storage, and foreign keys
- apply the busy timeout before any lock-taking initialization pragma
- add async sessions for mapped queries, commands, scalars, and transactions while keeping provider-specific types internal
- preserve both the original operation error and any rollback failure
- update DbaClientX.SQLite to 0.12.0

## Compatibility

The new APIs are additive. Existing SQLite entry points remain available.

SectigoCertificateManagerService will consume these APIs and remove its direct Microsoft.Data.Sqlite dependency.

## Validation

The focused SQLite contracts pass, including managed option visibility and rollback-failure aggregation. The complete Windows, Linux, macOS, PowerShell, CodeQL, and coverage checks are green.