### PR TITLE
Make SQLite package provenance deterministic

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Setup PowerShell modules
               shell: pwsh
               run: |
-                  Install-Module PSPublishModule -MinimumVersion 3.0.44 -Force -Scope CurrentUser -AllowClobber
+                  Install-Module PSPublishModule -MinimumVersion 3.0.51 -Force -Scope CurrentUser -AllowClobber
 
             - name: Refresh module manifest
               shell: pwsh
@@ -150,7 +150,7 @@ jobs:
                       Register-PSRepository -Default
                   }
                   Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-                  Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.44 -Force -SkipPublisherCheck -AllowClobber
+                  Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.51 -Force -SkipPublisherCheck -AllowClobber
                   Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
                   Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
 

--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />


### PR DESCRIPTION
## Summary

- keep the `net472` SQLite build in the framework directory consumed by `dotnet pack --no-build`
- prevent a stale non-RID assembly from entering the NuGet package when the project rebuild uses `win-x64`
- require PSPublishModule 3.0.51 in PowerShell CI so package payload provenance validation is guaranteed

## Why CI was green

The existing Windows package job used a clean runner, where no stale framework output existed, and its package was valid. Developer workspaces could retain `bin/Release/net472/DbaClientX.SQLite.dll` while the RID rebuild wrote to `bin/Release/net472/win-x64`; the provenance validator correctly rejected that state. Disabling the RID output-path suffix for the sole `win-x64` target makes clean and incremental builds use the same package-consumed path.