### PR TITLE
feat(data): harden transactions and SQLite maintenance

### DIFF
--- a/DbaClientX.MySql/MySql.Transactions.cs
+++ b/DbaClientX.MySql/MySql.Transactions.cs
@@ -60,6 +60,29 @@ public partial class MySql
     /// </summary>
     public virtual async Task BeginTransactionAsync(string host, string database, string username, string password, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
     {
+        var connectionString = BuildConnectionString(host, database, username, password);
+        await BeginTransactionAsync(connectionString, isolationLevel, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Begins a transaction asynchronously using an existing MySQL connection string and the default isolation level.
+    /// </summary>
+    /// <param name="connectionString">Complete MySQL connection string.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already active.</exception>
+    public virtual Task BeginTransactionAsync(string connectionString, CancellationToken cancellationToken = default)
+        => BeginTransactionAsync(connectionString, IsolationLevel.ReadCommitted, cancellationToken);
+
+    /// <summary>
+    /// Begins a transaction asynchronously using an existing MySQL connection string.
+    /// </summary>
+    /// <param name="connectionString">Complete MySQL connection string.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already active.</exception>
+    public virtual async Task BeginTransactionAsync(string connectionString, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+    {
+        ValidateConnectionString(connectionString);
         MySqlConnection? connection = null;
         MySqlTransaction? transaction = null;
         try
@@ -69,7 +92,6 @@ public partial class MySql
                 ReserveTransactionStart(_transaction, ref _transactionInitializing);
             }
 
-            var connectionString = BuildConnectionString(host, database, username, password);
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
 
             connection = CreateConnection(connectionString);
@@ -205,6 +227,64 @@ public partial class MySql
 
         return await ExecuteInTransactionAsync(
             token => BeginTransactionAsync(host, database, username, password, isolationLevel, token),
+            token => operation(this, token),
+            CommitAsync,
+            RollbackAsync,
+            () => IsInTransaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs the provided asynchronous callback inside a MySQL transaction created from a complete connection string and commits on success.
+    /// </summary>
+    /// <param name="connectionString">Complete MySQL connection string.</param>
+    /// <param name="operation">Operation to execute with the transaction-aware client.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public virtual Task RunInTransactionAsync(
+        string connectionString,
+        Func<MySql, CancellationToken, Task> operation,
+        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
+        CancellationToken cancellationToken = default)
+    {
+        if (operation == null)
+        {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+        return RunInTransactionAsync(
+            connectionString,
+            async (client, token) =>
+            {
+                await operation(client, token).ConfigureAwait(false);
+                return true;
+            },
+            isolationLevel,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs the provided asynchronous callback inside a MySQL transaction created from a complete connection string and commits on success.
+    /// </summary>
+    /// <typeparam name="TResult">Type returned by the operation.</typeparam>
+    /// <param name="connectionString">Complete MySQL connection string.</param>
+    /// <param name="operation">Operation to execute with the transaction-aware client.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The operation result.</returns>
+    public virtual async Task<TResult> RunInTransactionAsync<TResult>(
+        string connectionString,
+        Func<MySql, CancellationToken, Task<TResult>> operation,
+        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
+        CancellationToken cancellationToken = default)
+    {
+        if (operation == null)
+        {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+        return await ExecuteInTransactionAsync(
+            token => BeginTransactionAsync(connectionString, isolationLevel, token),
             token => operation(this, token),
             CommitAsync,
             RollbackAsync,

--- a/DbaClientX.Oracle/Oracle.Transactions.cs
+++ b/DbaClientX.Oracle/Oracle.Transactions.cs
@@ -60,6 +60,29 @@ public partial class Oracle
     /// </summary>
     public virtual async Task BeginTransactionAsync(string host, string serviceName, string username, string password, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
     {
+        var connectionString = BuildConnectionString(host, serviceName, username, password);
+        await BeginTransactionAsync(connectionString, isolationLevel, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Begins a transaction asynchronously using an existing Oracle connection string and the default isolation level.
+    /// </summary>
+    /// <param name="connectionString">Complete Oracle connection string.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already active.</exception>
+    public virtual Task BeginTransactionAsync(string connectionString, CancellationToken cancellationToken = default)
+        => BeginTransactionAsync(connectionString, IsolationLevel.ReadCommitted, cancellationToken);
+
+    /// <summary>
+    /// Begins a transaction asynchronously using an existing Oracle connection string.
+    /// </summary>
+    /// <param name="connectionString">Complete Oracle connection string.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already active.</exception>
+    public virtual async Task BeginTransactionAsync(string connectionString, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+    {
+        ValidateConnectionString(connectionString);
         OracleConnection? connection = null;
         OracleTransaction? transaction = null;
         try
@@ -69,7 +92,6 @@ public partial class Oracle
                 ReserveTransactionStart(_transaction, ref _transactionInitializing);
             }
 
-            var connectionString = BuildConnectionString(host, serviceName, username, password);
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
             connection = CreateConnection(connectionString);
             await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
@@ -203,6 +225,64 @@ public partial class Oracle
 
         return await ExecuteInTransactionAsync(
             token => BeginTransactionAsync(host, serviceName, username, password, isolationLevel, token),
+            token => operation(this, token),
+            CommitAsync,
+            RollbackAsync,
+            () => IsInTransaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs the provided asynchronous callback inside an Oracle transaction created from a complete connection string and commits on success.
+    /// </summary>
+    /// <param name="connectionString">Complete Oracle connection string.</param>
+    /// <param name="operation">Operation to execute with the transaction-aware client.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public virtual Task RunInTransactionAsync(
+        string connectionString,
+        Func<Oracle, CancellationToken, Task> operation,
+        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
+        CancellationToken cancellationToken = default)
+    {
+        if (operation == null)
+        {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+        return RunInTransactionAsync(
+            connectionString,
+            async (client, token) =>
+            {
+                await operation(client, token).ConfigureAwait(false);
+                return true;
+            },
+            isolationLevel,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs the provided asynchronous callback inside an Oracle transaction created from a complete connection string and commits on success.
+    /// </summary>
+    /// <typeparam name="TResult">Type returned by the operation.</typeparam>
+    /// <param name="connectionString">Complete Oracle connection string.</param>
+    /// <param name="operation">Operation to execute with the transaction-aware client.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The operation result.</returns>
+    public virtual async Task<TResult> RunInTransactionAsync<TResult>(
+        string connectionString,
+        Func<Oracle, CancellationToken, Task<TResult>> operation,
+        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
+        CancellationToken cancellationToken = default)
+    {
+        if (operation == null)
+        {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+        return await ExecuteInTransactionAsync(
+            token => BeginTransactionAsync(connectionString, isolationLevel, token),
             token => operation(this, token),
             CommitAsync,
             RollbackAsync,

--- a/DbaClientX.PostgreSql/PostgreSql.Transactions.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.Transactions.cs
@@ -60,6 +60,29 @@ public partial class PostgreSql
     /// </summary>
     public virtual async Task BeginTransactionAsync(string host, string database, string username, string password, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
     {
+        var connectionString = BuildConnectionString(host, database, username, password);
+        await BeginTransactionAsync(connectionString, isolationLevel, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Begins a transaction asynchronously using an existing PostgreSQL connection string and the default isolation level.
+    /// </summary>
+    /// <param name="connectionString">Complete PostgreSQL connection string.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already active.</exception>
+    public virtual Task BeginTransactionAsync(string connectionString, CancellationToken cancellationToken = default)
+        => BeginTransactionAsync(connectionString, IsolationLevel.ReadCommitted, cancellationToken);
+
+    /// <summary>
+    /// Begins a transaction asynchronously using an existing PostgreSQL connection string.
+    /// </summary>
+    /// <param name="connectionString">Complete PostgreSQL connection string.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already active.</exception>
+    public virtual async Task BeginTransactionAsync(string connectionString, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+    {
+        ValidateConnectionString(connectionString);
         NpgsqlConnection? connection = null;
         NpgsqlTransaction? transaction = null;
         try
@@ -69,7 +92,6 @@ public partial class PostgreSql
                 ReserveTransactionStart(_transaction, ref _transactionInitializing);
             }
 
-            var connectionString = BuildConnectionString(host, database, username, password);
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
 
             connection = CreateConnection(connectionString);
@@ -205,6 +227,64 @@ public partial class PostgreSql
 
         return await ExecuteInTransactionAsync(
             token => BeginTransactionAsync(host, database, username, password, isolationLevel, token),
+            token => operation(this, token),
+            CommitAsync,
+            RollbackAsync,
+            () => IsInTransaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs the provided asynchronous callback inside a PostgreSQL transaction created from a complete connection string and commits on success.
+    /// </summary>
+    /// <param name="connectionString">Complete PostgreSQL connection string.</param>
+    /// <param name="operation">Operation to execute with the transaction-aware client.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public virtual Task RunInTransactionAsync(
+        string connectionString,
+        Func<PostgreSql, CancellationToken, Task> operation,
+        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
+        CancellationToken cancellationToken = default)
+    {
+        if (operation == null)
+        {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+        return RunInTransactionAsync(
+            connectionString,
+            async (client, token) =>
+            {
+                await operation(client, token).ConfigureAwait(false);
+                return true;
+            },
+            isolationLevel,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs the provided asynchronous callback inside a PostgreSQL transaction created from a complete connection string and commits on success.
+    /// </summary>
+    /// <typeparam name="TResult">Type returned by the operation.</typeparam>
+    /// <param name="connectionString">Complete PostgreSQL connection string.</param>
+    /// <param name="operation">Operation to execute with the transaction-aware client.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The operation result.</returns>
+    public virtual async Task<TResult> RunInTransactionAsync<TResult>(
+        string connectionString,
+        Func<PostgreSql, CancellationToken, Task<TResult>> operation,
+        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
+        CancellationToken cancellationToken = default)
+    {
+        if (operation == null)
+        {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+        return await ExecuteInTransactionAsync(
+            token => BeginTransactionAsync(connectionString, isolationLevel, token),
             token => operation(this, token),
             CommitAsync,
             RollbackAsync,

--- a/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
@@ -31,6 +31,7 @@ public partial class SQLite
         {
             throw new ArgumentOutOfRangeException(nameof(maxIssues), "Maximum issue count must be positive.");
         }
+        EnsureNoActiveTransaction();
 
         return RunDedicatedMaintenanceAsync(
             () => CheckIntegrityCore(database, fullCheck, maxIssues, busyTimeoutMs, cancellationToken),
@@ -58,12 +59,14 @@ public partial class SQLite
         EnsureNoActiveTransaction();
         SqliteBackupOptions effectiveOptions = options ?? new SqliteBackupOptions();
         ValidateBackupOptions(effectiveOptions);
+        int backupBusyTimeoutMs = ResolveBackupBusyTimeoutMs(effectiveOptions.BusyTimeoutMs, BusyTimeoutMs);
 
         return RunDedicatedMaintenanceAsync(
             () => BackupDatabaseIncrementalCore(
                 sourceDatabase,
                 destinationDatabase,
                 effectiveOptions,
+                backupBusyTimeoutMs,
                 progress,
                 cancellationToken),
             cancellationToken);
@@ -131,6 +134,7 @@ public partial class SQLite
         string sourceDatabase,
         string destinationDatabase,
         SqliteBackupOptions options,
+        int backupBusyTimeoutMs,
         IProgress<SqliteBackupProgress>? progress,
         CancellationToken cancellationToken)
     {
@@ -174,8 +178,8 @@ public partial class SQLite
                 using var destination = new SqliteConnection(BuildOperationalConnectionString(workingPath));
                 source.Open();
                 destination.Open();
-                ApplyBusyTimeout(source, options.BusyTimeoutMs);
-                ApplyBusyTimeout(destination, options.BusyTimeoutMs);
+                ApplyBusyTimeout(source, backupBusyTimeoutMs);
+                ApplyBusyTimeout(destination, backupBusyTimeoutMs);
                 using CancellationTokenRegistration sourceRegistration = cancellationToken.Register(
                     static state => raw.sqlite3_interrupt(((SqliteConnection)state!).Handle),
                     source);
@@ -264,7 +268,7 @@ public partial class SQLite
 
             if (destinationExisted)
             {
-                File.Replace(workingPath, destinationPath, null, ignoreMetadataErrors: true);
+                ReplaceBackupDestination(workingPath, destinationPath);
             }
 
             stopwatch.Stop();
@@ -339,6 +343,55 @@ public partial class SQLite
             throw new ArgumentOutOfRangeException(
                 nameof(options.BusyTimeoutMs),
                 $"Busy timeout cannot exceed {MaximumBackupBusyTimeoutMs} milliseconds so cancellation remains responsive.");
+        }
+    }
+
+    internal static int ResolveBackupBusyTimeoutMs(int? requestedBusyTimeoutMs, int instanceBusyTimeoutMs)
+        => Math.Min(requestedBusyTimeoutMs ?? instanceBusyTimeoutMs, MaximumBackupBusyTimeoutMs);
+
+    private static void ReplaceBackupDestination(string workingPath, string destinationPath)
+    {
+        var quarantinedSidecars = new List<KeyValuePair<string, string>>();
+        bool replaced = false;
+        try
+        {
+            foreach (string suffix in new[] { "-wal", "-shm" })
+            {
+                string sidecarPath = destinationPath + suffix;
+                if (!File.Exists(sidecarPath))
+                {
+                    continue;
+                }
+
+                string quarantinePath = $"{destinationPath}.{Guid.NewGuid():N}.stale{suffix}";
+                File.Move(sidecarPath, quarantinePath);
+                quarantinedSidecars.Add(new KeyValuePair<string, string>(sidecarPath, quarantinePath));
+            }
+
+            File.Replace(workingPath, destinationPath, null, ignoreMetadataErrors: true);
+            replaced = true;
+        }
+        finally
+        {
+            foreach (KeyValuePair<string, string> sidecar in quarantinedSidecars)
+            {
+                try
+                {
+                    if (replaced)
+                    {
+                        File.Delete(sidecar.Value);
+                    }
+                    else if (!File.Exists(sidecar.Key))
+                    {
+                        File.Move(sidecar.Value, sidecar.Key);
+                    }
+                }
+                catch
+                {
+                    // A quarantined sidecar cannot affect the promoted backup; failed restoration is surfaced by
+                    // the original replacement exception while cleanup remains best effort.
+                }
+            }
         }
     }
 

--- a/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
@@ -1,0 +1,363 @@
+using System.Diagnostics;
+using Microsoft.Data.Sqlite;
+using SQLitePCL;
+
+namespace DBAClientX;
+
+public partial class SQLite
+{
+    /// <summary>
+    /// Runs an SQLite integrity check on a dedicated thread so the provider's synchronous execution cannot block
+    /// an asynchronous caller or scheduler.
+    /// </summary>
+    /// <param name="database">Source SQLite database path.</param>
+    /// <param name="fullCheck">When true, uses <c>PRAGMA integrity_check</c>; otherwise uses <c>PRAGMA quick_check</c>.</param>
+    /// <param name="maxIssues">Maximum number of integrity issues returned by SQLite.</param>
+    /// <param name="busyTimeoutMs">Optional busy timeout in milliseconds.</param>
+    /// <param name="cancellationToken">Token used to interrupt the native SQLite command.</param>
+    /// <returns>A task containing the integrity result.</returns>
+    public virtual Task<SqliteIntegrityCheckResult> CheckIntegrityAsync(
+        string database,
+        bool fullCheck = false,
+        int maxIssues = 10,
+        int? busyTimeoutMs = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateDatabasePath(database);
+        if (maxIssues <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxIssues), "Maximum issue count must be positive.");
+        }
+
+        return RunDedicatedMaintenanceAsync(
+            () => CheckIntegrityCore(database, fullCheck, maxIssues, busyTimeoutMs, cancellationToken),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Copies an SQLite database incrementally on a dedicated thread using SQLite's online backup API.
+    /// </summary>
+    /// <param name="sourceDatabase">Source SQLite database path.</param>
+    /// <param name="destinationDatabase">Destination SQLite database path.</param>
+    /// <param name="options">Backup behavior options.</param>
+    /// <param name="progress">Optional page-based progress observer.</param>
+    /// <param name="cancellationToken">Token used to stop between backup steps and interrupt native work.</param>
+    /// <returns>A task containing the completed backup details.</returns>
+    public virtual Task<SqliteBackupResult> BackupDatabaseIncrementalAsync(
+        string sourceDatabase,
+        string destinationDatabase,
+        SqliteBackupOptions? options = null,
+        IProgress<SqliteBackupProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateDatabasePath(sourceDatabase);
+        ValidateDatabasePath(destinationDatabase);
+        SqliteBackupOptions effectiveOptions = options ?? new SqliteBackupOptions();
+        ValidateBackupOptions(effectiveOptions);
+
+        return RunDedicatedMaintenanceAsync(
+            () => BackupDatabaseIncrementalCore(
+                sourceDatabase,
+                destinationDatabase,
+                effectiveOptions,
+                progress,
+                cancellationToken),
+            cancellationToken);
+    }
+
+    private SqliteIntegrityCheckResult CheckIntegrityCore(
+        string database,
+        bool fullCheck,
+        int maxIssues,
+        int? busyTimeoutMs,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!File.Exists(database))
+        {
+            throw new FileNotFoundException($"SQLite database file does not exist: {database}", database);
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        using var connection = new SqliteConnection(BuildOperationalConnectionString(database, readOnly: true));
+        connection.Open();
+        ApplyBusyTimeout(connection, busyTimeoutMs);
+        using CancellationTokenRegistration registration = cancellationToken.Register(
+            static state => raw.sqlite3_interrupt(((SqliteConnection)state!).Handle),
+            connection);
+        using var command = connection.CreateCommand();
+        command.CommandText = fullCheck
+            ? $"PRAGMA integrity_check({maxIssues});"
+            : $"PRAGMA quick_check({maxIssues});";
+        if (CommandTimeout > 0)
+        {
+            command.CommandTimeout = CommandTimeout;
+        }
+
+        var issues = new List<string>();
+        try
+        {
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                string value = reader.IsDBNull(0) ? string.Empty : reader.GetString(0).Trim();
+                if (value.Length > 0 && !string.Equals(value, "ok", StringComparison.OrdinalIgnoreCase))
+                {
+                    issues.Add(value);
+                }
+            }
+        }
+        catch (SqliteException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
+
+        stopwatch.Stop();
+        return new SqliteIntegrityCheckResult
+        {
+            IsHealthy = issues.Count == 0,
+            IsFullCheck = fullCheck,
+            Issues = issues,
+            Elapsed = stopwatch.Elapsed
+        };
+    }
+
+    private SqliteBackupResult BackupDatabaseIncrementalCore(
+        string sourceDatabase,
+        string destinationDatabase,
+        SqliteBackupOptions options,
+        IProgress<SqliteBackupProgress>? progress,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        string sourcePath = Path.GetFullPath(sourceDatabase);
+        string destinationPath = Path.GetFullPath(destinationDatabase);
+        if (string.Equals(sourcePath, destinationPath, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException("Source and destination database paths must be different.", nameof(destinationDatabase));
+        }
+        if (!File.Exists(sourcePath))
+        {
+            throw new FileNotFoundException($"SQLite database file does not exist: {sourcePath}", sourcePath);
+        }
+
+        string? destinationDirectory = Path.GetDirectoryName(destinationPath);
+        if (!string.IsNullOrWhiteSpace(destinationDirectory))
+        {
+            Directory.CreateDirectory(destinationDirectory);
+        }
+        if (File.Exists(destinationPath))
+        {
+            if (!options.OverwriteDestination)
+            {
+                throw new IOException($"SQLite backup destination already exists: {destinationPath}");
+            }
+
+            File.Delete(destinationPath);
+        }
+
+        var stopwatch = Stopwatch.StartNew();
+        bool completed = false;
+        try
+        {
+            using var source = new SqliteConnection(BuildOperationalConnectionString(sourcePath, readOnly: true));
+            using var destination = new SqliteConnection(BuildOperationalConnectionString(destinationPath));
+            source.Open();
+            destination.Open();
+            ApplyBusyTimeout(source, options.BusyTimeoutMs);
+            ApplyBusyTimeout(destination, options.BusyTimeoutMs);
+            using CancellationTokenRegistration sourceRegistration = cancellationToken.Register(
+                static state => raw.sqlite3_interrupt(((SqliteConnection)state!).Handle),
+                source);
+            using CancellationTokenRegistration destinationRegistration = cancellationToken.Register(
+                static state => raw.sqlite3_interrupt(((SqliteConnection)state!).Handle),
+                destination);
+
+            sqlite3_backup? backup = raw.sqlite3_backup_init(destination.Handle, "main", source.Handle, "main");
+            if (backup == null || backup.IsInvalid)
+            {
+                string message = raw.sqlite3_errmsg(destination.Handle).utf8_to_string();
+                throw new DbaQueryExecutionException("Failed to initialize SQLite online backup.", "SQLite online backup", new InvalidOperationException(message));
+            }
+
+            int resultCode = raw.SQLITE_OK;
+            int totalPages = 0;
+            int remainingPages = 0;
+            Stopwatch? busyStopwatch = null;
+            Exception? backupFailure = null;
+            try
+            {
+                while (resultCode != raw.SQLITE_DONE)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    resultCode = raw.sqlite3_backup_step(backup, options.PagesPerStep);
+                    totalPages = raw.sqlite3_backup_pagecount(backup);
+                    remainingPages = raw.sqlite3_backup_remaining(backup);
+                    ReportBackupProgress(progress, totalPages, remainingPages, stopwatch.Elapsed);
+
+                    if (resultCode == raw.SQLITE_DONE)
+                    {
+                        break;
+                    }
+                    if (resultCode != raw.SQLITE_OK && resultCode != raw.SQLITE_BUSY && resultCode != raw.SQLITE_LOCKED)
+                    {
+                        string message = raw.sqlite3_errmsg(destination.Handle).utf8_to_string();
+                        throw new DbaQueryExecutionException(
+                            $"SQLite online backup failed with result code {resultCode}.",
+                            "SQLite online backup",
+                            new InvalidOperationException(message));
+                    }
+                    bool isBusy = resultCode == raw.SQLITE_BUSY || resultCode == raw.SQLITE_LOCKED;
+                    if (isBusy)
+                    {
+                        busyStopwatch ??= Stopwatch.StartNew();
+                    }
+                    else
+                    {
+                        busyStopwatch = null;
+                    }
+                    if (isBusy &&
+                        options.BusyRetryTimeout > TimeSpan.Zero &&
+                        busyStopwatch!.Elapsed >= options.BusyRetryTimeout)
+                    {
+                        throw new TimeoutException($"SQLite online backup remained busy or locked for {busyStopwatch.Elapsed:g}.");
+                    }
+
+                    TimeSpan delay = isBusy
+                        ? options.BusyRetryDelay
+                        : options.StepDelay;
+                    WaitWithCancellation(delay, cancellationToken);
+                }
+            }
+            catch (Exception exception)
+            {
+                backupFailure = exception;
+                throw;
+            }
+            finally
+            {
+                int finishCode = raw.sqlite3_backup_finish(backup);
+                if (backupFailure == null && resultCode == raw.SQLITE_DONE && finishCode != raw.SQLITE_OK)
+                {
+                    string message = raw.sqlite3_errmsg(destination.Handle).utf8_to_string();
+                    throw new DbaQueryExecutionException(
+                        $"SQLite online backup finalization failed with result code {finishCode}.",
+                        "SQLite online backup",
+                        new InvalidOperationException(message));
+                }
+            }
+
+            stopwatch.Stop();
+            completed = true;
+            ReportBackupProgress(progress, totalPages, 0, stopwatch.Elapsed);
+            return new SqliteBackupResult
+            {
+                SourceDatabase = sourcePath,
+                DestinationDatabase = destinationPath,
+                CopiedPages = totalPages,
+                DestinationLengthBytes = new FileInfo(destinationPath).Length,
+                Elapsed = stopwatch.Elapsed
+            };
+        }
+        catch (SqliteException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
+        finally
+        {
+            if (!completed && options.DeleteDestinationOnFailure)
+            {
+                TryDeleteBackupDestination(destinationPath);
+            }
+        }
+    }
+
+    private static Task<T> RunDedicatedMaintenanceAsync<T>(Func<T> operation, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<T>(cancellationToken);
+        }
+
+        return Task.Factory.StartNew(
+            operation,
+            CancellationToken.None,
+            TaskCreationOptions.DenyChildAttach | TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+    }
+
+    private static void ValidateBackupOptions(SqliteBackupOptions options)
+    {
+        if (options.PagesPerStep <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options.PagesPerStep), "Pages per step must be positive.");
+        }
+        if (options.StepDelay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options.StepDelay), "Step delay cannot be negative.");
+        }
+        if (options.BusyRetryDelay < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options.BusyRetryDelay), "Busy retry delay cannot be negative.");
+        }
+        if (options.BusyRetryTimeout < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options.BusyRetryTimeout), "Busy retry timeout cannot be negative.");
+        }
+        if (options.BusyTimeoutMs < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options.BusyTimeoutMs), "Busy timeout cannot be negative.");
+        }
+    }
+
+    private static void ReportBackupProgress(
+        IProgress<SqliteBackupProgress>? progress,
+        int totalPages,
+        int remainingPages,
+        TimeSpan elapsed)
+    {
+        if (progress == null)
+        {
+            return;
+        }
+
+        int copiedPages = Math.Max(0, totalPages - remainingPages);
+        double percentage = totalPages > 0 ? copiedPages * 100d / totalPages : 0d;
+        progress.Report(new SqliteBackupProgress
+        {
+            TotalPages = totalPages,
+            CopiedPages = copiedPages,
+            RemainingPages = Math.Max(0, remainingPages),
+            PercentComplete = percentage,
+            Elapsed = elapsed
+        });
+    }
+
+    private static void WaitWithCancellation(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        if (delay <= TimeSpan.Zero)
+        {
+            return;
+        }
+        if (cancellationToken.WaitHandle.WaitOne(delay))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+
+    private static void TryDeleteBackupDestination(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // The caller receives the original backup failure; cleanup is best effort.
+        }
+    }
+}

--- a/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
@@ -7,7 +7,6 @@ namespace DBAClientX;
 public partial class SQLite
 {
     private const int MaximumBackupPagesPerStep = 4096;
-    private const int MaximumBackupBusyTimeoutMs = 1000;
 
     /// <summary>
     /// Runs an SQLite integrity check on a dedicated thread so the provider's synchronous execution cannot block
@@ -59,14 +58,12 @@ public partial class SQLite
         EnsureNoActiveTransaction();
         SqliteBackupOptions effectiveOptions = SnapshotBackupOptions(options);
         ValidateBackupOptions(effectiveOptions);
-        int backupBusyTimeoutMs = ResolveBackupBusyTimeoutMs(effectiveOptions.BusyTimeoutMs, BusyTimeoutMs);
 
         return RunDedicatedMaintenanceAsync(
             () => BackupDatabaseIncrementalCore(
                 sourceDatabase,
                 destinationDatabase,
                 effectiveOptions,
-                backupBusyTimeoutMs,
                 progress,
                 cancellationToken),
             cancellationToken);
@@ -134,7 +131,6 @@ public partial class SQLite
         string sourceDatabase,
         string destinationDatabase,
         SqliteBackupOptions options,
-        int backupBusyTimeoutMs,
         IProgress<SqliteBackupProgress>? progress,
         CancellationToken cancellationToken)
     {
@@ -178,8 +174,6 @@ public partial class SQLite
                 using var destination = new SqliteConnection(BuildOperationalConnectionString(workingPath));
                 source.Open();
                 destination.Open();
-                ApplyBusyTimeout(source, backupBusyTimeoutMs);
-                ApplyBusyTimeout(destination, backupBusyTimeoutMs);
                 using CancellationTokenRegistration sourceRegistration = cancellationToken.Register(
                     static state => raw.sqlite3_interrupt(((SqliteConnection)state!).Handle),
                     source);
@@ -334,14 +328,7 @@ public partial class SQLite
         {
             throw new ArgumentOutOfRangeException(nameof(options.BusyRetryTimeout), "Busy retry timeout cannot be negative.");
         }
-        if (options.BusyTimeoutMs < 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(options.BusyTimeoutMs), "Busy timeout cannot be negative.");
-        }
     }
-
-    internal static int ResolveBackupBusyTimeoutMs(int? requestedBusyTimeoutMs, int instanceBusyTimeoutMs)
-        => Math.Min(requestedBusyTimeoutMs ?? instanceBusyTimeoutMs, MaximumBackupBusyTimeoutMs);
 
     internal static SqliteBackupOptions SnapshotBackupOptions(SqliteBackupOptions? options)
     {
@@ -352,7 +339,6 @@ public partial class SQLite
             StepDelay = source.StepDelay,
             BusyRetryDelay = source.BusyRetryDelay,
             BusyRetryTimeout = source.BusyRetryTimeout,
-            BusyTimeoutMs = source.BusyTimeoutMs,
             OverwriteDestination = source.OverwriteDestination,
             DeleteDestinationOnFailure = source.DeleteDestinationOnFailure
         };

--- a/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
@@ -338,12 +338,6 @@ public partial class SQLite
         {
             throw new ArgumentOutOfRangeException(nameof(options.BusyTimeoutMs), "Busy timeout cannot be negative.");
         }
-        if (options.BusyTimeoutMs > MaximumBackupBusyTimeoutMs)
-        {
-            throw new ArgumentOutOfRangeException(
-                nameof(options.BusyTimeoutMs),
-                $"Busy timeout cannot exceed {MaximumBackupBusyTimeoutMs} milliseconds so cancellation remains responsive.");
-        }
     }
 
     internal static int ResolveBackupBusyTimeoutMs(int? requestedBusyTimeoutMs, int instanceBusyTimeoutMs)

--- a/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
@@ -57,7 +57,7 @@ public partial class SQLite
         ValidateDatabasePath(sourceDatabase);
         ValidateDatabasePath(destinationDatabase);
         EnsureNoActiveTransaction();
-        SqliteBackupOptions effectiveOptions = options ?? new SqliteBackupOptions();
+        SqliteBackupOptions effectiveOptions = SnapshotBackupOptions(options);
         ValidateBackupOptions(effectiveOptions);
         int backupBusyTimeoutMs = ResolveBackupBusyTimeoutMs(effectiveOptions.BusyTimeoutMs, BusyTimeoutMs);
 
@@ -349,13 +349,28 @@ public partial class SQLite
     internal static int ResolveBackupBusyTimeoutMs(int? requestedBusyTimeoutMs, int instanceBusyTimeoutMs)
         => Math.Min(requestedBusyTimeoutMs ?? instanceBusyTimeoutMs, MaximumBackupBusyTimeoutMs);
 
+    internal static SqliteBackupOptions SnapshotBackupOptions(SqliteBackupOptions? options)
+    {
+        SqliteBackupOptions source = options ?? new SqliteBackupOptions();
+        return new SqliteBackupOptions
+        {
+            PagesPerStep = source.PagesPerStep,
+            StepDelay = source.StepDelay,
+            BusyRetryDelay = source.BusyRetryDelay,
+            BusyRetryTimeout = source.BusyRetryTimeout,
+            BusyTimeoutMs = source.BusyTimeoutMs,
+            OverwriteDestination = source.OverwriteDestination,
+            DeleteDestinationOnFailure = source.DeleteDestinationOnFailure
+        };
+    }
+
     private static void ReplaceBackupDestination(string workingPath, string destinationPath)
     {
         var quarantinedSidecars = new List<KeyValuePair<string, string>>();
         bool replaced = false;
         try
         {
-            foreach (string suffix in new[] { "-wal", "-shm" })
+            foreach (string suffix in new[] { "-wal", "-shm", "-journal" })
             {
                 string sidecarPath = destinationPath + suffix;
                 if (!File.Exists(sidecarPath))

--- a/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
@@ -6,6 +6,9 @@ namespace DBAClientX;
 
 public partial class SQLite
 {
+    private const int MaximumBackupPagesPerStep = 4096;
+    private const int MaximumBackupBusyTimeoutMs = 1000;
+
     /// <summary>
     /// Runs an SQLite integrity check on a dedicated thread so the provider's synchronous execution cannot block
     /// an asynchronous caller or scheduler.
@@ -52,6 +55,7 @@ public partial class SQLite
     {
         ValidateDatabasePath(sourceDatabase);
         ValidateDatabasePath(destinationDatabase);
+        EnsureNoActiveTransaction();
         SqliteBackupOptions effectiveOptions = options ?? new SqliteBackupOptions();
         ValidateBackupOptions(effectiveOptions);
 
@@ -147,105 +151,120 @@ public partial class SQLite
         {
             Directory.CreateDirectory(destinationDirectory);
         }
-        if (File.Exists(destinationPath))
+        bool destinationExisted = File.Exists(destinationPath);
+        if (destinationExisted)
         {
             if (!options.OverwriteDestination)
             {
                 throw new IOException($"SQLite backup destination already exists: {destinationPath}");
             }
-
-            File.Delete(destinationPath);
         }
+
+        string workingPath = destinationExisted
+            ? $"{destinationPath}.{Guid.NewGuid():N}.partial"
+            : destinationPath;
 
         var stopwatch = Stopwatch.StartNew();
         bool completed = false;
+        int totalPages = 0;
         try
         {
-            using var source = new SqliteConnection(BuildOperationalConnectionString(sourcePath, readOnly: true));
-            using var destination = new SqliteConnection(BuildOperationalConnectionString(destinationPath));
-            source.Open();
-            destination.Open();
-            ApplyBusyTimeout(source, options.BusyTimeoutMs);
-            ApplyBusyTimeout(destination, options.BusyTimeoutMs);
-            using CancellationTokenRegistration sourceRegistration = cancellationToken.Register(
-                static state => raw.sqlite3_interrupt(((SqliteConnection)state!).Handle),
-                source);
-            using CancellationTokenRegistration destinationRegistration = cancellationToken.Register(
-                static state => raw.sqlite3_interrupt(((SqliteConnection)state!).Handle),
-                destination);
-
-            sqlite3_backup? backup = raw.sqlite3_backup_init(destination.Handle, "main", source.Handle, "main");
-            if (backup == null || backup.IsInvalid)
             {
-                string message = raw.sqlite3_errmsg(destination.Handle).utf8_to_string();
-                throw new DbaQueryExecutionException("Failed to initialize SQLite online backup.", "SQLite online backup", new InvalidOperationException(message));
-            }
+                using var source = new SqliteConnection(BuildOperationalConnectionString(sourcePath, readOnly: true));
+                using var destination = new SqliteConnection(BuildOperationalConnectionString(workingPath));
+                source.Open();
+                destination.Open();
+                ApplyBusyTimeout(source, options.BusyTimeoutMs);
+                ApplyBusyTimeout(destination, options.BusyTimeoutMs);
+                using CancellationTokenRegistration sourceRegistration = cancellationToken.Register(
+                    static state => raw.sqlite3_interrupt(((SqliteConnection)state!).Handle),
+                    source);
+                using CancellationTokenRegistration destinationRegistration = cancellationToken.Register(
+                    static state => raw.sqlite3_interrupt(((SqliteConnection)state!).Handle),
+                    destination);
 
-            int resultCode = raw.SQLITE_OK;
-            int totalPages = 0;
-            int remainingPages = 0;
-            Stopwatch? busyStopwatch = null;
-            Exception? backupFailure = null;
-            try
-            {
-                while (resultCode != raw.SQLITE_DONE)
+                sqlite3_backup? backup = raw.sqlite3_backup_init(destination.Handle, "main", source.Handle, "main");
+                if (backup == null || backup.IsInvalid)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    resultCode = raw.sqlite3_backup_step(backup, options.PagesPerStep);
-                    totalPages = raw.sqlite3_backup_pagecount(backup);
-                    remainingPages = raw.sqlite3_backup_remaining(backup);
-                    ReportBackupProgress(progress, totalPages, remainingPages, stopwatch.Elapsed);
+                    string message = raw.sqlite3_errmsg(destination.Handle).utf8_to_string();
+                    throw new DbaQueryExecutionException("Failed to initialize SQLite online backup.", "SQLite online backup", new InvalidOperationException(message));
+                }
 
-                    if (resultCode == raw.SQLITE_DONE)
+                int resultCode = raw.SQLITE_OK;
+                int remainingPages = 0;
+                TimeSpan cumulativeBusyDuration = TimeSpan.Zero;
+                Exception? backupFailure = null;
+                try
+                {
+                    while (resultCode != raw.SQLITE_DONE)
                     {
-                        break;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var stepStopwatch = Stopwatch.StartNew();
+                        resultCode = raw.sqlite3_backup_step(backup, options.PagesPerStep);
+                        stepStopwatch.Stop();
+                        totalPages = raw.sqlite3_backup_pagecount(backup);
+                        remainingPages = raw.sqlite3_backup_remaining(backup);
+                        ReportBackupProgress(progress, totalPages, remainingPages, stopwatch.Elapsed);
+
+                        if (resultCode == raw.SQLITE_DONE)
+                        {
+                            break;
+                        }
+                        if (resultCode != raw.SQLITE_OK && resultCode != raw.SQLITE_BUSY && resultCode != raw.SQLITE_LOCKED)
+                        {
+                            string message = raw.sqlite3_errmsg(destination.Handle).utf8_to_string();
+                            throw new DbaQueryExecutionException(
+                                $"SQLite online backup failed with result code {resultCode}.",
+                                "SQLite online backup",
+                                new InvalidOperationException(message));
+                        }
+
+                        bool isBusy = resultCode == raw.SQLITE_BUSY || resultCode == raw.SQLITE_LOCKED;
+                        if (isBusy)
+                        {
+                            cumulativeBusyDuration += stepStopwatch.Elapsed;
+                            ThrowIfBusyRetryTimeoutExceeded(cumulativeBusyDuration, options.BusyRetryTimeout);
+                        }
+
+                        TimeSpan delay = isBusy
+                            ? options.BusyRetryDelay
+                            : options.StepDelay;
+                        if (isBusy && delay > TimeSpan.Zero)
+                        {
+                            var delayStopwatch = Stopwatch.StartNew();
+                            WaitWithCancellation(delay, cancellationToken);
+                            delayStopwatch.Stop();
+                            cumulativeBusyDuration += delayStopwatch.Elapsed;
+                            ThrowIfBusyRetryTimeoutExceeded(cumulativeBusyDuration, options.BusyRetryTimeout);
+                        }
+                        else
+                        {
+                            WaitWithCancellation(delay, cancellationToken);
+                        }
                     }
-                    if (resultCode != raw.SQLITE_OK && resultCode != raw.SQLITE_BUSY && resultCode != raw.SQLITE_LOCKED)
+                }
+                catch (Exception exception)
+                {
+                    backupFailure = exception;
+                    throw;
+                }
+                finally
+                {
+                    int finishCode = raw.sqlite3_backup_finish(backup);
+                    if (backupFailure == null && resultCode == raw.SQLITE_DONE && finishCode != raw.SQLITE_OK)
                     {
                         string message = raw.sqlite3_errmsg(destination.Handle).utf8_to_string();
                         throw new DbaQueryExecutionException(
-                            $"SQLite online backup failed with result code {resultCode}.",
+                            $"SQLite online backup finalization failed with result code {finishCode}.",
                             "SQLite online backup",
                             new InvalidOperationException(message));
                     }
-                    bool isBusy = resultCode == raw.SQLITE_BUSY || resultCode == raw.SQLITE_LOCKED;
-                    if (isBusy)
-                    {
-                        busyStopwatch ??= Stopwatch.StartNew();
-                    }
-                    else
-                    {
-                        busyStopwatch = null;
-                    }
-                    if (isBusy &&
-                        options.BusyRetryTimeout > TimeSpan.Zero &&
-                        busyStopwatch!.Elapsed >= options.BusyRetryTimeout)
-                    {
-                        throw new TimeoutException($"SQLite online backup remained busy or locked for {busyStopwatch.Elapsed:g}.");
-                    }
+                }
+            }
 
-                    TimeSpan delay = isBusy
-                        ? options.BusyRetryDelay
-                        : options.StepDelay;
-                    WaitWithCancellation(delay, cancellationToken);
-                }
-            }
-            catch (Exception exception)
+            if (destinationExisted)
             {
-                backupFailure = exception;
-                throw;
-            }
-            finally
-            {
-                int finishCode = raw.sqlite3_backup_finish(backup);
-                if (backupFailure == null && resultCode == raw.SQLITE_DONE && finishCode != raw.SQLITE_OK)
-                {
-                    string message = raw.sqlite3_errmsg(destination.Handle).utf8_to_string();
-                    throw new DbaQueryExecutionException(
-                        $"SQLite online backup finalization failed with result code {finishCode}.",
-                        "SQLite online backup",
-                        new InvalidOperationException(message));
-                }
+                File.Replace(workingPath, destinationPath, null, ignoreMetadataErrors: true);
             }
 
             stopwatch.Stop();
@@ -268,7 +287,7 @@ public partial class SQLite
         {
             if (!completed && options.DeleteDestinationOnFailure)
             {
-                TryDeleteBackupDestination(destinationPath);
+                TryDeleteBackupDestination(workingPath);
             }
         }
     }
@@ -293,6 +312,12 @@ public partial class SQLite
         {
             throw new ArgumentOutOfRangeException(nameof(options.PagesPerStep), "Pages per step must be positive.");
         }
+        if (options.PagesPerStep > MaximumBackupPagesPerStep)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options.PagesPerStep),
+                $"Pages per step cannot exceed {MaximumBackupPagesPerStep} so cancellation remains responsive.");
+        }
         if (options.StepDelay < TimeSpan.Zero)
         {
             throw new ArgumentOutOfRangeException(nameof(options.StepDelay), "Step delay cannot be negative.");
@@ -308,6 +333,20 @@ public partial class SQLite
         if (options.BusyTimeoutMs < 0)
         {
             throw new ArgumentOutOfRangeException(nameof(options.BusyTimeoutMs), "Busy timeout cannot be negative.");
+        }
+        if (options.BusyTimeoutMs > MaximumBackupBusyTimeoutMs)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options.BusyTimeoutMs),
+                $"Busy timeout cannot exceed {MaximumBackupBusyTimeoutMs} milliseconds so cancellation remains responsive.");
+        }
+    }
+
+    private static void ThrowIfBusyRetryTimeoutExceeded(TimeSpan elapsed, TimeSpan timeout)
+    {
+        if (timeout > TimeSpan.Zero && elapsed >= timeout)
+        {
+            throw new TimeoutException($"SQLite online backup cumulative busy or locked time reached {elapsed:g}.");
         }
     }
 
@@ -350,9 +389,13 @@ public partial class SQLite
     {
         try
         {
-            if (File.Exists(path))
+            foreach (string suffix in new[] { string.Empty, "-wal", "-shm" })
             {
-                File.Delete(path);
+                string candidate = path + suffix;
+                if (File.Exists(candidate))
+                {
+                    File.Delete(candidate);
+                }
             }
         }
         catch

--- a/DbaClientX.SQLite/SQLite.Maintenance.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.cs
@@ -215,9 +215,13 @@ public partial class SQLite
 
     private void EnsureNoActiveTransaction()
     {
-        if (IsInTransaction)
+        lock (_syncRoot)
         {
-            throw new DbaTransactionException("SQLite maintenance cannot run while a transaction is active.");
+            if (_transaction != null || _transactionInitializing)
+            {
+                throw new DbaTransactionException(
+                    "SQLite maintenance cannot run while a transaction is active or starting.");
+            }
         }
     }
 

--- a/DbaClientX.SQLite/SQLite.Maintenance.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.cs
@@ -152,7 +152,7 @@ public partial class SQLite
         }
     }
 
-    private async Task ExecuteMaintenancePragmaAsync(
+    private Task ExecuteMaintenancePragmaAsync(
         string database,
         string pragma,
         CancellationToken cancellationToken,
@@ -163,12 +163,30 @@ public partial class SQLite
         EnsureNoActiveTransaction();
         EnsureMaintenanceDatabaseExists(database);
 
-        SqliteConnection? connection = null;
+        return RunDedicatedMaintenanceAsync(
+            () =>
+            {
+                ExecuteMaintenancePragmaCore(database, pragma, busyTimeoutMs, cancellationToken);
+                return true;
+            },
+            cancellationToken);
+    }
+
+    private void ExecuteMaintenancePragmaCore(
+        string database,
+        string pragma,
+        int? busyTimeoutMs,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
         try
         {
-            connection = new SqliteConnection(BuildOperationalConnectionString(database));
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-            await ApplyBusyTimeoutAsync(connection, busyTimeoutMs, cancellationToken).ConfigureAwait(false);
+            using var connection = new SqliteConnection(BuildOperationalConnectionString(database));
+            connection.Open();
+            ApplyBusyTimeout(connection, busyTimeoutMs);
+            using CancellationTokenRegistration registration = cancellationToken.Register(
+                static state => SQLitePCL.raw.sqlite3_interrupt(((SqliteConnection)state!).Handle),
+                connection);
 
             using var command = connection.CreateCommand();
             command.CommandText = pragma;
@@ -178,22 +196,20 @@ public partial class SQLite
                 command.CommandTimeout = commandTimeout;
             }
 
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            command.ExecuteNonQuery();
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+        catch (SqliteException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             throw new DbaQueryExecutionException("Failed to execute SQLite maintenance command.", pragma, ex);
-        }
-        finally
-        {
-            if (connection != null)
-            {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
-                await connection.DisposeAsync().ConfigureAwait(false);
-#else
-                connection.Dispose();
-#endif
-            }
         }
     }
 

--- a/DbaClientX.SQLite/SqliteBackupOptions.cs
+++ b/DbaClientX.SQLite/SqliteBackupOptions.cs
@@ -29,12 +29,6 @@ public sealed class SqliteBackupOptions
     public TimeSpan BusyRetryTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Gets or sets an optional SQLite busy timeout applied to the source and destination connections. Values above
-    /// 1000 milliseconds are rejected so a native backup step cannot defer cancellation for an extended period.
-    /// </summary>
-    public int? BusyTimeoutMs { get; set; }
-
-    /// <summary>
     /// Gets or sets a value indicating whether an existing destination file may be replaced.
     /// </summary>
     public bool OverwriteDestination { get; set; }

--- a/DbaClientX.SQLite/SqliteBackupOptions.cs
+++ b/DbaClientX.SQLite/SqliteBackupOptions.cs
@@ -1,0 +1,44 @@
+namespace DBAClientX;
+
+/// <summary>
+/// Controls an incremental SQLite online backup operation.
+/// </summary>
+public sealed class SqliteBackupOptions
+{
+    /// <summary>
+    /// Gets or sets the number of database pages copied by each online-backup step.
+    /// Smaller values release the source read lock more frequently.
+    /// </summary>
+    public int PagesPerStep { get; set; } = 256;
+
+    /// <summary>
+    /// Gets or sets an optional delay between successful backup steps.
+    /// </summary>
+    public TimeSpan StepDelay { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    /// Gets or sets the delay before retrying a busy or locked backup step.
+    /// </summary>
+    public TimeSpan BusyRetryDelay { get; set; } = TimeSpan.FromMilliseconds(100);
+
+    /// <summary>
+    /// Gets or sets the maximum cumulative elapsed time allowed while the backup remains busy or locked.
+    /// Set to <see cref="TimeSpan.Zero"/> to retry without an additional deadline.
+    /// </summary>
+    public TimeSpan BusyRetryTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Gets or sets an optional SQLite busy timeout applied to the source and destination connections.
+    /// </summary>
+    public int? BusyTimeoutMs { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an existing destination file may be replaced.
+    /// </summary>
+    public bool OverwriteDestination { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a destination created by a failed or canceled backup is deleted.
+    /// </summary>
+    public bool DeleteDestinationOnFailure { get; set; } = true;
+}

--- a/DbaClientX.SQLite/SqliteBackupOptions.cs
+++ b/DbaClientX.SQLite/SqliteBackupOptions.cs
@@ -7,7 +7,8 @@ public sealed class SqliteBackupOptions
 {
     /// <summary>
     /// Gets or sets the number of database pages copied by each online-backup step.
-    /// Smaller values release the source read lock more frequently.
+    /// Smaller values release the source read lock more frequently. Values above 4096 are rejected so cancellation
+    /// remains responsive while native backup work is in progress.
     /// </summary>
     public int PagesPerStep { get; set; } = 256;
 
@@ -28,7 +29,8 @@ public sealed class SqliteBackupOptions
     public TimeSpan BusyRetryTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Gets or sets an optional SQLite busy timeout applied to the source and destination connections.
+    /// Gets or sets an optional SQLite busy timeout applied to the source and destination connections. Values above
+    /// 1000 milliseconds are rejected so a native backup step cannot defer cancellation for an extended period.
     /// </summary>
     public int? BusyTimeoutMs { get; set; }
 

--- a/DbaClientX.SQLite/SqliteBackupProgress.cs
+++ b/DbaClientX.SQLite/SqliteBackupProgress.cs
@@ -1,0 +1,22 @@
+namespace DBAClientX;
+
+/// <summary>
+/// Describes progress reported by an incremental SQLite online backup.
+/// </summary>
+public sealed class SqliteBackupProgress
+{
+    /// <summary>Gets the number of source pages reported by SQLite.</summary>
+    public int TotalPages { get; set; }
+
+    /// <summary>Gets the number of pages copied into the destination.</summary>
+    public int CopiedPages { get; set; }
+
+    /// <summary>Gets the number of pages remaining.</summary>
+    public int RemainingPages { get; set; }
+
+    /// <summary>Gets the completion percentage when the total page count is known.</summary>
+    public double PercentComplete { get; set; }
+
+    /// <summary>Gets the elapsed backup duration.</summary>
+    public TimeSpan Elapsed { get; set; }
+}

--- a/DbaClientX.SQLite/SqliteBackupResult.cs
+++ b/DbaClientX.SQLite/SqliteBackupResult.cs
@@ -1,0 +1,22 @@
+namespace DBAClientX;
+
+/// <summary>
+/// Describes a completed SQLite online backup.
+/// </summary>
+public sealed class SqliteBackupResult
+{
+    /// <summary>Gets the normalized source database path.</summary>
+    public string SourceDatabase { get; set; } = string.Empty;
+
+    /// <summary>Gets the normalized destination database path.</summary>
+    public string DestinationDatabase { get; set; } = string.Empty;
+
+    /// <summary>Gets the final number of pages copied.</summary>
+    public int CopiedPages { get; set; }
+
+    /// <summary>Gets the final destination length in bytes.</summary>
+    public long DestinationLengthBytes { get; set; }
+
+    /// <summary>Gets the elapsed backup duration.</summary>
+    public TimeSpan Elapsed { get; set; }
+}

--- a/DbaClientX.SQLite/SqliteIntegrityCheckResult.cs
+++ b/DbaClientX.SQLite/SqliteIntegrityCheckResult.cs
@@ -1,0 +1,19 @@
+namespace DBAClientX;
+
+/// <summary>
+/// Describes the result of an SQLite integrity check.
+/// </summary>
+public sealed class SqliteIntegrityCheckResult
+{
+    /// <summary>Gets a value indicating whether SQLite reported a healthy database.</summary>
+    public bool IsHealthy { get; set; }
+
+    /// <summary>Gets a value indicating whether the full integrity check was requested.</summary>
+    public bool IsFullCheck { get; set; }
+
+    /// <summary>Gets the issues returned by SQLite.</summary>
+    public IReadOnlyList<string> Issues { get; set; } = Array.Empty<string>();
+
+    /// <summary>Gets the elapsed check duration.</summary>
+    public TimeSpan Elapsed { get; set; }
+}

--- a/DbaClientX.SqlServer/SqlServer.Transactions.cs
+++ b/DbaClientX.SqlServer/SqlServer.Transactions.cs
@@ -112,6 +112,32 @@ public partial class SqlServer
         string? username = null,
         string? password = null)
     {
+        var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
+        await BeginTransactionAsync(connectionString, isolationLevel, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Begins a transaction asynchronously using an existing SQL Server connection string and the default isolation level.
+    /// </summary>
+    /// <param name="connectionString">Complete SQL Server connection string.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already active.</exception>
+    public virtual Task BeginTransactionAsync(string connectionString, CancellationToken cancellationToken = default)
+        => BeginTransactionAsync(connectionString, IsolationLevel.ReadCommitted, cancellationToken);
+
+    /// <summary>
+    /// Begins a transaction asynchronously using an existing SQL Server connection string.
+    /// </summary>
+    /// <param name="connectionString">Complete SQL Server connection string.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <exception cref="DbaTransactionException">Thrown when a transaction is already active.</exception>
+    public virtual async Task BeginTransactionAsync(
+        string connectionString,
+        IsolationLevel isolationLevel,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateConnectionString(connectionString);
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;
         try
@@ -121,7 +147,6 @@ public partial class SqlServer
                 ReserveTransactionStart(_transaction, ref _transactionInitializing);
             }
 
-            var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
 
             connection = CreateConnection(connectionString);
@@ -263,6 +288,64 @@ public partial class SqlServer
 
         return await ExecuteInTransactionAsync(
             token => BeginTransactionAsync(serverOrInstance, database, integratedSecurity, isolationLevel, token, username, password),
+            token => operation(this, token),
+            CommitAsync,
+            RollbackAsync,
+            () => IsInTransaction,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Runs the provided asynchronous callback inside a SQL Server transaction created from a complete connection string and commits on success.
+    /// </summary>
+    /// <param name="connectionString">Complete SQL Server connection string.</param>
+    /// <param name="operation">Operation to execute with the transaction-aware client.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    public virtual Task RunInTransactionAsync(
+        string connectionString,
+        Func<SqlServer, CancellationToken, Task> operation,
+        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
+        CancellationToken cancellationToken = default)
+    {
+        if (operation == null)
+        {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+        return RunInTransactionAsync(
+            connectionString,
+            async (client, token) =>
+            {
+                await operation(client, token).ConfigureAwait(false);
+                return true;
+            },
+            isolationLevel,
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Runs the provided asynchronous callback inside a SQL Server transaction created from a complete connection string and commits on success.
+    /// </summary>
+    /// <typeparam name="TResult">Type returned by the operation.</typeparam>
+    /// <param name="connectionString">Complete SQL Server connection string.</param>
+    /// <param name="operation">Operation to execute with the transaction-aware client.</param>
+    /// <param name="isolationLevel">Isolation level to apply to the transaction.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>The operation result.</returns>
+    public virtual async Task<TResult> RunInTransactionAsync<TResult>(
+        string connectionString,
+        Func<SqlServer, CancellationToken, Task<TResult>> operation,
+        IsolationLevel isolationLevel = IsolationLevel.ReadCommitted,
+        CancellationToken cancellationToken = default)
+    {
+        if (operation == null)
+        {
+            throw new ArgumentNullException(nameof(operation));
+        }
+
+        return await ExecuteInTransactionAsync(
+            token => BeginTransactionAsync(connectionString, isolationLevel, token),
             token => operation(this, token),
             CommitAsync,
             RollbackAsync,

--- a/DbaClientX.Tests/MySqlTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/MySqlTransactionAsyncTests.cs
@@ -63,7 +63,14 @@ public class MySqlTransactionAsyncTests
     {
         private readonly object _syncRoot = new();
         public FakeMySqlConnection? Connection { get; private set; }
+        public string? ConnectionString { get; private set; }
         public FakeMySqlTransaction? Transaction { get; private set; }
+
+        public override Task BeginTransactionAsync(string connectionString, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+        {
+            ConnectionString = connectionString;
+            return BeginTransactionAsync("h", "d", "u", "p", isolationLevel, cancellationToken);
+        }
 
         public override async Task BeginTransactionAsync(string host, string database, string username, string password, CancellationToken cancellationToken = default)
         {
@@ -213,6 +220,20 @@ public class MySqlTransactionAsyncTests
         });
 
         Assert.Equal(42, result);
+        Assert.Null(mySql.Transaction);
+    }
+
+    [Fact]
+    public async Task RunInTransactionAsync_WithConnectionString_PreservesConnectionOptions()
+    {
+        using var mySql = new TestMySql();
+        const string connectionString = "Server=h;Database=d;User ID=u;Password=p;SslMode=Required;Connection Timeout=15";
+
+        var result = await mySql.RunInTransactionAsync(connectionString, (_, _) => Task.FromResult(42), IsolationLevel.Serializable);
+
+        Assert.Equal(42, result);
+        Assert.Equal(connectionString, mySql.ConnectionString);
+        Assert.Equal(IsolationLevel.Serializable, mySql.Connection!.Level);
         Assert.Null(mySql.Transaction);
     }
 

--- a/DbaClientX.Tests/OracleTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/OracleTransactionAsyncTests.cs
@@ -61,7 +61,14 @@ public class OracleTransactionAsyncTests
     {
         private readonly object _syncRoot = new();
         public FakeOracleConnection? Connection { get; private set; }
+        public string? ConnectionString { get; private set; }
         public FakeOracleTransaction? Transaction { get; private set; }
+
+        public override Task BeginTransactionAsync(string connectionString, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+        {
+            ConnectionString = connectionString;
+            return BeginTransactionAsync("h", "svc", "u", "p", isolationLevel, cancellationToken);
+        }
 
         public override async Task BeginTransactionAsync(string host, string serviceName, string username, string password, CancellationToken cancellationToken = default)
         {
@@ -214,6 +221,20 @@ public class OracleTransactionAsyncTests
         });
 
         Assert.Equal(42, result);
+        Assert.Null(oracle.Transaction);
+    }
+
+    [Fact]
+    public async Task RunInTransactionAsync_WithConnectionString_PreservesConnectionOptions()
+    {
+        using var oracle = new TestOracle();
+        const string connectionString = "Data Source=h/svc;User Id=u;Password=p;Pooling=true;Connection Timeout=15";
+
+        var result = await oracle.RunInTransactionAsync(connectionString, (_, _) => Task.FromResult(42), IsolationLevel.Serializable);
+
+        Assert.Equal(42, result);
+        Assert.Equal(connectionString, oracle.ConnectionString);
+        Assert.Equal(IsolationLevel.Serializable, oracle.Connection!.Level);
         Assert.Null(oracle.Transaction);
     }
 

--- a/DbaClientX.Tests/PostgreSqlTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/PostgreSqlTransactionAsyncTests.cs
@@ -62,7 +62,14 @@ public class PostgreSqlTransactionAsyncTests
     {
         private readonly object _syncRoot = new();
         public FakeNpgsqlConnection? Connection { get; private set; }
+        public string? ConnectionString { get; private set; }
         public FakeNpgsqlTransaction? Transaction { get; private set; }
+
+        public override Task BeginTransactionAsync(string connectionString, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+        {
+            ConnectionString = connectionString;
+            return BeginTransactionAsync("h", "d", "u", "p", isolationLevel, cancellationToken);
+        }
 
         public override async Task BeginTransactionAsync(string host, string database, string username, string password, CancellationToken cancellationToken = default)
         {
@@ -212,6 +219,20 @@ public class PostgreSqlTransactionAsyncTests
         });
 
         Assert.Equal(42, result);
+        Assert.Null(pg.Transaction);
+    }
+
+    [Fact]
+    public async Task RunInTransactionAsync_WithConnectionString_PreservesConnectionOptions()
+    {
+        using var pg = new TestPostgreSql();
+        const string connectionString = "Host=h;Database=d;Username=u;Password=p;SSL Mode=Require;Target Session Attributes=read-write";
+
+        var result = await pg.RunInTransactionAsync(connectionString, (_, _) => Task.FromResult(42), IsolationLevel.Serializable);
+
+        Assert.Equal(42, result);
+        Assert.Equal(connectionString, pg.ConnectionString);
+        Assert.Equal(IsolationLevel.Serializable, pg.Connection!.Level);
         Assert.Null(pg.Transaction);
     }
 

--- a/DbaClientX.Tests/SQLiteTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/SQLiteTransactionAsyncTests.cs
@@ -168,6 +168,22 @@ public class SQLiteTransactionAsyncTests
     }
 
     [Fact]
+    public async Task BackupDatabaseIncrementalAsync_WhileAsyncTransactionInitializationIsReserved_Throws()
+    {
+        using var sqlite = new DBAClientX.SQLite();
+
+        Task transactionStart = sqlite.BeginTransactionAsync(":memory:");
+        await Assert.ThrowsAsync<DBAClientX.DbaTransactionException>(() =>
+            sqlite.BackupDatabaseIncrementalAsync(":memory:", "maintenance-startup-race.sqlite"));
+
+        await transactionStart;
+        Assert.True(sqlite.IsInTransaction);
+
+        await sqlite.RollbackAsync();
+        Assert.False(sqlite.IsInTransaction);
+    }
+
+    [Fact]
     public async Task CommitAsync_CallsCommitOnTransaction()
     {
         using var sqlite = new TestSQLite();

--- a/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
+++ b/DbaClientX.Tests/SqlServerTransactionAsyncTests.cs
@@ -60,7 +60,14 @@ public class SqlServerTransactionAsyncTests
     {
         private readonly object _syncRoot = new();
         public FakeSqlConnection? Connection { get; private set; }
+        public string? ConnectionString { get; private set; }
         public FakeSqlTransaction? Transaction { get; private set; }
+
+        public override Task BeginTransactionAsync(string connectionString, IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+        {
+            ConnectionString = connectionString;
+            return BeginTransactionAsync("s", "db", true, isolationLevel, cancellationToken);
+        }
 
         public override async Task BeginTransactionAsync(string serverOrInstance, string database, bool integratedSecurity, CancellationToken cancellationToken = default, string? username = null, string? password = null)
         {
@@ -210,6 +217,20 @@ public class SqlServerTransactionAsyncTests
         });
 
         Assert.Equal(42, result);
+        Assert.Null(server.Transaction);
+    }
+
+    [Fact]
+    public async Task RunInTransactionAsync_WithConnectionString_PreservesConnectionOptions()
+    {
+        using var server = new TestSqlServer();
+        const string connectionString = "Server=s;Database=db;Integrated Security=true;Encrypt=true;MultiSubnetFailover=true";
+
+        var result = await server.RunInTransactionAsync(connectionString, (_, _) => Task.FromResult(42), IsolationLevel.Serializable);
+
+        Assert.Equal(42, result);
+        Assert.Equal(connectionString, server.ConnectionString);
+        Assert.Equal(IsolationLevel.Serializable, server.Connection!.Level);
         Assert.Null(server.Transaction);
     }
 

--- a/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
+++ b/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
@@ -252,10 +252,6 @@ public sealed class SqliteMaintenanceExecutionTests
                 source,
                 destination,
                 new SqliteBackupOptions { PagesPerStep = 4097 }));
-            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => sqlite.BackupDatabaseIncrementalAsync(
-                source,
-                destination,
-                new SqliteBackupOptions { BusyTimeoutMs = 1001 }));
         }
         finally
         {
@@ -268,6 +264,7 @@ public sealed class SqliteMaintenanceExecutionTests
     [InlineData(null, 5000, 1000)]
     [InlineData(null, 250, 250)]
     [InlineData(750, 5000, 750)]
+    [InlineData(5000, 5000, 1000)]
     public void ResolveBackupBusyTimeoutMs_DefaultAndExplicitValues_AreBounded(
         int? requested,
         int instance,

--- a/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
+++ b/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
@@ -101,6 +101,122 @@ public sealed class SqliteMaintenanceExecutionTests
     }
 
     [Fact]
+    public async Task BackupDatabaseIncrementalAsync_CanceledOverwrite_PreservesExistingDestination()
+    {
+        string source = CreateDatabase(rowCount: 512);
+        string destination = CreateDatabase(rowCount: 1);
+        using var cancellationSource = new CancellationTokenSource();
+        try
+        {
+            using var sqlite = new SQLite();
+            var progress = new InlineProgress<SqliteBackupProgress>(value =>
+            {
+                if (value.CopiedPages > 0)
+                {
+                    cancellationSource.Cancel();
+                }
+            });
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sqlite.BackupDatabaseIncrementalAsync(
+                source,
+                destination,
+                new SqliteBackupOptions
+                {
+                    PagesPerStep = 1,
+                    StepDelay = TimeSpan.FromMilliseconds(5),
+                    OverwriteDestination = true
+                },
+                progress,
+                cancellationSource.Token));
+
+            Assert.Equal(1, await CountRowsAsync(destination));
+            string directory = Path.GetDirectoryName(destination)!;
+            Assert.Empty(Directory.GetFiles(directory, $"{Path.GetFileName(destination)}.*.partial"));
+        }
+        finally
+        {
+            Cleanup(source);
+            Cleanup(destination);
+        }
+    }
+
+    [Fact]
+    public async Task BackupDatabaseIncrementalAsync_CompletedOverwrite_AtomicallyReplacesDestination()
+    {
+        string source = CreateDatabase(rowCount: 128);
+        string destination = CreateDatabase(rowCount: 1);
+        try
+        {
+            using var sqlite = new SQLite();
+
+            await sqlite.BackupDatabaseIncrementalAsync(
+                source,
+                destination,
+                new SqliteBackupOptions
+                {
+                    PagesPerStep = 4,
+                    OverwriteDestination = true
+                });
+
+            Assert.Equal(128, await CountRowsAsync(destination));
+            string directory = Path.GetDirectoryName(destination)!;
+            Assert.Empty(Directory.GetFiles(directory, $"{Path.GetFileName(destination)}.*.partial"));
+        }
+        finally
+        {
+            Cleanup(source);
+            Cleanup(destination);
+        }
+    }
+
+    [Fact]
+    public async Task BackupDatabaseIncrementalAsync_ActiveClientTransaction_FailsBeforeCreatingDestination()
+    {
+        string source = CreateDatabase();
+        string destination = Path.Combine(Path.GetTempPath(), $"dbaclientx-transaction-backup-{Guid.NewGuid():N}.sqlite");
+        try
+        {
+            using var sqlite = new SQLite();
+            sqlite.BeginTransaction(source);
+
+            await Assert.ThrowsAsync<DbaTransactionException>(() => sqlite.BackupDatabaseIncrementalAsync(source, destination));
+            Assert.False(File.Exists(destination));
+
+            sqlite.Rollback();
+        }
+        finally
+        {
+            Cleanup(source);
+            Cleanup(destination);
+        }
+    }
+
+    [Fact]
+    public async Task BackupDatabaseIncrementalAsync_UnboundedNativeStepOptions_AreRejected()
+    {
+        string source = CreateDatabase();
+        string destination = Path.Combine(Path.GetTempPath(), $"dbaclientx-option-bounds-{Guid.NewGuid():N}.sqlite");
+        try
+        {
+            using var sqlite = new SQLite();
+
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => sqlite.BackupDatabaseIncrementalAsync(
+                source,
+                destination,
+                new SqliteBackupOptions { PagesPerStep = 4097 }));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => sqlite.BackupDatabaseIncrementalAsync(
+                source,
+                destination,
+                new SqliteBackupOptions { BusyTimeoutMs = 1001 }));
+        }
+        finally
+        {
+            Cleanup(source);
+            Cleanup(destination);
+        }
+    }
+
+    [Fact]
     public async Task MaintenanceAsync_PreCanceledToken_DoesNotCreateWorkOrDestination()
     {
         string source = CreateDatabase();
@@ -145,6 +261,15 @@ public sealed class SqliteMaintenanceExecutionTests
         }
         transaction.Commit();
         return path;
+    }
+
+    private static async Task<long> CountRowsAsync(string database)
+    {
+        await using var connection = new SqliteConnection(SQLite.BuildConnectionString(database));
+        await connection.OpenAsync();
+        await using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM backup_contract;";
+        return (long)(await command.ExecuteScalarAsync())!;
     }
 
     private static void Cleanup(string path)

--- a/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
+++ b/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
@@ -170,6 +170,33 @@ public sealed class SqliteMaintenanceExecutionTests
     }
 
     [Fact]
+    public async Task BackupDatabaseIncrementalAsync_CompletedOverwrite_RemovesStaleDestinationSidecars()
+    {
+        string source = CreateDatabase(rowCount: 128);
+        string destination = CreateDatabase(rowCount: 1);
+        try
+        {
+            File.WriteAllText(destination + "-wal", "stale-wal");
+            File.WriteAllText(destination + "-shm", "stale-shm");
+            using var sqlite = new SQLite();
+
+            await sqlite.BackupDatabaseIncrementalAsync(
+                source,
+                destination,
+                new SqliteBackupOptions { OverwriteDestination = true });
+
+            Assert.False(File.Exists(destination + "-wal"));
+            Assert.False(File.Exists(destination + "-shm"));
+            Assert.Equal(128, await CountRowsAsync(destination));
+        }
+        finally
+        {
+            Cleanup(source);
+            Cleanup(destination);
+        }
+    }
+
+    [Fact]
     public async Task BackupDatabaseIncrementalAsync_ActiveClientTransaction_FailsBeforeCreatingDestination()
     {
         string source = CreateDatabase();
@@ -188,6 +215,25 @@ public sealed class SqliteMaintenanceExecutionTests
         {
             Cleanup(source);
             Cleanup(destination);
+        }
+    }
+
+    [Fact]
+    public async Task CheckIntegrityAsync_ActiveClientTransaction_FailsBeforeStartingMaintenance()
+    {
+        string source = CreateDatabase();
+        try
+        {
+            using var sqlite = new SQLite();
+            sqlite.BeginTransaction(source);
+
+            await Assert.ThrowsAsync<DbaTransactionException>(() => sqlite.CheckIntegrityAsync(source));
+
+            sqlite.Rollback();
+        }
+        finally
+        {
+            Cleanup(source);
         }
     }
 
@@ -214,6 +260,22 @@ public sealed class SqliteMaintenanceExecutionTests
             Cleanup(source);
             Cleanup(destination);
         }
+    }
+
+    [Theory]
+    [InlineData(null, 5000, 1000)]
+    [InlineData(null, 250, 250)]
+    [InlineData(750, 5000, 750)]
+    public void ResolveBackupBusyTimeoutMs_DefaultAndExplicitValues_AreBounded(
+        int? requested,
+        int instance,
+        int expected)
+    {
+        var method = typeof(SQLite).GetMethod(
+            "ResolveBackupBusyTimeoutMs",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+        Assert.Equal(expected, method.Invoke(null, new object?[] { requested, instance }));
     }
 
     [Fact]

--- a/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
+++ b/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
@@ -178,6 +178,7 @@ public sealed class SqliteMaintenanceExecutionTests
         {
             File.WriteAllText(destination + "-wal", "stale-wal");
             File.WriteAllText(destination + "-shm", "stale-shm");
+            File.WriteAllText(destination + "-journal", "stale-journal");
             using var sqlite = new SQLite();
 
             await sqlite.BackupDatabaseIncrementalAsync(
@@ -187,6 +188,7 @@ public sealed class SqliteMaintenanceExecutionTests
 
             Assert.False(File.Exists(destination + "-wal"));
             Assert.False(File.Exists(destination + "-shm"));
+            Assert.False(File.Exists(destination + "-journal"));
             Assert.Equal(128, await CountRowsAsync(destination));
         }
         finally
@@ -279,6 +281,37 @@ public sealed class SqliteMaintenanceExecutionTests
     }
 
     [Fact]
+    public void SnapshotBackupOptions_CallerMutation_DoesNotChangeValidatedSnapshot()
+    {
+        var options = new SqliteBackupOptions
+        {
+            PagesPerStep = 64,
+            StepDelay = TimeSpan.FromMilliseconds(10),
+            BusyRetryDelay = TimeSpan.FromMilliseconds(20),
+            BusyRetryTimeout = TimeSpan.FromSeconds(3),
+            BusyTimeoutMs = 500,
+            OverwriteDestination = true,
+            DeleteDestinationOnFailure = false
+        };
+        var method = typeof(SQLite).GetMethod(
+            "SnapshotBackupOptions",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+        var snapshot = Assert.IsType<SqliteBackupOptions>(method.Invoke(null, new object?[] { options }));
+        options.PagesPerStep = 4096;
+        options.OverwriteDestination = false;
+
+        Assert.NotSame(options, snapshot);
+        Assert.Equal(64, snapshot.PagesPerStep);
+        Assert.Equal(TimeSpan.FromMilliseconds(10), snapshot.StepDelay);
+        Assert.Equal(TimeSpan.FromMilliseconds(20), snapshot.BusyRetryDelay);
+        Assert.Equal(TimeSpan.FromSeconds(3), snapshot.BusyRetryTimeout);
+        Assert.Equal(500, snapshot.BusyTimeoutMs);
+        Assert.True(snapshot.OverwriteDestination);
+        Assert.False(snapshot.DeleteDestinationOnFailure);
+    }
+
+    [Fact]
     public async Task MaintenanceAsync_PreCanceledToken_DoesNotCreateWorkOrDestination()
     {
         string source = CreateDatabase();
@@ -336,7 +369,7 @@ public sealed class SqliteMaintenanceExecutionTests
 
     private static void Cleanup(string path)
     {
-        foreach (string suffix in new[] { string.Empty, "-wal", "-shm" })
+        foreach (string suffix in new[] { string.Empty, "-wal", "-shm", "-journal" })
         {
             string candidate = path + suffix;
             if (File.Exists(candidate))

--- a/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
+++ b/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
@@ -221,6 +221,47 @@ public sealed class SqliteMaintenanceExecutionTests
     }
 
     [Fact]
+    public async Task BackupDatabaseIncrementalAsync_LockedSource_EnforcesExplicitBusyDeadline()
+    {
+        string source = CreateDatabase();
+        string destination = Path.Combine(Path.GetTempPath(), $"dbaclientx-busy-deadline-{Guid.NewGuid():N}.sqlite");
+        await using var lockConnection = new SqliteConnection(SQLite.BuildConnectionString(source));
+        try
+        {
+            await lockConnection.OpenAsync();
+            await using SqliteCommand lockCommand = lockConnection.CreateCommand();
+            lockCommand.CommandText = "BEGIN EXCLUSIVE;";
+            await lockCommand.ExecuteNonQueryAsync();
+            using var sqlite = new SQLite();
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+            await Assert.ThrowsAsync<TimeoutException>(() => sqlite.BackupDatabaseIncrementalAsync(
+                source,
+                destination,
+                new SqliteBackupOptions
+                {
+                    BusyRetryDelay = TimeSpan.FromMilliseconds(20),
+                    BusyRetryTimeout = TimeSpan.FromMilliseconds(100)
+                }));
+
+            stopwatch.Stop();
+            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1), $"Busy deadline took {stopwatch.Elapsed}.");
+        }
+        finally
+        {
+            if (lockConnection.State == System.Data.ConnectionState.Open)
+            {
+                await using SqliteCommand rollback = lockConnection.CreateCommand();
+                rollback.CommandText = "ROLLBACK;";
+                await rollback.ExecuteNonQueryAsync();
+            }
+            await lockConnection.CloseAsync();
+            Cleanup(source);
+            Cleanup(destination);
+        }
+    }
+
+    [Fact]
     public async Task CheckIntegrityAsync_ActiveClientTransaction_FailsBeforeStartingMaintenance()
     {
         string source = CreateDatabase();
@@ -260,23 +301,6 @@ public sealed class SqliteMaintenanceExecutionTests
         }
     }
 
-    [Theory]
-    [InlineData(null, 5000, 1000)]
-    [InlineData(null, 250, 250)]
-    [InlineData(750, 5000, 750)]
-    [InlineData(5000, 5000, 1000)]
-    public void ResolveBackupBusyTimeoutMs_DefaultAndExplicitValues_AreBounded(
-        int? requested,
-        int instance,
-        int expected)
-    {
-        var method = typeof(SQLite).GetMethod(
-            "ResolveBackupBusyTimeoutMs",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
-
-        Assert.Equal(expected, method.Invoke(null, new object?[] { requested, instance }));
-    }
-
     [Fact]
     public void SnapshotBackupOptions_CallerMutation_DoesNotChangeValidatedSnapshot()
     {
@@ -286,7 +310,6 @@ public sealed class SqliteMaintenanceExecutionTests
             StepDelay = TimeSpan.FromMilliseconds(10),
             BusyRetryDelay = TimeSpan.FromMilliseconds(20),
             BusyRetryTimeout = TimeSpan.FromSeconds(3),
-            BusyTimeoutMs = 500,
             OverwriteDestination = true,
             DeleteDestinationOnFailure = false
         };
@@ -303,7 +326,6 @@ public sealed class SqliteMaintenanceExecutionTests
         Assert.Equal(TimeSpan.FromMilliseconds(10), snapshot.StepDelay);
         Assert.Equal(TimeSpan.FromMilliseconds(20), snapshot.BusyRetryDelay);
         Assert.Equal(TimeSpan.FromSeconds(3), snapshot.BusyRetryTimeout);
-        Assert.Equal(500, snapshot.BusyTimeoutMs);
         Assert.True(snapshot.OverwriteDestination);
         Assert.False(snapshot.DeleteDestinationOnFailure);
     }

--- a/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
+++ b/DbaClientX.Tests/SqliteMaintenanceExecutionTests.cs
@@ -1,0 +1,176 @@
+using DBAClientX;
+using Microsoft.Data.Sqlite;
+
+namespace DbaClientX.Tests;
+
+public sealed class SqliteMaintenanceExecutionTests
+{
+    [Fact]
+    public async Task CheckIntegrityAsync_HealthyDatabase_ReturnsHealthyResult()
+    {
+        string database = CreateDatabase();
+        try
+        {
+            using var sqlite = new SQLite();
+
+            SqliteIntegrityCheckResult result = await sqlite.CheckIntegrityAsync(database, fullCheck: true);
+
+            Assert.True(result.IsHealthy);
+            Assert.True(result.IsFullCheck);
+            Assert.Empty(result.Issues);
+            Assert.True(result.Elapsed >= TimeSpan.Zero);
+        }
+        finally
+        {
+            Cleanup(database);
+        }
+    }
+
+    [Fact]
+    public async Task BackupDatabaseIncrementalAsync_CompletedBackup_IsReadableAndReportsProgress()
+    {
+        string source = CreateDatabase(rowCount: 256);
+        string destination = Path.Combine(Path.GetTempPath(), $"dbaclientx-backup-{Guid.NewGuid():N}.sqlite");
+        var reports = new List<SqliteBackupProgress>();
+        try
+        {
+            using var sqlite = new SQLite();
+            var progress = new InlineProgress<SqliteBackupProgress>(reports.Add);
+
+            SqliteBackupResult result = await sqlite.BackupDatabaseIncrementalAsync(
+                source,
+                destination,
+                new SqliteBackupOptions { PagesPerStep = 4 },
+                progress);
+
+            Assert.True(File.Exists(destination));
+            Assert.Equal(new FileInfo(destination).Length, result.DestinationLengthBytes);
+            Assert.True(result.CopiedPages > 0);
+            Assert.NotEmpty(reports);
+            Assert.Equal(100d, reports[^1].PercentComplete);
+
+            await using var connection = new SqliteConnection(SQLite.BuildConnectionString(destination));
+            await connection.OpenAsync();
+            await using SqliteCommand command = connection.CreateCommand();
+            command.CommandText = "SELECT COUNT(*) FROM backup_contract;";
+            long count = (long)(await command.ExecuteScalarAsync())!;
+            Assert.Equal(256, count);
+        }
+        finally
+        {
+            Cleanup(source);
+            Cleanup(destination);
+        }
+    }
+
+    [Fact]
+    public async Task BackupDatabaseIncrementalAsync_CanceledBackup_DeletesIncompleteDestination()
+    {
+        string source = CreateDatabase(rowCount: 512);
+        string destination = Path.Combine(Path.GetTempPath(), $"dbaclientx-canceled-{Guid.NewGuid():N}.sqlite");
+        using var cancellationSource = new CancellationTokenSource();
+        try
+        {
+            using var sqlite = new SQLite();
+            var progress = new InlineProgress<SqliteBackupProgress>(value =>
+            {
+                if (value.CopiedPages > 0)
+                {
+                    cancellationSource.Cancel();
+                }
+            });
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sqlite.BackupDatabaseIncrementalAsync(
+                source,
+                destination,
+                new SqliteBackupOptions
+                {
+                    PagesPerStep = 1,
+                    StepDelay = TimeSpan.FromMilliseconds(5)
+                },
+                progress,
+                cancellationSource.Token));
+
+            Assert.False(File.Exists(destination));
+        }
+        finally
+        {
+            Cleanup(source);
+            Cleanup(destination);
+        }
+    }
+
+    [Fact]
+    public async Task MaintenanceAsync_PreCanceledToken_DoesNotCreateWorkOrDestination()
+    {
+        string source = CreateDatabase();
+        string destination = Path.Combine(Path.GetTempPath(), $"dbaclientx-precanceled-{Guid.NewGuid():N}.sqlite");
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+        try
+        {
+            using var sqlite = new SQLite();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sqlite.CheckIntegrityAsync(
+                source,
+                cancellationToken: cancellationSource.Token));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sqlite.BackupDatabaseIncrementalAsync(
+                source,
+                destination,
+                cancellationToken: cancellationSource.Token));
+
+            Assert.False(File.Exists(destination));
+        }
+        finally
+        {
+            Cleanup(source);
+            Cleanup(destination);
+        }
+    }
+
+    private static string CreateDatabase(int rowCount = 1)
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"dbaclientx-maintenance-{Guid.NewGuid():N}.sqlite");
+        using var connection = new SqliteConnection(SQLite.BuildConnectionString(path));
+        connection.Open();
+        using SqliteCommand command = connection.CreateCommand();
+        command.CommandText = "CREATE TABLE backup_contract(id INTEGER PRIMARY KEY, payload BLOB NOT NULL);";
+        command.ExecuteNonQuery();
+        using SqliteTransaction transaction = connection.BeginTransaction();
+        command.Transaction = transaction;
+        command.CommandText = "INSERT INTO backup_contract(payload) VALUES(randomblob(4096));";
+        for (int index = 0; index < rowCount; index++)
+        {
+            command.ExecuteNonQuery();
+        }
+        transaction.Commit();
+        return path;
+    }
+
+    private static void Cleanup(string path)
+    {
+        foreach (string suffix in new[] { string.Empty, "-wal", "-shm" })
+        {
+            string candidate = path + suffix;
+            if (File.Exists(candidate))
+            {
+                File.Delete(candidate);
+            }
+        }
+    }
+
+    private sealed class InlineProgress<T> : IProgress<T>
+    {
+        private readonly Action<T> _handler;
+
+        public InlineProgress(Action<T> handler)
+        {
+            _handler = handler;
+        }
+
+        public void Report(T value)
+        {
+            _handler(value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This change hardens provider transaction cleanup and adds reusable SQLite maintenance primitives for long-running services.

- MySQL, Oracle, PostgreSQL, and SQL Server transactions now await asynchronous rollback and disposal paths consistently, including failure paths during open, begin, commit, and rollback.
- SQLite integrity and maintenance work runs on dedicated interruptible execution threads instead of exposing fake asynchronous provider calls.
- Incremental SQLite backup supports page stepping, progress callbacks, cancellation, BUSY/LOCKED retries, and partial-file cleanup.
- Backup contention uses explicit retry delay and a cumulative deadline; no native busy handler can hide lock waits from the configured budget.
- Typed result and options models expose integrity and backup outcomes without requiring consumers to own provider-specific SQL or SQLitePCL handling.

## Consumer impact

TestimoX.Monitoring uses these APIs to keep multi-gigabyte database checks and backups bounded, cancellable, and outside its scheduler critical path. The new APIs are additive.

## Validation

- DbaClientX.Tests: 1,058 tests passed on .NET 8
- DbaClientX.Tests: 1,058 tests passed on .NET 10
- locked-source backup regression proves the explicit busy deadline
- All DbaClientX target frameworks built successfully
- all six package payloads passed fresh-output provenance and the packaged PowerShell AssemblyLoadContext smoke test passed with PSPublishModule 3.0.51