### PR TITLE
Harden query builder SQL boundaries

### DIFF
--- a/DbaClientX.Core/QueryBuilder/Query.Joins.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.Joins.cs
@@ -1,0 +1,144 @@
+using System;
+
+namespace DBAClientX.QueryBuilder;
+
+public partial class Query
+{
+    /// <summary>Adds a caller-authored inner join expression.</summary>
+    /// <remarks>Use an identifier-based overload when any input is not trusted.</remarks>
+    [Obsolete("Join(table, condition) treats both arguments as raw SQL. Use JoinRaw or an identifier-based Join overload.")]
+    public Query Join(string table, string condition) => JoinRaw(table, condition);
+
+    /// <summary>Adds an inner join using quoted table and column identifiers.</summary>
+    public Query Join(string table, string leftColumn, string rightColumn)
+        => AddJoin("JOIN", table, alias: null, leftColumn, "=", rightColumn);
+
+    /// <summary>Adds an inner join using quoted table and column identifiers.</summary>
+    public Query Join(string table, string leftColumn, string op, string rightColumn)
+        => AddJoin("JOIN", table, alias: null, leftColumn, op, rightColumn);
+
+    /// <summary>Adds an aliased inner join using quoted table, alias, and column identifiers.</summary>
+    public Query Join(string table, string alias, string leftColumn, string op, string rightColumn)
+        => AddJoin("JOIN", table, alias, leftColumn, op, rightColumn);
+
+    /// <summary>Adds a caller-authored inner join expression.</summary>
+    /// <remarks>Never pass untrusted input to this method.</remarks>
+    public Query JoinRaw(string tableExpression, string condition)
+        => AddRawJoin("JOIN", tableExpression, condition);
+
+    /// <summary>Adds a caller-authored left join expression.</summary>
+    /// <remarks>Use an identifier-based overload when any input is not trusted.</remarks>
+    [Obsolete("LeftJoin(table, condition) treats both arguments as raw SQL. Use LeftJoinRaw or an identifier-based LeftJoin overload.")]
+    public Query LeftJoin(string table, string condition) => LeftJoinRaw(table, condition);
+
+    /// <summary>Adds a left join using quoted table and column identifiers.</summary>
+    public Query LeftJoin(string table, string leftColumn, string op, string rightColumn)
+        => AddJoin("LEFT JOIN", table, alias: null, leftColumn, op, rightColumn);
+
+    /// <summary>Adds an aliased left join using quoted identifiers.</summary>
+    public Query LeftJoin(string table, string alias, string leftColumn, string op, string rightColumn)
+        => AddJoin("LEFT JOIN", table, alias, leftColumn, op, rightColumn);
+
+    /// <summary>Adds a caller-authored left join expression.</summary>
+    /// <remarks>Never pass untrusted input to this method.</remarks>
+    public Query LeftJoinRaw(string tableExpression, string condition)
+        => AddRawJoin("LEFT JOIN", tableExpression, condition);
+
+    /// <summary>Adds a caller-authored right join expression.</summary>
+    /// <remarks>Use an identifier-based overload when any input is not trusted.</remarks>
+    [Obsolete("RightJoin(table, condition) treats both arguments as raw SQL. Use RightJoinRaw or an identifier-based RightJoin overload.")]
+    public Query RightJoin(string table, string condition) => RightJoinRaw(table, condition);
+
+    /// <summary>Adds a right join using quoted table and column identifiers.</summary>
+    public Query RightJoin(string table, string leftColumn, string op, string rightColumn)
+        => AddJoin("RIGHT JOIN", table, alias: null, leftColumn, op, rightColumn);
+
+    /// <summary>Adds an aliased right join using quoted identifiers.</summary>
+    public Query RightJoin(string table, string alias, string leftColumn, string op, string rightColumn)
+        => AddJoin("RIGHT JOIN", table, alias, leftColumn, op, rightColumn);
+
+    /// <summary>Adds a caller-authored right join expression.</summary>
+    /// <remarks>Never pass untrusted input to this method.</remarks>
+    public Query RightJoinRaw(string tableExpression, string condition)
+        => AddRawJoin("RIGHT JOIN", tableExpression, condition);
+
+    /// <summary>Adds a cross join using a quoted table identifier.</summary>
+    public Query CrossJoin(string table)
+    {
+        ValidateString(table, nameof(table));
+        _joins.Add(new QueryJoinClause("CROSS JOIN", new QueryExpression(table, IsRaw: false), null, null, null, null, null));
+        return this;
+    }
+
+    /// <summary>Adds an aliased cross join using quoted identifiers.</summary>
+    public Query CrossJoin(string table, string alias)
+    {
+        ValidateString(table, nameof(table));
+        ValidateString(alias, nameof(alias));
+        _joins.Add(new QueryJoinClause("CROSS JOIN", new QueryExpression(table, IsRaw: false), alias, null, null, null, null));
+        return this;
+    }
+
+    /// <summary>Adds a caller-authored cross join expression.</summary>
+    /// <remarks>Never pass untrusted input to this method.</remarks>
+    public Query CrossJoinRaw(string tableExpression)
+    {
+        ValidateString(tableExpression, nameof(tableExpression));
+        _joins.Add(new QueryJoinClause("CROSS JOIN", new QueryExpression(tableExpression, IsRaw: true), null, null, null, null, null));
+        return this;
+    }
+
+    /// <summary>Adds a caller-authored full outer join expression.</summary>
+    /// <remarks>Use an identifier-based overload when any input is not trusted.</remarks>
+    [Obsolete("FullOuterJoin(table, condition) treats both arguments as raw SQL. Use FullOuterJoinRaw or an identifier-based FullOuterJoin overload.")]
+    public Query FullOuterJoin(string table, string condition) => FullOuterJoinRaw(table, condition);
+
+    /// <summary>Adds a full outer join using quoted table and column identifiers.</summary>
+    public Query FullOuterJoin(string table, string leftColumn, string op, string rightColumn)
+        => AddJoin("FULL OUTER JOIN", table, alias: null, leftColumn, op, rightColumn);
+
+    /// <summary>Adds an aliased full outer join using quoted identifiers.</summary>
+    public Query FullOuterJoin(string table, string alias, string leftColumn, string op, string rightColumn)
+        => AddJoin("FULL OUTER JOIN", table, alias, leftColumn, op, rightColumn);
+
+    /// <summary>Adds a caller-authored full outer join expression.</summary>
+    /// <remarks>Never pass untrusted input to this method.</remarks>
+    public Query FullOuterJoinRaw(string tableExpression, string condition)
+        => AddRawJoin("FULL OUTER JOIN", tableExpression, condition);
+
+    private Query AddJoin(string type, string table, string? alias, string leftColumn, string op, string rightColumn)
+    {
+        ValidateString(table, nameof(table));
+        if (alias != null)
+        {
+            ValidateString(alias, nameof(alias));
+        }
+        ValidateString(leftColumn, nameof(leftColumn));
+        ValidateString(rightColumn, nameof(rightColumn));
+        var normalizedOperator = QueryComparisonOperator.Normalize(op, nameof(op));
+        _joins.Add(new QueryJoinClause(
+            type,
+            new QueryExpression(table, IsRaw: false),
+            alias,
+            leftColumn,
+            normalizedOperator,
+            rightColumn,
+            RawCondition: null));
+        return this;
+    }
+
+    private Query AddRawJoin(string type, string tableExpression, string condition)
+    {
+        ValidateString(tableExpression, nameof(tableExpression));
+        ValidateString(condition, nameof(condition));
+        _joins.Add(new QueryJoinClause(
+            type,
+            new QueryExpression(tableExpression, IsRaw: true),
+            Alias: null,
+            LeftColumn: null,
+            Operator: null,
+            RightColumn: null,
+            RawCondition: condition));
+        return this;
+    }
+}

--- a/DbaClientX.Core/QueryBuilder/Query.Ordering.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.Ordering.cs
@@ -1,0 +1,130 @@
+using System;
+
+namespace DBAClientX.QueryBuilder;
+
+public partial class Query
+{
+    /// <summary>Adds columns to the <c>ORDER BY</c> clause in ascending order.</summary>
+    public Query OrderBy(params string[] columns)
+    {
+        ValidateStrings(columns, nameof(columns));
+        foreach (var column in columns)
+        {
+            _orderBy.Add(new QueryOrderExpression(column, IsRaw: false, Descending: false));
+        }
+        return this;
+    }
+
+    /// <summary>Adds columns to the <c>ORDER BY</c> clause in descending order.</summary>
+    public Query OrderByDescending(params string[] columns)
+    {
+        ValidateStrings(columns, nameof(columns));
+        foreach (var column in columns)
+        {
+            _orderBy.Add(new QueryOrderExpression(column, IsRaw: false, Descending: true));
+        }
+        return this;
+    }
+
+    /// <summary>Adds caller-authored SQL expressions to the <c>ORDER BY</c> clause.</summary>
+    /// <remarks>Never pass untrusted input to this method.</remarks>
+    public Query OrderByRaw(params string[] expressions)
+    {
+        ValidateStrings(expressions, nameof(expressions));
+        foreach (var expression in expressions)
+        {
+            _orderBy.Add(new QueryOrderExpression(expression, IsRaw: true, Descending: false));
+        }
+        return this;
+    }
+
+    /// <summary>Adds columns to the <c>GROUP BY</c> clause.</summary>
+    public Query GroupBy(params string[] columns)
+    {
+        ValidateStrings(columns, nameof(columns));
+        foreach (var column in columns)
+        {
+            _groupBy.Add(new QueryExpression(column, IsRaw: false));
+        }
+        return this;
+    }
+
+    /// <summary>Adds caller-authored SQL expressions to the <c>GROUP BY</c> clause.</summary>
+    /// <remarks>Never pass untrusted input to this method.</remarks>
+    public Query GroupByRaw(params string[] expressions)
+    {
+        ValidateStrings(expressions, nameof(expressions));
+        foreach (var expression in expressions)
+        {
+            _groupBy.Add(new QueryExpression(expression, IsRaw: true));
+        }
+        return this;
+    }
+
+    /// <inheritdoc cref="Having(string, string, object)"/>
+    public Query Having(string column, object value) => Having(column, "=", value);
+
+    /// <summary>Adds a predicate to the <c>HAVING</c> clause.</summary>
+    public Query Having(string column, string op, object value)
+    {
+        ValidateString(column, nameof(column));
+        var normalizedOperator = QueryComparisonOperator.Normalize(op, nameof(op));
+        if (value == null)
+        {
+            throw new ArgumentException("Value cannot be null.", nameof(value));
+        }
+        _having.Add(new QueryHavingClause(column, normalizedOperator, value, IsRaw: false));
+        return this;
+    }
+
+    /// <summary>Adds a predicate whose left side is a caller-authored SQL expression to <c>HAVING</c>.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query HavingRaw(string expression, string op, object value)
+    {
+        ValidateString(expression, nameof(expression));
+        var normalizedOperator = QueryComparisonOperator.Normalize(op, nameof(op));
+        if (value == null)
+        {
+            throw new ArgumentException("Value cannot be null.", nameof(value));
+        }
+        _having.Add(new QueryHavingClause(expression, normalizedOperator, value, IsRaw: true));
+        return this;
+    }
+
+    /// <summary>Applies a non-negative <c>LIMIT</c> or provider equivalent.</summary>
+    public Query Limit(int limit)
+    {
+        if (limit < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(limit), limit, "Limit cannot be negative.");
+        }
+        _limit = limit;
+        _useTop = false;
+        return this;
+    }
+
+    /// <summary>Applies a non-negative <c>OFFSET</c>.</summary>
+    public Query Offset(int offset)
+    {
+        if (offset < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(offset), offset, "Offset cannot be negative.");
+        }
+        _offset = offset;
+        _useTop = false;
+        return this;
+    }
+
+    /// <summary>Applies a non-negative SQL Server-style <c>TOP</c> value.</summary>
+    public Query Top(int top)
+    {
+        if (top < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(top), top, "Top cannot be negative.");
+        }
+        _limit = top;
+        _useTop = true;
+        _offset = null;
+        return this;
+    }
+}

--- a/DbaClientX.Core/QueryBuilder/Query.State.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.State.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DBAClientX.QueryBuilder;
+
+public partial class Query
+{
+    /// <summary>Gets the selected columns for the query.</summary>
+    public IReadOnlyList<string> SelectColumns => _select.Select(static expression => expression.Text).ToArray();
+
+    internal IReadOnlyList<QueryExpression> SelectExpressions => _select;
+
+    /// <summary>Gets the table used in the <c>FROM</c> clause, when not using a subquery.</summary>
+    public string? Table => _from?.Text;
+
+    internal QueryExpression? TableExpression => _from;
+
+    internal string? TableAlias => _fromAlias;
+
+    /// <summary>Gets the subquery used in the <c>FROM</c> clause, if any.</summary>
+    public (Query Query, string Alias)? FromSubquery => _fromSubquery;
+
+    /// <summary>Gets the sequence of tokens representing the <c>WHERE</c> clause.</summary>
+    public IReadOnlyList<IWhereToken> WhereTokens => _where;
+
+    /// <summary>Gets the table targeted by an <c>INSERT</c> statement.</summary>
+    public string? InsertTable => _insertTable;
+
+    /// <summary>Gets the column list used for <c>INSERT</c> statements.</summary>
+    public IReadOnlyList<string> InsertColumns => _insertColumns;
+
+    /// <summary>Gets the rows of values used for <c>INSERT</c> statements.</summary>
+    public IReadOnlyList<IReadOnlyList<object>> InsertValues => _values;
+
+    /// <summary>Gets a value indicating whether the query is configured as an upsert.</summary>
+    public bool IsUpsert => _isUpsert;
+
+    /// <summary>Gets the columns used to detect conflicts during an upsert.</summary>
+    public IReadOnlyList<string> ConflictColumns => _conflictColumns;
+
+    /// <summary>Gets the subset of columns that should be updated during an upsert.</summary>
+    public IReadOnlyList<string> UpsertUpdateOnlyColumns => _upsertUpdateOnly;
+
+    /// <summary>Gets the table targeted by an <c>UPDATE</c> statement.</summary>
+    public string? UpdateTable => _updateTable;
+
+    /// <summary>Gets the column/value pairs configured for an <c>UPDATE</c> statement.</summary>
+    public IReadOnlyList<(string Column, object Value)> SetValues => _set;
+
+    /// <summary>Gets the table targeted by a <c>DELETE</c> statement.</summary>
+    public string? DeleteTable => _deleteTable;
+
+    /// <summary>Gets the column expressions used for ordering.</summary>
+    public IReadOnlyList<string> OrderByColumns => _orderBy
+        .Select(static expression => expression.Text + (expression.Descending ? " DESC" : string.Empty))
+        .ToArray();
+
+    internal IReadOnlyList<QueryOrderExpression> OrderByExpressions => _orderBy;
+
+    /// <summary>Gets the column expressions used for grouping.</summary>
+    public IReadOnlyList<string> GroupByColumns => _groupBy.Select(static expression => expression.Text).ToArray();
+
+    internal IReadOnlyList<QueryExpression> GroupByExpressions => _groupBy;
+
+    /// <summary>Gets the predicates configured for the <c>HAVING</c> clause.</summary>
+    public IReadOnlyList<(string Column, string Operator, object Value)> HavingClauses => _having
+        .Select(static clause => (clause.Expression, clause.Operator, clause.Value))
+        .ToArray();
+
+    internal IReadOnlyList<QueryHavingClause> HavingExpressions => _having;
+
+    /// <summary>Gets the join definitions applied to the query.</summary>
+    public IReadOnlyList<(string Type, string Table, string? Condition)> Joins => _joins
+        .Select(static join => (
+            join.Type,
+            join.Table.Text,
+            join.RawCondition ?? (join.LeftColumn == null ? null : $"{join.LeftColumn} {join.Operator} {join.RightColumn}")))
+        .ToArray();
+
+    internal IReadOnlyList<QueryJoinClause> JoinClauses => _joins;
+
+    /// <summary>Gets the compound queries appended to the current query.</summary>
+    public IReadOnlyList<(string Type, Query Query)> CompoundQueries => _compoundQueries;
+
+    /// <summary>Gets a value indicating whether the query uses <c>DISTINCT</c>.</summary>
+    public bool IsDistinct => _distinct;
+
+    /// <summary>Gets the configured <c>LIMIT</c> value, if any.</summary>
+    public int? LimitValue => _limit;
+
+    /// <summary>Gets the configured <c>OFFSET</c> value, if any.</summary>
+    public int? OffsetValue => _offset;
+
+    /// <summary>Gets a value indicating whether the query should use <c>TOP</c> semantics.</summary>
+    public bool UseTop => _useTop;
+
+    /// <summary>Gets the number of open grouping tokens used to validate balanced conditions.</summary>
+    public int OpenGroups => _openGroups;
+}

--- a/DbaClientX.Core/QueryBuilder/Query.WhereRaw.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.WhereRaw.cs
@@ -1,0 +1,74 @@
+namespace DBAClientX.QueryBuilder;
+
+public partial class Query
+{
+    /// <summary>Adds a caller-authored SQL expression compared for equality.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query WhereRaw(string expression, object value)
+        => AddCondition(expression, "=", value, isRawExpression: true);
+
+    /// <summary>Adds a caller-authored SQL expression to an <c>OR</c> equality predicate.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query OrWhereRaw(string expression, object value)
+        => AddCondition(expression, "=", value, "OR", isRawExpression: true);
+
+    /// <summary>Adds an <c>IN</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query WhereInRaw(string expression, params object[] values)
+        => AddInCondition(expression, values, isRawExpression: true);
+
+    /// <summary>Adds an <c>OR IN</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query OrWhereInRaw(string expression, params object[] values)
+        => AddInCondition(expression, values, "OR", isRawExpression: true);
+
+    /// <summary>Adds a <c>NOT IN</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query WhereNotInRaw(string expression, params object[] values)
+        => AddInCondition(expression, values, not: true, isRawExpression: true);
+
+    /// <summary>Adds an <c>OR NOT IN</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query OrWhereNotInRaw(string expression, params object[] values)
+        => AddInCondition(expression, values, "OR", not: true, isRawExpression: true);
+
+    /// <summary>Adds a <c>BETWEEN</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query WhereBetweenRaw(string expression, object start, object end)
+        => AddBetweenCondition(expression, start, end, isRawExpression: true);
+
+    /// <summary>Adds an <c>OR BETWEEN</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query OrWhereBetweenRaw(string expression, object start, object end)
+        => AddBetweenCondition(expression, start, end, "OR", isRawExpression: true);
+
+    /// <summary>Adds a <c>NOT BETWEEN</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query WhereNotBetweenRaw(string expression, object start, object end)
+        => AddBetweenCondition(expression, start, end, not: true, isRawExpression: true);
+
+    /// <summary>Adds an <c>OR NOT BETWEEN</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query OrWhereNotBetweenRaw(string expression, object start, object end)
+        => AddBetweenCondition(expression, start, end, "OR", not: true, isRawExpression: true);
+
+    /// <summary>Adds an <c>IS NULL</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query WhereNullRaw(string expression)
+        => AddNullCondition(expression, isRawExpression: true);
+
+    /// <summary>Adds an <c>OR IS NULL</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query OrWhereNullRaw(string expression)
+        => AddNullCondition(expression, "OR", isRawExpression: true);
+
+    /// <summary>Adds an <c>IS NOT NULL</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query WhereNotNullRaw(string expression)
+        => AddNotNullCondition(expression, isRawExpression: true);
+
+    /// <summary>Adds an <c>OR IS NOT NULL</c> predicate for a caller-authored SQL expression.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query OrWhereNotNullRaw(string expression)
+        => AddNotNullCondition(expression, "OR", isRawExpression: true);
+}

--- a/DbaClientX.Core/QueryBuilder/Query.WhereRaw.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.WhereRaw.cs
@@ -17,20 +17,40 @@ public partial class Query
     public Query WhereInRaw(string expression, params object[] values)
         => AddInCondition(expression, values, isRawExpression: true);
 
+    /// <summary>Adds an <c>IN</c> predicate comparing a caller-authored SQL expression to a subquery.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query WhereInRaw(string expression, Query subQuery)
+        => AddCondition(expression, "IN", subQuery, isRawExpression: true);
+
     /// <summary>Adds an <c>OR IN</c> predicate for a caller-authored SQL expression.</summary>
     /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
     public Query OrWhereInRaw(string expression, params object[] values)
         => AddInCondition(expression, values, "OR", isRawExpression: true);
+
+    /// <summary>Adds an <c>OR IN</c> predicate comparing a caller-authored SQL expression to a subquery.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query OrWhereInRaw(string expression, Query subQuery)
+        => AddCondition(expression, "IN", subQuery, "OR", isRawExpression: true);
 
     /// <summary>Adds a <c>NOT IN</c> predicate for a caller-authored SQL expression.</summary>
     /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
     public Query WhereNotInRaw(string expression, params object[] values)
         => AddInCondition(expression, values, not: true, isRawExpression: true);
 
+    /// <summary>Adds a <c>NOT IN</c> predicate comparing a caller-authored SQL expression to a subquery.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query WhereNotInRaw(string expression, Query subQuery)
+        => AddCondition(expression, "NOT IN", subQuery, isRawExpression: true);
+
     /// <summary>Adds an <c>OR NOT IN</c> predicate for a caller-authored SQL expression.</summary>
     /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
     public Query OrWhereNotInRaw(string expression, params object[] values)
         => AddInCondition(expression, values, "OR", not: true, isRawExpression: true);
+
+    /// <summary>Adds an <c>OR NOT IN</c> predicate comparing a caller-authored SQL expression to a subquery.</summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query OrWhereNotInRaw(string expression, Query subQuery)
+        => AddCondition(expression, "NOT IN", subQuery, "OR", isRawExpression: true);
 
     /// <summary>Adds a <c>BETWEEN</c> predicate for a caller-authored SQL expression.</summary>
     /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>

--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -443,6 +443,10 @@ public partial class Query
             {
                 throw new ArgumentException("Values cannot contain null.", nameof(values));
             }
+            if (value is Query)
+            {
+                throw new ArgumentException("Use the Query overload for a subquery instead of passing it as a value-list item.", nameof(values));
+            }
         }
         AddLogicalOperator(logical);
         var list = new List<object>(values);

--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -7,13 +7,14 @@ namespace DBAClientX.QueryBuilder;
 /// <summary>
 /// Provides a fluent interface for constructing SQL queries in a provider-agnostic manner.
 /// </summary>
-public class Query
+public partial class Query
 {
-    private readonly List<string> _select = new();
+    private readonly List<QueryExpression> _select = new();
     private bool _distinct;
-    private string? _from;
+    private QueryExpression? _from;
+    private string? _fromAlias;
     private (Query Query, string Alias)? _fromSubquery;
-    private readonly List<(string Type, string Table, string? Condition)> _joins = new();
+    private readonly List<QueryJoinClause> _joins = new();
     private readonly List<IWhereToken> _where = new();
     private string? _insertTable;
     private readonly List<string> _insertColumns = new();
@@ -24,9 +25,9 @@ public class Query
     private string? _updateTable;
     private readonly List<(string Column, object Value)> _set = new();
     private string? _deleteTable;
-    private readonly List<string> _orderBy = new();
-    private readonly List<string> _groupBy = new();
-    private readonly List<(string Column, string Operator, object Value)> _having = new();
+    private readonly List<QueryOrderExpression> _orderBy = new();
+    private readonly List<QueryExpression> _groupBy = new();
+    private readonly List<QueryHavingClause> _having = new();
     private int? _limit;
     private int? _offset;
     private bool _useTop;
@@ -41,7 +42,26 @@ public class Query
     public Query Select(params string[] columns)
     {
         ValidateStrings(columns, nameof(columns));
-        _select.AddRange(columns);
+        foreach (var column in columns)
+        {
+            _select.Add(new QueryExpression(column, IsRaw: false));
+        }
+        return this;
+    }
+
+    /// <summary>
+    /// Adds one or more caller-authored SQL expressions to the <c>SELECT</c> clause.
+    /// </summary>
+    /// <param name="expressions">Trusted SQL expressions that are emitted without identifier quoting.</param>
+    /// <returns>The current <see cref="Query"/> instance.</returns>
+    /// <remarks>Never pass untrusted input to this method.</remarks>
+    public Query SelectRaw(params string[] expressions)
+    {
+        ValidateStrings(expressions, nameof(expressions));
+        foreach (var expression in expressions)
+        {
+            _select.Add(new QueryExpression(expression, IsRaw: true));
+        }
         return this;
     }
 
@@ -63,7 +83,34 @@ public class Query
     public Query From(string table)
     {
         ValidateString(table, nameof(table));
-        _from = table;
+        _from = new QueryExpression(table, IsRaw: false);
+        _fromAlias = null;
+        _fromSubquery = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Specifies a table and alias for the <c>FROM</c> clause using identifier quoting for both values.
+    /// </summary>
+    public Query From(string table, string alias)
+    {
+        ValidateString(table, nameof(table));
+        ValidateString(alias, nameof(alias));
+        _from = new QueryExpression(table, IsRaw: false);
+        _fromAlias = alias;
+        _fromSubquery = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Specifies a caller-authored SQL expression for the <c>FROM</c> clause.
+    /// </summary>
+    /// <remarks>Never pass untrusted input to this method.</remarks>
+    public Query FromRaw(string expression)
+    {
+        ValidateString(expression, nameof(expression));
+        _from = new QueryExpression(expression, IsRaw: true);
+        _fromAlias = null;
         _fromSubquery = null;
         return this;
     }
@@ -82,69 +129,8 @@ public class Query
         }
         ValidateString(alias, nameof(alias));
         _from = null;
+        _fromAlias = null;
         _fromSubquery = (subQuery, alias);
-        return this;
-    }
-
-    /// <summary>
-    /// Adds an inner join to the query.
-    /// </summary>
-    /// <param name="table">The joined table.</param>
-    /// <param name="condition">The join condition.</param>
-    /// <returns>The current <see cref="Query"/> instance.</returns>
-    public Query Join(string table, string condition)
-    {
-        ValidateString(table, nameof(table));
-        ValidateString(condition, nameof(condition));
-        _joins.Add(("JOIN", table, condition));
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a left outer join to the query.
-    /// </summary>
-    /// <inheritdoc cref="Join(string, string)"/>
-    public Query LeftJoin(string table, string condition)
-    {
-        ValidateString(table, nameof(table));
-        ValidateString(condition, nameof(condition));
-        _joins.Add(("LEFT JOIN", table, condition));
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a right outer join to the query.
-    /// </summary>
-    /// <inheritdoc cref="Join(string, string)"/>
-    public Query RightJoin(string table, string condition)
-    {
-        ValidateString(table, nameof(table));
-        ValidateString(condition, nameof(condition));
-        _joins.Add(("RIGHT JOIN", table, condition));
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a cross join to the query.
-    /// </summary>
-    /// <param name="table">The joined table.</param>
-    /// <returns>The current <see cref="Query"/> instance.</returns>
-    public Query CrossJoin(string table)
-    {
-        ValidateString(table, nameof(table));
-        _joins.Add(("CROSS JOIN", table, null));
-        return this;
-    }
-
-    /// <summary>
-    /// Adds a full outer join to the query.
-    /// </summary>
-    /// <inheritdoc cref="Join(string, string)"/>
-    public Query FullOuterJoin(string table, string condition)
-    {
-        ValidateString(table, nameof(table));
-        ValidateString(condition, nameof(condition));
-        _joins.Add(("FULL OUTER JOIN", table, condition));
         return this;
     }
 
@@ -164,6 +150,15 @@ public class Query
     public Query Where(string column, string op, object value)
     {
         return AddCondition(column, op, value);
+    }
+
+    /// <summary>
+    /// Adds a predicate whose left side is a caller-authored SQL expression.
+    /// </summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query WhereRaw(string expression, string op, object value)
+    {
+        return AddCondition(expression, op, value, isRawExpression: true);
     }
 
     /// <summary>
@@ -191,6 +186,15 @@ public class Query
     public Query OrWhere(string column, string op, object value)
     {
         return AddCondition(column, op, value, "OR");
+    }
+
+    /// <summary>
+    /// Adds an <c>OR</c> predicate whose left side is a caller-authored SQL expression.
+    /// </summary>
+    /// <remarks>Never pass untrusted input to <paramref name="expression"/>.</remarks>
+    public Query OrWhereRaw(string expression, string op, object value)
+    {
+        return AddCondition(expression, op, value, "OR", isRawExpression: true);
     }
 
     /// <summary>
@@ -391,36 +395,42 @@ public class Query
         return this;
     }
 
-    private Query AddCondition(string column, string op, object value, string? logical = null)
+    private Query AddCondition(string column, string op, object value, string? logical = null, bool isRawExpression = false)
     {
         ValidateString(column, nameof(column));
-        ValidateString(op, nameof(op));
+        var normalizedOperator = QueryComparisonOperator.Normalize(op, nameof(op));
         if (value == null)
         {
             throw new ArgumentException("Value cannot be null.", nameof(value));
         }
+        if ((normalizedOperator == "IN" || normalizedOperator == "NOT IN") && value is not Query)
+        {
+            throw new ArgumentException("Use WhereIn/WhereNotIn for value lists; IN operators on this overload require a Query value.", nameof(value));
+        }
         AddLogicalOperator(logical);
-        _where.Add(new ConditionToken(column, op, value));
+        _where.Add(isRawExpression
+            ? new RawConditionToken(column, normalizedOperator, value)
+            : new ConditionToken(column, normalizedOperator, value));
         return this;
     }
 
-    private Query AddNullCondition(string column, string? logical = null)
+    private Query AddNullCondition(string column, string? logical = null, bool isRawExpression = false)
     {
         ValidateString(column, nameof(column));
         AddLogicalOperator(logical);
-        _where.Add(new NullToken(column));
+        _where.Add(isRawExpression ? new RawNullToken(column) : new NullToken(column));
         return this;
     }
 
-    private Query AddNotNullCondition(string column, string? logical = null)
+    private Query AddNotNullCondition(string column, string? logical = null, bool isRawExpression = false)
     {
         ValidateString(column, nameof(column));
         AddLogicalOperator(logical);
-        _where.Add(new NotNullToken(column));
+        _where.Add(isRawExpression ? new RawNotNullToken(column) : new NotNullToken(column));
         return this;
     }
 
-    private Query AddInCondition(string column, object[] values, string? logical = null, bool not = false)
+    private Query AddInCondition(string column, object[] values, string? logical = null, bool not = false, bool isRawExpression = false)
     {
         ValidateString(column, nameof(column));
         if (values == null || values.Length == 0)
@@ -438,16 +448,16 @@ public class Query
         var list = new List<object>(values);
         if (not)
         {
-            _where.Add(new NotInToken(column, list));
+            _where.Add(isRawExpression ? new RawNotInToken(column, list) : new NotInToken(column, list));
         }
         else
         {
-            _where.Add(new InToken(column, list));
+            _where.Add(isRawExpression ? new RawInToken(column, list) : new InToken(column, list));
         }
         return this;
     }
 
-    private Query AddBetweenCondition(string column, object start, object end, string? logical = null, bool not = false)
+    private Query AddBetweenCondition(string column, object start, object end, string? logical = null, bool not = false, bool isRawExpression = false)
     {
         ValidateString(column, nameof(column));
         if (start == null || end == null)
@@ -457,11 +467,11 @@ public class Query
         AddLogicalOperator(logical);
         if (not)
         {
-            _where.Add(new NotBetweenToken(column, start, end));
+            _where.Add(isRawExpression ? new RawNotBetweenToken(column, start, end) : new NotBetweenToken(column, start, end));
         }
         else
         {
-            _where.Add(new BetweenToken(column, start, end));
+            _where.Add(isRawExpression ? new RawBetweenToken(column, start, end) : new BetweenToken(column, start, end));
         }
         return this;
     }
@@ -601,121 +611,6 @@ public class Query
     }
 
     /// <summary>
-    /// Adds columns to the <c>ORDER BY</c> clause in ascending order.
-    /// </summary>
-    /// <param name="columns">The columns or expressions to order by.</param>
-    /// <returns>The current <see cref="Query"/> instance.</returns>
-    public Query OrderBy(params string[] columns)
-    {
-        ValidateStrings(columns, nameof(columns));
-        _orderBy.AddRange(columns);
-        return this;
-    }
-
-    /// <summary>
-    /// Adds columns to the <c>ORDER BY</c> clause in descending order.
-    /// </summary>
-    /// <inheritdoc cref="OrderBy(string[])"/>
-    public Query OrderByDescending(params string[] columns)
-    {
-        ValidateStrings(columns, nameof(columns));
-        foreach (var column in columns)
-        {
-            _orderBy.Add($"{column} DESC");
-        }
-        return this;
-    }
-
-    /// <summary>
-    /// Adds raw expressions to the <c>ORDER BY</c> clause.
-    /// </summary>
-    /// <param name="expressions">Raw ordering expressions.</param>
-    /// <returns>The current <see cref="Query"/> instance.</returns>
-    public Query OrderByRaw(params string[] expressions)
-    {
-        ValidateStrings(expressions, nameof(expressions));
-        _orderBy.AddRange(expressions);
-        return this;
-    }
-
-    /// <summary>
-    /// Adds columns to the <c>GROUP BY</c> clause.
-    /// </summary>
-    /// <param name="columns">The columns or expressions used for grouping.</param>
-    /// <returns>The current <see cref="Query"/> instance.</returns>
-    public Query GroupBy(params string[] columns)
-    {
-        ValidateStrings(columns, nameof(columns));
-        _groupBy.AddRange(columns);
-        return this;
-    }
-
-    /// <inheritdoc cref="Having(string, string, object)"/>
-    public Query Having(string column, object value)
-    {
-        return Having(column, "=", value);
-    }
-
-    /// <summary>
-    /// Adds a predicate to the <c>HAVING</c> clause.
-    /// </summary>
-    /// <param name="column">The aggregated column or expression.</param>
-    /// <param name="op">The comparison operator.</param>
-    /// <param name="value">The value to compare with.</param>
-    /// <returns>The current <see cref="Query"/> instance.</returns>
-    public Query Having(string column, string op, object value)
-    {
-        ValidateString(column, nameof(column));
-        ValidateString(op, nameof(op));
-        if (value == null)
-        {
-            throw new ArgumentException("Value cannot be null.", nameof(value));
-        }
-        _having.Add((column, op, value));
-        return this;
-    }
-
-    /// <summary>
-    /// Applies a <c>LIMIT</c> (or provider equivalent) clause to restrict result count.
-    /// </summary>
-    /// <param name="limit">The maximum number of rows to return.</param>
-    /// <returns>The current <see cref="Query"/> instance.</returns>
-    public Query Limit(int limit)
-    {
-        _limit = limit;
-        _useTop = false;
-        // Ensure pagination mode is exclusive
-        // Limit/Offset mode should not use TOP
-        return this;
-    }
-
-    /// <summary>
-    /// Applies an <c>OFFSET</c> clause to skip a number of rows.
-    /// </summary>
-    /// <param name="offset">The number of rows to skip.</param>
-    /// <returns>The current <see cref="Query"/> instance.</returns>
-    public Query Offset(int offset)
-    {
-        _offset = offset;
-        _useTop = false;
-        return this;
-    }
-
-    /// <summary>
-    /// Applies a <c>TOP</c> clause (SQL Server style) to limit results.
-    /// </summary>
-    /// <param name="top">The number of rows to return.</param>
-    /// <returns>The current <see cref="Query"/> instance.</returns>
-    public Query Top(int top)
-    {
-        _limit = top;
-        _useTop = true;
-        // Reset offset when switching to TOP to avoid mixed pagination modes
-        _offset = null;
-        return this;
-    }
-
-    /// <summary>
     /// Adds a <c>UNION</c> compound query.
     /// </summary>
     /// <param name="query">The query to union.</param>
@@ -822,190 +717,5 @@ public class Query
         return compiler.CompileWithParameters(this);
     }
 
-    /// <summary>
-    /// Gets the selected columns for the query.
-    /// </summary>
-    public IReadOnlyList<string> SelectColumns => _select;
-
-    /// <summary>
-    /// Gets the table used in the <c>FROM</c> clause, when not using a subquery.
-    /// </summary>
-    public string? Table => _from;
-
-    /// <summary>
-    /// Gets the subquery used in the <c>FROM</c> clause, if any.
-    /// </summary>
-    public (Query Query, string Alias)? FromSubquery => _fromSubquery;
-
-    /// <summary>
-    /// Gets the sequence of tokens representing the <c>WHERE</c> clause.
-    /// </summary>
-    public IReadOnlyList<IWhereToken> WhereTokens => _where;
-
-    /// <summary>
-    /// Gets the table targeted by an <c>INSERT</c> statement.
-    /// </summary>
-    public string? InsertTable => _insertTable;
-
-    /// <summary>
-    /// Gets the column list used for <c>INSERT</c> statements.
-    /// </summary>
-    public IReadOnlyList<string> InsertColumns => _insertColumns;
-
-    /// <summary>
-    /// Gets the rows of values used for <c>INSERT</c> statements.
-    /// </summary>
-    public IReadOnlyList<IReadOnlyList<object>> InsertValues => _values;
-
-    /// <summary>
-    /// Gets a value indicating whether the query is configured as an upsert.
-    /// </summary>
-    public bool IsUpsert => _isUpsert;
-
-    /// <summary>
-    /// Gets the columns used to detect conflicts during an upsert.
-    /// </summary>
-    public IReadOnlyList<string> ConflictColumns => _conflictColumns;
-
-    /// <summary>
-    /// Gets the subset of columns that should be updated during an upsert.
-    /// </summary>
-    public IReadOnlyList<string> UpsertUpdateOnlyColumns => _upsertUpdateOnly;
-
-    /// <summary>
-    /// Gets the table targeted by an <c>UPDATE</c> statement.
-    /// </summary>
-    public string? UpdateTable => _updateTable;
-
-    /// <summary>
-    /// Gets the column/value pairs configured for an <c>UPDATE</c> statement.
-    /// </summary>
-    public IReadOnlyList<(string Column, object Value)> SetValues => _set;
-
-    /// <summary>
-    /// Gets the table targeted by a <c>DELETE</c> statement.
-    /// </summary>
-    public string? DeleteTable => _deleteTable;
-
-    /// <summary>
-    /// Gets the column expressions used for ordering.
-    /// </summary>
-    public IReadOnlyList<string> OrderByColumns => _orderBy;
-
-    /// <summary>
-    /// Gets the column expressions used for grouping.
-    /// </summary>
-    public IReadOnlyList<string> GroupByColumns => _groupBy;
-
-    /// <summary>
-    /// Gets the predicates configured for the <c>HAVING</c> clause.
-    /// </summary>
-    public IReadOnlyList<(string Column, string Operator, object Value)> HavingClauses => _having;
-
-    /// <summary>
-    /// Gets the join definitions applied to the query.
-    /// </summary>
-    public IReadOnlyList<(string Type, string Table, string? Condition)> Joins => _joins;
-
-    /// <summary>
-    /// Gets the compound queries appended to the current query.
-    /// </summary>
-    public IReadOnlyList<(string Type, Query Query)> CompoundQueries => _compoundQueries;
-
-    /// <summary>
-    /// Gets a value indicating whether the query uses <c>DISTINCT</c>.
-    /// </summary>
-    public bool IsDistinct => _distinct;
-
-    /// <summary>
-    /// Gets the configured <c>LIMIT</c> value, if any.
-    /// </summary>
-    public int? LimitValue => _limit;
-
-    /// <summary>
-    /// Gets the configured <c>OFFSET</c> value, if any.
-    /// </summary>
-    public int? OffsetValue => _offset;
-
-    /// <summary>
-    /// Gets a value indicating whether the query should use <c>TOP</c> semantics.
-    /// </summary>
-    public bool UseTop => _useTop;
-
-    /// <summary>
-    /// Gets the number of open grouping tokens to validate balanced conditions.
-    /// </summary>
-    public int OpenGroups => _openGroups;
 }
-
-/// <summary>
-/// Marker interface for <c>WHERE</c> clause tokens.
-/// </summary>
-public interface IWhereToken { }
-
-/// <summary>
-/// Represents a comparison predicate in the <c>WHERE</c> clause.
-/// </summary>
-/// <param name="Column">The column being compared.</param>
-/// <param name="Operator">The comparison operator.</param>
-/// <param name="Value">The comparison value.</param>
-public sealed record ConditionToken(string Column, string Operator, object Value) : IWhereToken;
-
-/// <summary>
-/// Represents a logical operator token (e.g., AND/OR).
-/// </summary>
-/// <param name="Operator">The logical operator text.</param>
-public sealed record OperatorToken(string Operator) : IWhereToken;
-
-/// <summary>
-/// Marks the start of a grouped condition.
-/// </summary>
-public sealed record GroupStartToken() : IWhereToken;
-
-/// <summary>
-/// Marks the end of a grouped condition.
-/// </summary>
-public sealed record GroupEndToken() : IWhereToken;
-
-/// <summary>
-/// Represents an <c>IS NULL</c> predicate.
-/// </summary>
-/// <param name="Column">The column evaluated for null.</param>
-public sealed record NullToken(string Column) : IWhereToken;
-
-/// <summary>
-/// Represents an <c>IS NOT NULL</c> predicate.
-/// </summary>
-/// <param name="Column">The column evaluated for non-null values.</param>
-public sealed record NotNullToken(string Column) : IWhereToken;
-
-/// <summary>
-/// Represents an <c>IN</c> predicate with literal values.
-/// </summary>
-/// <param name="Column">The column being compared.</param>
-/// <param name="Values">The values to test.</param>
-public sealed record InToken(string Column, IReadOnlyList<object> Values) : IWhereToken;
-
-/// <summary>
-/// Represents a <c>NOT IN</c> predicate with literal values.
-/// </summary>
-/// <param name="Column">The column being compared.</param>
-/// <param name="Values">The values to exclude.</param>
-public sealed record NotInToken(string Column, IReadOnlyList<object> Values) : IWhereToken;
-
-/// <summary>
-/// Represents a <c>BETWEEN</c> predicate.
-/// </summary>
-/// <param name="Column">The column being compared.</param>
-/// <param name="Start">The inclusive start value.</param>
-/// <param name="End">The inclusive end value.</param>
-public sealed record BetweenToken(string Column, object Start, object End) : IWhereToken;
-
-/// <summary>
-/// Represents a <c>NOT BETWEEN</c> predicate.
-/// </summary>
-/// <param name="Column">The column being compared.</param>
-/// <param name="Start">The inclusive start value.</param>
-/// <param name="End">The inclusive end value.</param>
-public sealed record NotBetweenToken(string Column, object Start, object End) : IWhereToken;
 

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.Identifiers.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.Identifiers.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Globalization;
+using System.Text;
+
+namespace DBAClientX.QueryBuilder;
+
+public partial class QueryCompiler
+{
+    private void AppendAlias(StringBuilder builder, string alias)
+    {
+        builder.Append(_dialect == SqlDialect.Oracle ? " " : " AS ")
+            .Append(QuoteIdentifier(alias));
+    }
+
+    private string QuoteIdentifier(string identifier)
+    {
+        if (string.IsNullOrEmpty(identifier) || identifier == "*")
+        {
+            return identifier;
+        }
+
+        var (open, close) = _dialect switch
+        {
+            SqlDialect.SqlServer => ('[', ']'),
+            SqlDialect.MySql => ('`', '`'),
+            SqlDialect.PostgreSql => ('"', '"'),
+            SqlDialect.SQLite => ('"', '"'),
+            SqlDialect.Oracle => ('"', '"'),
+            _ => ('"', '"')
+        };
+
+        var parts = identifier.Split('.');
+        var builder = new StringBuilder();
+        for (var index = 0; index < parts.Length; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append('.');
+            }
+
+            if (parts[index] == "*")
+            {
+                builder.Append('*');
+                continue;
+            }
+
+            var escapedPart = parts[index].Replace(close.ToString(), new string(close, 2));
+            builder.Append(open).Append(escapedPart).Append(close);
+        }
+
+        return builder.ToString();
+    }
+
+    private string QuoteSelectColumn(string identifier, bool allowStandaloneLiterals)
+    {
+        if (allowStandaloneLiterals && LooksLikeStandaloneLiteral(identifier))
+        {
+            return identifier;
+        }
+
+        return QuoteIdentifier(identifier);
+    }
+
+    private static bool LooksLikeStandaloneLiteral(string identifier)
+    {
+        if (string.IsNullOrWhiteSpace(identifier))
+        {
+            return false;
+        }
+
+        if (double.TryParse(identifier, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
+        {
+            return true;
+        }
+
+        return string.Equals(identifier, "NULL", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(identifier, "TRUE", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(identifier, "FALSE", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.Values.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.Values.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace DBAClientX.QueryBuilder;
+
+public partial class QueryCompiler
+{
+    private void AppendValues(StringBuilder builder, IReadOnlyList<object> values, List<object>? parameters)
+    {
+        for (var index = 0; index < values.Count; index++)
+        {
+            if (index > 0)
+            {
+                builder.Append(", ");
+            }
+
+            AppendValue(builder, values[index], parameters);
+        }
+    }
+
+    private void AppendValue(StringBuilder builder, object value, List<object>? parameters)
+    {
+        if (value is Query query)
+        {
+            builder.Append('(').Append(CompileInternal(query, parameters)).Append(')');
+            return;
+        }
+
+        builder.Append(parameters != null ? AddParameter(value, parameters) : FormatValue(value));
+    }
+
+    private static string AddParameter(object value, List<object> parameters)
+    {
+        var name = "@p" + parameters.Count;
+        parameters.Add(value);
+        return name;
+    }
+
+    private string FormatValue(object value)
+    {
+        return value switch
+        {
+            string text => $"'{text.Replace("'", "''")}'",
+            null => "NULL",
+            bool boolean => FormatBooleanLiteral(boolean),
+            DateTime dateTime => $"'{dateTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)}'",
+            DateTimeOffset dateTimeOffset => $"'{dateTimeOffset.ToString("yyyy-MM-ddTHH:mm:ss.fffffffzzz", CultureInfo.InvariantCulture)}'",
+            decimal number => number.ToString(CultureInfo.InvariantCulture),
+            double number => number.ToString(CultureInfo.InvariantCulture),
+            float number => number.ToString(CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? string.Empty
+        };
+    }
+
+    private string FormatBooleanLiteral(bool value)
+        => _dialect switch
+        {
+            SqlDialect.PostgreSql => value ? "TRUE" : "FALSE",
+            _ => value ? "1" : "0"
+        };
+}

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -126,10 +126,14 @@ public partial class QueryCompiler
                 switch (token)
                 {
                     case ConditionToken cond:
-                        sb.Append("WCI:").Append(cond.Column).Append(':').Append(cond.Operator).Append('|');
+                        sb.Append("WCI:").Append(cond.Column).Append(':').Append(cond.Operator).Append(':');
+                        AppendCacheValueShape(sb, cond.Value);
+                        sb.Append('|');
                         break;
                     case RawConditionToken cond:
-                        sb.Append("WCR:").Append(cond.Expression).Append(':').Append(cond.Operator).Append('|');
+                        sb.Append("WCR:").Append(cond.Expression).Append(':').Append(cond.Operator).Append(':');
+                        AppendCacheValueShape(sb, cond.Value);
+                        sb.Append('|');
                         break;
                     case OperatorToken op:
                         sb.Append("WO:").Append(op.Operator).Append('|');
@@ -153,35 +157,62 @@ public partial class QueryCompiler
                         sb.Append("WNNR:").Append(nn.Expression).Append('|');
                         break;
                     case InToken it:
-                        sb.Append("WII:").Append(it.Column).Append(':').Append(it.Values.Count).Append('|');
+                        sb.Append("WII:").Append(it.Column).Append(':');
+                        AppendCacheValueShapes(sb, it.Values);
+                        sb.Append('|');
                         break;
                     case RawInToken it:
-                        sb.Append("WIR:").Append(it.Expression).Append(':').Append(it.Values.Count).Append('|');
+                        sb.Append("WIR:").Append(it.Expression).Append(':');
+                        AppendCacheValueShapes(sb, it.Values);
+                        sb.Append('|');
                         break;
                     case NotInToken nit:
-                        sb.Append("WNII:").Append(nit.Column).Append(':').Append(nit.Values.Count).Append('|');
+                        sb.Append("WNII:").Append(nit.Column).Append(':');
+                        AppendCacheValueShapes(sb, nit.Values);
+                        sb.Append('|');
                         break;
                     case RawNotInToken nit:
-                        sb.Append("WNIR:").Append(nit.Expression).Append(':').Append(nit.Values.Count).Append('|');
+                        sb.Append("WNIR:").Append(nit.Expression).Append(':');
+                        AppendCacheValueShapes(sb, nit.Values);
+                        sb.Append('|');
                         break;
                     case BetweenToken bt:
-                        sb.Append("WBI:").Append(bt.Column).Append('|');
+                        sb.Append("WBI:").Append(bt.Column).Append(':');
+                        AppendCacheValueShape(sb, bt.Start);
+                        AppendCacheValueShape(sb, bt.End);
+                        sb.Append('|');
                         break;
                     case RawBetweenToken bt:
-                        sb.Append("WBR:").Append(bt.Expression).Append('|');
+                        sb.Append("WBR:").Append(bt.Expression).Append(':');
+                        AppendCacheValueShape(sb, bt.Start);
+                        AppendCacheValueShape(sb, bt.End);
+                        sb.Append('|');
                         break;
                     case NotBetweenToken nbt:
-                        sb.Append("WNBI:").Append(nbt.Column).Append('|');
+                        sb.Append("WNBI:").Append(nbt.Column).Append(':');
+                        AppendCacheValueShape(sb, nbt.Start);
+                        AppendCacheValueShape(sb, nbt.End);
+                        sb.Append('|');
                         break;
                     case RawNotBetweenToken nbt:
-                        sb.Append("WNBR:").Append(nbt.Expression).Append('|');
+                        sb.Append("WNBR:").Append(nbt.Expression).Append(':');
+                        AppendCacheValueShape(sb, nbt.Start);
+                        AppendCacheValueShape(sb, nbt.End);
+                        sb.Append('|');
                         break;
                 }
             }
         }
         if (!string.IsNullOrWhiteSpace(query.InsertTable))
         {
-            sb.Append("I:").Append(query.InsertTable!).Append('(').Append(string.Join(",", query.InsertColumns)).Append(')').Append(':').Append(query.InsertValues.Count).Append('|');
+            sb.Append("I:").Append(query.InsertTable!).Append('(').Append(string.Join(",", query.InsertColumns)).Append(')').Append(':');
+            foreach (var row in query.InsertValues)
+            {
+                sb.Append('[');
+                AppendCacheValueShapes(sb, row);
+                sb.Append(']');
+            }
+            sb.Append('|');
             if (query.IsUpsert)
             {
                 sb.Append("U:").Append(string.Join(",", query.ConflictColumns)).Append('|');
@@ -193,7 +224,14 @@ public partial class QueryCompiler
         }
         if (!string.IsNullOrWhiteSpace(query.UpdateTable))
         {
-            sb.Append("UP:").Append(query.UpdateTable!).Append('(').Append(string.Join(",", query.SetValues.Select(s => s.Column))).Append(')').Append('|');
+            sb.Append("UP:").Append(query.UpdateTable!).Append('(');
+            foreach (var set in query.SetValues)
+            {
+                sb.Append(set.Column).Append(':');
+                AppendCacheValueShape(sb, set.Value);
+                sb.Append(',');
+            }
+            sb.Append(")|");
         }
         if (!string.IsNullOrWhiteSpace(query.DeleteTable))
         {
@@ -217,7 +255,9 @@ public partial class QueryCompiler
         {
             foreach (var h in query.HavingExpressions)
             {
-                sb.Append(h.IsRaw ? "HR:" : "HI:").Append(h.Expression).Append(':').Append(h.Operator).Append('|');
+                sb.Append(h.IsRaw ? "HR:" : "HI:").Append(h.Expression).Append(':').Append(h.Operator).Append(':');
+                AppendCacheValueShape(sb, h.Value);
+                sb.Append('|');
             }
         }
         if (query.LimitValue.HasValue)
@@ -240,6 +280,25 @@ public partial class QueryCompiler
             }
         }
         return sb.ToString();
+    }
+
+    private void AppendCacheValueShapes(StringBuilder builder, IReadOnlyList<object> values)
+    {
+        foreach (var value in values)
+        {
+            AppendCacheValueShape(builder, value);
+        }
+    }
+
+    private void AppendCacheValueShape(StringBuilder builder, object value)
+    {
+        if (value is Query subQuery)
+        {
+            builder.Append("Q(").Append(BuildCacheKey(subQuery)).Append(')');
+            return;
+        }
+
+        builder.Append('P');
     }
 
     private string CompileInternal(Query query, List<object>? parameters)

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -10,7 +9,7 @@ namespace DBAClientX.QueryBuilder;
 /// <summary>
 /// Compiles <see cref="Query"/> objects into SQL text tailored to a specific <see cref="SqlDialect"/>.
 /// </summary>
-public class QueryCompiler
+public partial class QueryCompiler
 {
     private readonly SqlDialect _dialect;
 
@@ -94,19 +93,30 @@ public class QueryCompiler
     {
         var sb = new StringBuilder();
         sb.Append(_dialect).Append('|');
-        sb.Append(string.Join(",", query.SelectColumns)).Append('|');
+        foreach (var expression in query.SelectExpressions)
+        {
+            sb.Append(expression.IsRaw ? "SR:" : "SI:").Append(expression.Text).Append('|');
+        }
         sb.Append(query.IsDistinct).Append('|');
-        sb.Append(query.Table ?? string.Empty).Append('|');
+        if (query.TableExpression is { } table)
+        {
+            sb.Append(table.IsRaw ? "FR:" : "FI:").Append(table.Text).Append(':').Append(query.TableAlias ?? string.Empty).Append('|');
+        }
         if (query.FromSubquery.HasValue)
         {
             var (sub, alias) = query.FromSubquery.Value;
             sb.Append("SUB:").Append(BuildCacheKey(sub)).Append(':').Append(alias).Append('|');
         }
-        if (query.Joins.Count > 0)
+        if (query.JoinClauses.Count > 0)
         {
-            foreach (var j in query.Joins)
+            foreach (var j in query.JoinClauses)
             {
-                sb.Append('J').Append(j.Type).Append(':').Append(j.Table).Append(':').Append(j.Condition ?? string.Empty).Append('|');
+                sb.Append('J').Append(j.Type).Append(':')
+                    .Append(j.Table.IsRaw ? "R:" : "I:").Append(j.Table.Text).Append(':')
+                    .Append(j.Alias ?? string.Empty).Append(':')
+                    .Append(j.RawCondition ?? j.LeftColumn ?? string.Empty).Append(':')
+                    .Append(j.Operator ?? string.Empty).Append(':')
+                    .Append(j.RightColumn ?? string.Empty).Append('|');
             }
         }
         if (query.WhereTokens.Count > 0)
@@ -116,7 +126,10 @@ public class QueryCompiler
                 switch (token)
                 {
                     case ConditionToken cond:
-                        sb.Append("WC:").Append(cond.Column).Append(':').Append(cond.Operator).Append('|');
+                        sb.Append("WCI:").Append(cond.Column).Append(':').Append(cond.Operator).Append('|');
+                        break;
+                    case RawConditionToken cond:
+                        sb.Append("WCR:").Append(cond.Expression).Append(':').Append(cond.Operator).Append('|');
                         break;
                     case OperatorToken op:
                         sb.Append("WO:").Append(op.Operator).Append('|');
@@ -128,22 +141,40 @@ public class QueryCompiler
                         sb.Append("WG)").Append('|');
                         break;
                     case NullToken n:
-                        sb.Append("WN:").Append(n.Column).Append('|');
+                        sb.Append("WNI:").Append(n.Column).Append('|');
+                        break;
+                    case RawNullToken n:
+                        sb.Append("WNR:").Append(n.Expression).Append('|');
                         break;
                     case NotNullToken nn:
-                        sb.Append("WNN:").Append(nn.Column).Append('|');
+                        sb.Append("WNNI:").Append(nn.Column).Append('|');
+                        break;
+                    case RawNotNullToken nn:
+                        sb.Append("WNNR:").Append(nn.Expression).Append('|');
                         break;
                     case InToken it:
-                        sb.Append("WI:").Append(it.Column).Append(':').Append(it.Values.Count).Append('|');
+                        sb.Append("WII:").Append(it.Column).Append(':').Append(it.Values.Count).Append('|');
+                        break;
+                    case RawInToken it:
+                        sb.Append("WIR:").Append(it.Expression).Append(':').Append(it.Values.Count).Append('|');
                         break;
                     case NotInToken nit:
-                        sb.Append("WNI:").Append(nit.Column).Append(':').Append(nit.Values.Count).Append('|');
+                        sb.Append("WNII:").Append(nit.Column).Append(':').Append(nit.Values.Count).Append('|');
+                        break;
+                    case RawNotInToken nit:
+                        sb.Append("WNIR:").Append(nit.Expression).Append(':').Append(nit.Values.Count).Append('|');
                         break;
                     case BetweenToken bt:
-                        sb.Append("WB:").Append(bt.Column).Append('|');
+                        sb.Append("WBI:").Append(bt.Column).Append('|');
+                        break;
+                    case RawBetweenToken bt:
+                        sb.Append("WBR:").Append(bt.Expression).Append('|');
                         break;
                     case NotBetweenToken nbt:
-                        sb.Append("WNB:").Append(nbt.Column).Append('|');
+                        sb.Append("WNBI:").Append(nbt.Column).Append('|');
+                        break;
+                    case RawNotBetweenToken nbt:
+                        sb.Append("WNBR:").Append(nbt.Expression).Append('|');
                         break;
                 }
             }
@@ -168,19 +199,25 @@ public class QueryCompiler
         {
             sb.Append("D:").Append(query.DeleteTable!).Append('|');
         }
-        if (query.OrderByColumns.Count > 0)
+        if (query.OrderByExpressions.Count > 0)
         {
-            sb.Append("O:").Append(string.Join(",", query.OrderByColumns)).Append('|');
-        }
-        if (query.GroupByColumns.Count > 0)
-        {
-            sb.Append("G:").Append(string.Join(",", query.GroupByColumns)).Append('|');
-        }
-        if (query.HavingClauses.Count > 0)
-        {
-            foreach (var h in query.HavingClauses)
+            foreach (var expression in query.OrderByExpressions)
             {
-                sb.Append("H:").Append(h.Column).Append(':').Append(h.Operator).Append('|');
+                sb.Append(expression.IsRaw ? "OR:" : "OI:").Append(expression.Text).Append(':').Append(expression.Descending).Append('|');
+            }
+        }
+        if (query.GroupByExpressions.Count > 0)
+        {
+            foreach (var expression in query.GroupByExpressions)
+            {
+                sb.Append(expression.IsRaw ? "GR:" : "GI:").Append(expression.Text).Append('|');
+            }
+        }
+        if (query.HavingExpressions.Count > 0)
+        {
+            foreach (var h in query.HavingExpressions)
+            {
+                sb.Append(h.IsRaw ? "HR:" : "HI:").Append(h.Expression).Append(':').Append(h.Operator).Append('|');
             }
         }
         if (query.LimitValue.HasValue)
@@ -304,34 +341,61 @@ public class QueryCompiler
             sb.Append("TOP ").Append(query.LimitValue.Value).Append(' ');
         }
 
-        if (query.SelectColumns.Count > 0)
+        if (query.SelectExpressions.Count > 0)
         {
-            var allowStandaloneLiterals = string.IsNullOrWhiteSpace(query.Table) && !query.FromSubquery.HasValue;
-            sb.Append(string.Join(", ", query.SelectColumns.Select(column => QuoteSelectColumn(column, allowStandaloneLiterals))));
+            var allowStandaloneLiterals = query.TableExpression == null && !query.FromSubquery.HasValue;
+            for (var index = 0; index < query.SelectExpressions.Count; index++)
+            {
+                if (index > 0)
+                {
+                    sb.Append(", ");
+                }
+
+                var expression = query.SelectExpressions[index];
+                sb.Append(expression.IsRaw
+                    ? expression.Text
+                    : QuoteSelectColumn(expression.Text, allowStandaloneLiterals));
+            }
         }
         else
         {
             sb.Append("*");
         }
 
-        if (!string.IsNullOrWhiteSpace(query.Table))
+        if (query.TableExpression is { } fromExpression)
         {
-            sb.Append(" FROM ").Append(QuoteIdentifier(query.Table!));
+            sb.Append(" FROM ").Append(fromExpression.IsRaw ? fromExpression.Text : QuoteIdentifier(fromExpression.Text));
+            if (!string.IsNullOrWhiteSpace(query.TableAlias))
+            {
+                AppendAlias(sb, query.TableAlias!);
+            }
         }
         else if (query.FromSubquery.HasValue)
         {
             var (subQuery, alias) = query.FromSubquery.Value;
-            sb.Append(" FROM (").Append(CompileInternal(subQuery, parameters)).Append(") AS ").Append(QuoteIdentifier(alias));
+            sb.Append(" FROM (").Append(CompileInternal(subQuery, parameters)).Append(')');
+            AppendAlias(sb, alias);
         }
 
-        if (query.Joins.Count > 0)
+        if (query.JoinClauses.Count > 0)
         {
-            foreach (var join in query.Joins)
+            foreach (var join in query.JoinClauses)
             {
-                sb.Append(' ').Append(join.Type).Append(' ').Append(QuoteIdentifier(join.Table));
-                if (!string.IsNullOrWhiteSpace(join.Condition))
+                sb.Append(' ').Append(join.Type).Append(' ')
+                    .Append(join.Table.IsRaw ? join.Table.Text : QuoteIdentifier(join.Table.Text));
+                if (!string.IsNullOrWhiteSpace(join.Alias))
                 {
-                    sb.Append(" ON ").Append(join.Condition);
+                    AppendAlias(sb, join.Alias!);
+                }
+                if (!string.IsNullOrWhiteSpace(join.RawCondition))
+                {
+                    sb.Append(" ON ").Append(join.RawCondition);
+                }
+                else if (!string.IsNullOrWhiteSpace(join.LeftColumn))
+                {
+                    sb.Append(" ON ").Append(QuoteIdentifier(join.LeftColumn!))
+                        .Append(' ').Append(join.Operator).Append(' ')
+                        .Append(QuoteIdentifier(join.RightColumn!));
                 }
             }
         }
@@ -342,37 +406,60 @@ public class QueryCompiler
             AppendWhereTokens(sb, query.WhereTokens, parameters);
         }
 
-        if (query.GroupByColumns.Count > 0)
+        if (query.GroupByExpressions.Count > 0)
         {
-            sb.Append(" GROUP BY ").Append(string.Join(", ", query.GroupByColumns.Select(QuoteIdentifier)));
+            sb.Append(" GROUP BY ");
+            for (var index = 0; index < query.GroupByExpressions.Count; index++)
+            {
+                if (index > 0)
+                {
+                    sb.Append(", ");
+                }
+                var expression = query.GroupByExpressions[index];
+                sb.Append(expression.IsRaw ? expression.Text : QuoteIdentifier(expression.Text));
+            }
         }
 
-        if (query.HavingClauses.Count > 0)
+        if (query.HavingExpressions.Count > 0)
         {
             sb.Append(" HAVING ");
             bool first = true;
-            foreach (var clause in query.HavingClauses)
+            foreach (var clause in query.HavingExpressions)
             {
                 if (!first)
                 {
                     sb.Append(" AND ");
                 }
-                sb.Append(QuoteIdentifier(clause.Column)).Append(' ').Append(clause.Operator).Append(' ');
+                sb.Append(clause.IsRaw ? clause.Expression : QuoteIdentifier(clause.Expression))
+                    .Append(' ').Append(clause.Operator).Append(' ');
                 AppendValue(sb, clause.Value, parameters);
                 first = false;
             }
         }
 
-        if (query.OrderByColumns.Count > 0)
+        if (query.OrderByExpressions.Count > 0)
         {
-            sb.Append(" ORDER BY ").Append(string.Join(", ", query.OrderByColumns.Select(QuoteIdentifier)));
+            sb.Append(" ORDER BY ");
+            for (var index = 0; index < query.OrderByExpressions.Count; index++)
+            {
+                if (index > 0)
+                {
+                    sb.Append(", ");
+                }
+                var expression = query.OrderByExpressions[index];
+                sb.Append(expression.IsRaw ? expression.Text : QuoteIdentifier(expression.Text));
+                if (expression.Descending)
+                {
+                    sb.Append(" DESC");
+                }
+            }
         }
 
         if (_dialect == SqlDialect.SqlServer)
         {
             if (query.OffsetValue.HasValue)
             {
-                if (query.OrderByColumns.Count == 0)
+                if (query.OrderByExpressions.Count == 0)
                 {
                     throw new InvalidOperationException("SQL Server OFFSET/FETCH requires ORDER BY.");
                 }
@@ -570,6 +657,10 @@ public class QueryCompiler
                     sb.Append(QuoteIdentifier(cond.Column)).Append(' ').Append(cond.Operator).Append(' ');
                     AppendValue(sb, cond.Value, parameters);
                     break;
+                case RawConditionToken cond:
+                    sb.Append(cond.Expression).Append(' ').Append(cond.Operator).Append(' ');
+                    AppendValue(sb, cond.Value, parameters);
+                    break;
                 case GroupStartToken:
                     sb.Append('(');
                     break;
@@ -579,31 +670,33 @@ public class QueryCompiler
                 case NullToken n:
                     sb.Append(QuoteIdentifier(n.Column)).Append(" IS NULL");
                     break;
+                case RawNullToken n:
+                    sb.Append(n.Expression).Append(" IS NULL");
+                    break;
                 case NotNullToken nn:
                     sb.Append(QuoteIdentifier(nn.Column)).Append(" IS NOT NULL");
                     break;
+                case RawNotNullToken nn:
+                    sb.Append(nn.Expression).Append(" IS NOT NULL");
+                    break;
                 case InToken it:
                     sb.Append(QuoteIdentifier(it.Column)).Append(" IN (");
-                    for (int i = 0; i < it.Values.Count; i++)
-                    {
-                        if (i > 0)
-                        {
-                            sb.Append(", ");
-                        }
-                        AppendValue(sb, it.Values[i], parameters);
-                    }
+                    AppendValues(sb, it.Values, parameters);
+                    sb.Append(')');
+                    break;
+                case RawInToken it:
+                    sb.Append(it.Expression).Append(" IN (");
+                    AppendValues(sb, it.Values, parameters);
                     sb.Append(')');
                     break;
                 case NotInToken nit:
                     sb.Append(QuoteIdentifier(nit.Column)).Append(" NOT IN (");
-                    for (int i = 0; i < nit.Values.Count; i++)
-                    {
-                        if (i > 0)
-                        {
-                            sb.Append(", ");
-                        }
-                        AppendValue(sb, nit.Values[i], parameters);
-                    }
+                    AppendValues(sb, nit.Values, parameters);
+                    sb.Append(')');
+                    break;
+                case RawNotInToken nit:
+                    sb.Append(nit.Expression).Append(" NOT IN (");
+                    AppendValues(sb, nit.Values, parameters);
                     sb.Append(')');
                     break;
                 case BetweenToken bt:
@@ -612,8 +705,20 @@ public class QueryCompiler
                     sb.Append(" AND ");
                     AppendValue(sb, bt.End, parameters);
                     break;
+                case RawBetweenToken bt:
+                    sb.Append(bt.Expression).Append(" BETWEEN ");
+                    AppendValue(sb, bt.Start, parameters);
+                    sb.Append(" AND ");
+                    AppendValue(sb, bt.End, parameters);
+                    break;
                 case NotBetweenToken nbt:
                     sb.Append(QuoteIdentifier(nbt.Column)).Append(" NOT BETWEEN ");
+                    AppendValue(sb, nbt.Start, parameters);
+                    sb.Append(" AND ");
+                    AppendValue(sb, nbt.End, parameters);
+                    break;
+                case RawNotBetweenToken nbt:
+                    sb.Append(nbt.Expression).Append(" NOT BETWEEN ");
                     AppendValue(sb, nbt.Start, parameters);
                     sb.Append(" AND ");
                     AppendValue(sb, nbt.End, parameters);
@@ -654,128 +759,4 @@ public class QueryCompiler
         throw new InvalidOperationException($"Upsert column '{columnName}' is missing from the insert column list.");
     }
 
-    private string QuoteIdentifier(string identifier)
-    {
-        if (string.IsNullOrEmpty(identifier))
-        {
-            return identifier;
-        }
-
-        string suffix = string.Empty;
-        if (identifier.EndsWith(" DESC", StringComparison.OrdinalIgnoreCase))
-        {
-            suffix = " DESC";
-            identifier = identifier.Substring(0, identifier.Length - 5);
-        }
-        else if (identifier.EndsWith(" ASC", StringComparison.OrdinalIgnoreCase))
-        {
-            suffix = " ASC";
-            identifier = identifier.Substring(0, identifier.Length - 4);
-        }
-
-        if (identifier == "*" || identifier.Contains(' ') || identifier.Contains('(') || identifier.Contains(')'))
-        {
-            return identifier + suffix;
-        }
-
-        var (open, close) = _dialect switch
-        {
-            SqlDialect.SqlServer => ('[', ']'),
-            SqlDialect.MySql => ('`', '`'),
-            SqlDialect.PostgreSql => ('"', '"'),
-            SqlDialect.SQLite => ('"', '"'),
-            SqlDialect.Oracle => ('"', '"'),
-            _ => ('"', '"')
-        };
-
-        var parts = identifier.Split('.');
-        var sb = new StringBuilder();
-        for (int i = 0; i < parts.Length; i++)
-        {
-            if (i > 0)
-            {
-                sb.Append('.');
-            }
-            var escapedPart = parts[i].Replace(close.ToString(), new string(close, 2));
-            sb.Append(open).Append(escapedPart).Append(close);
-        }
-
-        sb.Append(suffix);
-        return sb.ToString();
-    }
-
-    private string QuoteSelectColumn(string identifier, bool allowStandaloneLiterals)
-    {
-        if (allowStandaloneLiterals && LooksLikeStandaloneLiteral(identifier))
-        {
-            return identifier;
-        }
-
-        return QuoteIdentifier(identifier);
-    }
-
-    private static bool LooksLikeStandaloneLiteral(string identifier)
-    {
-        if (string.IsNullOrWhiteSpace(identifier))
-        {
-            return false;
-        }
-
-        if (double.TryParse(identifier, NumberStyles.Float, CultureInfo.InvariantCulture, out _))
-        {
-            return true;
-        }
-
-        return string.Equals(identifier, "NULL", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(identifier, "TRUE", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(identifier, "FALSE", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private void AppendValue(StringBuilder sb, object value, List<object>? parameters)
-    {
-        if (value is Query q)
-        {
-            sb.Append('(').Append(CompileInternal(q, parameters)).Append(')');
-            return;
-        }
-
-        if (parameters != null)
-        {
-            sb.Append(AddParameter(value, parameters));
-        }
-        else
-        {
-            sb.Append(FormatValue(value));
-        }
-    }
-
-    private string AddParameter(object value, List<object> parameters)
-    {
-        var name = "@p" + parameters.Count;
-        parameters.Add(value);
-        return name;
-    }
-
-    private string FormatValue(object value)
-    {
-        return value switch
-        {
-            string s => $"'{s.Replace("'", "''")}'",
-            null => "NULL",
-            bool b => FormatBooleanLiteral(b),
-            DateTime dt => $"'{dt.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)}'",
-            DateTimeOffset dto => $"'{dto.ToString("yyyy-MM-ddTHH:mm:ss.fffffffzzz", CultureInfo.InvariantCulture)}'",
-            decimal d => d.ToString(CultureInfo.InvariantCulture),
-            double d => d.ToString(CultureInfo.InvariantCulture),
-            float f => f.ToString(CultureInfo.InvariantCulture),
-            _ => value.ToString() ?? string.Empty
-        };
-    }
-
-    private string FormatBooleanLiteral(bool value)
-        => _dialect switch
-        {
-            SqlDialect.PostgreSql => value ? "TRUE" : "FALSE",
-            _ => value ? "1" : "0"
-        };
 }

--- a/DbaClientX.Core/QueryBuilder/QueryParts.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryParts.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+
+namespace DBAClientX.QueryBuilder;
+
+internal readonly record struct QueryExpression(string Text, bool IsRaw);
+
+internal readonly record struct QueryOrderExpression(string Text, bool IsRaw, bool Descending);
+
+internal sealed record QueryJoinClause(
+    string Type,
+    QueryExpression Table,
+    string? Alias,
+    string? LeftColumn,
+    string? Operator,
+    string? RightColumn,
+    string? RawCondition);
+
+internal readonly record struct QueryHavingClause(string Expression, string Operator, object Value, bool IsRaw);
+
+internal sealed record RawConditionToken(string Expression, string Operator, object Value) : IWhereToken;
+
+internal sealed record RawNullToken(string Expression) : IWhereToken;
+
+internal sealed record RawNotNullToken(string Expression) : IWhereToken;
+
+internal sealed record RawInToken(string Expression, IReadOnlyList<object> Values) : IWhereToken;
+
+internal sealed record RawNotInToken(string Expression, IReadOnlyList<object> Values) : IWhereToken;
+
+internal sealed record RawBetweenToken(string Expression, object Start, object End) : IWhereToken;
+
+internal sealed record RawNotBetweenToken(string Expression, object Start, object End) : IWhereToken;
+
+internal static class QueryComparisonOperator
+{
+    private static readonly HashSet<string> Allowed = new(StringComparer.Ordinal)
+    {
+        "=",
+        "<>",
+        "!=",
+        "<",
+        "<=",
+        ">",
+        ">=",
+        "LIKE",
+        "NOT LIKE",
+        "IS",
+        "IS NOT",
+        "IN",
+        "NOT IN",
+        "<=>",
+        "!<",
+        "!>",
+        "ILIKE",
+        "NOT ILIKE",
+        "SIMILAR TO",
+        "NOT SIMILAR TO",
+        "REGEXP",
+        "RLIKE",
+        "GLOB",
+        "MATCH",
+        "IS DISTINCT FROM",
+        "IS NOT DISTINCT FROM"
+    };
+
+    public static string Normalize(string value, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Operator cannot be null, empty, or whitespace.", parameterName);
+        }
+
+        var normalized = string.Join(" ", value.Trim().Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+            .ToUpperInvariant();
+        if (!Allowed.Contains(normalized))
+        {
+            throw new ArgumentException($"Operator '{value}' is not supported by the safe query API.", parameterName);
+        }
+
+        return normalized;
+    }
+}

--- a/DbaClientX.Core/QueryBuilder/QueryTokens.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryTokens.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+namespace DBAClientX.QueryBuilder;
+
+/// <summary>Marker interface for <c>WHERE</c> clause tokens.</summary>
+public interface IWhereToken { }
+
+/// <summary>Represents a comparison predicate in the <c>WHERE</c> clause.</summary>
+/// <param name="Column">The column being compared.</param>
+/// <param name="Operator">The comparison operator.</param>
+/// <param name="Value">The comparison value.</param>
+public sealed record ConditionToken(string Column, string Operator, object Value) : IWhereToken;
+
+/// <summary>Represents a logical operator token, such as <c>AND</c> or <c>OR</c>.</summary>
+/// <param name="Operator">The logical operator text.</param>
+public sealed record OperatorToken(string Operator) : IWhereToken;
+
+/// <summary>Marks the start of a grouped condition.</summary>
+public sealed record GroupStartToken() : IWhereToken;
+
+/// <summary>Marks the end of a grouped condition.</summary>
+public sealed record GroupEndToken() : IWhereToken;
+
+/// <summary>Represents an <c>IS NULL</c> predicate.</summary>
+/// <param name="Column">The column evaluated for null.</param>
+public sealed record NullToken(string Column) : IWhereToken;
+
+/// <summary>Represents an <c>IS NOT NULL</c> predicate.</summary>
+/// <param name="Column">The column evaluated for non-null values.</param>
+public sealed record NotNullToken(string Column) : IWhereToken;
+
+/// <summary>Represents an <c>IN</c> predicate with literal values.</summary>
+/// <param name="Column">The column being compared.</param>
+/// <param name="Values">The values to test.</param>
+public sealed record InToken(string Column, IReadOnlyList<object> Values) : IWhereToken;
+
+/// <summary>Represents a <c>NOT IN</c> predicate with literal values.</summary>
+/// <param name="Column">The column being compared.</param>
+/// <param name="Values">The values to exclude.</param>
+public sealed record NotInToken(string Column, IReadOnlyList<object> Values) : IWhereToken;
+
+/// <summary>Represents a <c>BETWEEN</c> predicate.</summary>
+/// <param name="Column">The column being compared.</param>
+/// <param name="Start">The inclusive start value.</param>
+/// <param name="End">The inclusive end value.</param>
+public sealed record BetweenToken(string Column, object Start, object End) : IWhereToken;
+
+/// <summary>Represents a <c>NOT BETWEEN</c> predicate.</summary>
+/// <param name="Column">The column being compared.</param>
+/// <param name="Start">The inclusive start value.</param>
+/// <param name="End">The inclusive end value.</param>
+public sealed record NotBetweenToken(string Column, object Start, object End) : IWhereToken;

--- a/DbaClientX.Core/README.md
+++ b/DbaClientX.Core/README.md
@@ -30,7 +30,7 @@ await DbInvoker.ExecuteSqlAsync(
 );
 ```
 
-## Query builder (string-safe, provider-aware quoting)
+## Query builder (safe identifiers and explicit raw SQL)
 
 ```csharp
 using DBAClientX.QueryBuilder;
@@ -43,7 +43,29 @@ var sql = QueryBuilder
     .Compile(SqlDialect.SqlServer);
 ```
 
+Identifier methods quote every identifier; spaces and parentheses no longer switch the compiler into raw-SQL mode. Use an explicit raw method only for trusted expressions:
+
+```csharp
+var aggregate = new Query()
+    .Select("DepartmentId")
+    .SelectRaw("COUNT(*)")
+    .From("Employees")
+    .GroupBy("DepartmentId")
+    .HavingRaw("COUNT(*)", ">", 5)
+    .OrderByRaw("COUNT(*) DESC");
+```
+
+For aliased joins, prefer the identifier overload so tables, aliases, and both sides of the condition are quoted:
+
+```csharp
+var joined = new Query()
+    .Select("u.Id", "o.Total")
+    .From("Users", "u")
+    .Join("Orders", "o", "u.Id", "=", "o.UserId");
+```
+
+`SelectRaw`, `FromRaw`, `JoinRaw`, `WhereRaw`, `GroupByRaw`, `HavingRaw`, and `OrderByRaw` emit caller-authored SQL. Never pass user input to these methods. The legacy two-string join overloads remain available for migration but are obsolete because they treat both arguments as raw SQL. Comparison operators are limited to the supported safe operator set, and `Limit`, `Offset`, and `Top` reject negative values.
+
 ## Notes
 - Ship a per-provider package alongside Core for ADO.NET specifics (see provider READMEs).
 - `DbParameterMapper` supports dotted paths and ambient values.
-

--- a/DbaClientX.Examples/JoinExample.cs
+++ b/DbaClientX.Examples/JoinExample.cs
@@ -6,9 +6,9 @@ public static class JoinExample
     {
         var query = new Query()
             .Select("u.name", "o.total")
-            .From("users u")
-            .FullOuterJoin("orders o", "u.id = o.user_id")
-            .CrossJoin("regions r");
+            .From("users", "u")
+            .FullOuterJoin("orders", "o", "u.id", "=", "o.user_id")
+            .CrossJoin("regions", "r");
 
         Console.WriteLine(QueryBuilder.Compile(query));
     }

--- a/DbaClientX.Tests/QueryBuilderSafetyTests.cs
+++ b/DbaClientX.Tests/QueryBuilderSafetyTests.cs
@@ -50,6 +50,32 @@ public sealed class QueryBuilderSafetyTests
         Assert.Equal(new object[] { "alice", "bob" }, parameters);
     }
 
+    [Fact]
+    public void WhereInRaw_SubqueryCompilesAsSetInsteadOfScalarListItem()
+    {
+        var subQuery = new Query().Select("user_id").From("active_users");
+
+        var sql = new Query()
+            .Select("*")
+            .From("users")
+            .WhereInRaw("LOWER(name)", subQuery)
+            .Compile(SqlDialect.PostgreSql);
+
+        Assert.Equal(
+            "SELECT * FROM \"users\" WHERE LOWER(name) IN (SELECT \"user_id\" FROM \"active_users\")",
+            sql);
+    }
+
+    [Fact]
+    public void WhereInRaw_ValueListRejectsEmbeddedSubqueries()
+    {
+        var values = new object[] { new Query().Select("user_id").From("active_users") };
+
+        var exception = Assert.Throws<ArgumentException>(() => new Query().WhereInRaw("LOWER(name)", values));
+
+        Assert.Equal("values", exception.ParamName);
+    }
+
     [Theory]
     [InlineData("= 1; DROP TABLE users;--")]
     [InlineData("LIKE/**/OR")]

--- a/DbaClientX.Tests/QueryBuilderSafetyTests.cs
+++ b/DbaClientX.Tests/QueryBuilderSafetyTests.cs
@@ -1,0 +1,137 @@
+using DBAClientX.QueryBuilder;
+
+namespace DbaClientX.Tests;
+
+public sealed class QueryBuilderSafetyTests
+{
+    [Fact]
+    public void IdentifierMethods_DoNotInferRawSqlFromPunctuation()
+    {
+        var sql = new Query()
+            .Select("name); DROP TABLE users;--")
+            .From("users u")
+            .OrderBy("RANDOM()")
+            .Compile(SqlDialect.PostgreSql);
+
+        Assert.Equal(
+            "SELECT \"name); DROP TABLE users;--\" FROM \"users u\" ORDER BY \"RANDOM()\"",
+            sql);
+    }
+
+    [Fact]
+    public void RawMethods_EmitOnlyExplicitExpressions()
+    {
+        var sql = new Query()
+            .Select("age")
+            .SelectRaw("COUNT(*)")
+            .From("users")
+            .GroupBy("age")
+            .HavingRaw("COUNT(*)", ">", 1)
+            .OrderByRaw("COUNT(*) DESC")
+            .Compile(SqlDialect.PostgreSql);
+
+        Assert.Equal(
+            "SELECT \"age\", COUNT(*) FROM \"users\" GROUP BY \"age\" HAVING COUNT(*) > 1 ORDER BY COUNT(*) DESC",
+            sql);
+    }
+
+    [Fact]
+    public void RawWhereVariants_PreserveParameterizedValues()
+    {
+        var query = new Query()
+            .Select("*")
+            .From("users")
+            .WhereInRaw("LOWER(name)", "alice", "bob")
+            .OrWhereNullRaw("TRIM(email)");
+
+        var (sql, parameters) = query.CompileWithParameters(SqlDialect.PostgreSql);
+
+        Assert.Equal("SELECT * FROM \"users\" WHERE LOWER(name) IN (@p0, @p1) OR TRIM(email) IS NULL", sql);
+        Assert.Equal(new object[] { "alice", "bob" }, parameters);
+    }
+
+    [Theory]
+    [InlineData("= 1; DROP TABLE users;--")]
+    [InlineData("LIKE/**/OR")]
+    [InlineData("IN (SELECT 1)")]
+    public void SafePredicates_RejectUnknownOperators(string value)
+    {
+        var query = new Query();
+
+        var exception = Assert.Throws<ArgumentException>(() => query.Where("id", value, 1));
+
+        Assert.Equal("op", exception.ParamName);
+    }
+
+    [Fact]
+    public void InOperator_RequiresSubqueryOnGeneralPredicateOverload()
+    {
+        var query = new Query();
+
+        var exception = Assert.Throws<ArgumentException>(() => query.Where("id", "IN", 1));
+
+        Assert.Equal("value", exception.ParamName);
+    }
+
+    [Fact]
+    public void SafeJoin_QuotesEveryIdentifier()
+    {
+        var sql = new Query()
+            .Select("u.id", "o.user_id")
+            .From("users", "u")
+            .Join("orders", "o", "u.id", "=", "o.user_id")
+            .Compile(SqlDialect.SqlServer);
+
+        Assert.Equal(
+            "SELECT [u].[id], [o].[user_id] FROM [users] AS [u] JOIN [orders] AS [o] ON [u].[id] = [o].[user_id]",
+            sql);
+    }
+
+    [Fact]
+    public void OracleTableAliases_OmitUnsupportedAsKeyword()
+    {
+        var sql = new Query()
+            .Select("u.id", "o.user_id")
+            .From("users", "u")
+            .Join("orders", "o", "u.id", "=", "o.user_id")
+            .Compile(SqlDialect.Oracle);
+
+        Assert.Equal(
+            "SELECT \"u\".\"id\", \"o\".\"user_id\" FROM \"users\" \"u\" JOIN \"orders\" \"o\" ON \"u\".\"id\" = \"o\".\"user_id\"",
+            sql);
+    }
+
+    [Fact]
+    public void SafeJoin_RejectsUnknownOperators()
+    {
+        var query = new Query();
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            query.Join("orders", "users.id", "= orders.user_id; DROP TABLE users;--", "orders.user_id"));
+
+        Assert.Equal("op", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(-1, "limit")]
+    [InlineData(-10, "limit")]
+    public void Limit_RejectsNegativeValues(int value, string parameterName)
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new Query().Limit(value));
+        Assert.Equal(parameterName, exception.ParamName);
+    }
+
+    [Fact]
+    public void Offset_RejectsNegativeValues()
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new Query().Offset(-1));
+        Assert.Equal("offset", exception.ParamName);
+    }
+
+    [Fact]
+    public void Top_RejectsNegativeValues()
+    {
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new Query().Top(-1));
+        Assert.Equal("top", exception.ParamName);
+    }
+}

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -604,10 +604,11 @@ public class QueryBuilderTests
     public void GroupByHaving()
     {
         var query = new Query()
-            .Select("age", "COUNT(*)")
+            .Select("age")
+            .SelectRaw("COUNT(*)")
             .From("users")
             .GroupBy("age")
-            .Having("COUNT(*)", ">", 1);
+            .HavingRaw("COUNT(*)", ">", 1);
 
         var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
         Assert.Equal("SELECT \"age\", COUNT(*) FROM \"users\" GROUP BY \"age\" HAVING COUNT(*) > 1", sql);
@@ -656,11 +657,11 @@ public class QueryBuilderTests
     {
         var query = new Query()
             .Select("u.name", "o.total")
-            .From("users u")
-            .Join("orders o", "u.id = o.user_id");
+            .From("users", "u")
+            .Join("orders", "o", "u.id", "=", "o.user_id");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
-        Assert.Equal("SELECT \"u\".\"name\", \"o\".\"total\" FROM users u JOIN orders o ON u.id = o.user_id", sql);
+        Assert.Equal("SELECT \"u\".\"name\", \"o\".\"total\" FROM \"users\" AS \"u\" JOIN \"orders\" AS \"o\" ON \"u\".\"id\" = \"o\".\"user_id\"", sql);
     }
 
     [Fact]
@@ -668,23 +669,23 @@ public class QueryBuilderTests
     {
         var query = new Query()
             .Select("*")
-            .From("users u")
-            .LeftJoin("profiles p", "u.id = p.user_id")
-            .RightJoin("photos ph", "u.id = ph.user_id");
+            .From("users", "u")
+            .LeftJoin("profiles", "p", "u.id", "=", "p.user_id")
+            .RightJoin("photos", "ph", "u.id", "=", "ph.user_id");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
-        Assert.Equal("SELECT * FROM users u LEFT JOIN profiles p ON u.id = p.user_id RIGHT JOIN photos ph ON u.id = ph.user_id", sql);
+        Assert.Equal("SELECT * FROM \"users\" AS \"u\" LEFT JOIN \"profiles\" AS \"p\" ON \"u\".\"id\" = \"p\".\"user_id\" RIGHT JOIN \"photos\" AS \"ph\" ON \"u\".\"id\" = \"ph\".\"user_id\"", sql);
     }
     [Fact]
     public void CrossJoinQueries()
     {
         var query = new Query()
             .Select("*")
-            .From("users u")
-            .CrossJoin("orders o");
+            .From("users", "u")
+            .CrossJoin("orders", "o");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
-        Assert.Equal("SELECT * FROM users u CROSS JOIN orders o", sql);
+        Assert.Equal("SELECT * FROM \"users\" AS \"u\" CROSS JOIN \"orders\" AS \"o\"", sql);
     }
 
     [Fact]
@@ -692,14 +693,13 @@ public class QueryBuilderTests
     {
         var query = new Query()
             .Select("u.name", "o.total")
-            .From("users u")
-            .FullOuterJoin("orders o", "u.id = o.user_id");
+            .From("users", "u")
+            .FullOuterJoin("orders", "o", "u.id", "=", "o.user_id");
 
         var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
-        Assert.Equal("SELECT \"u\".\"name\", \"o\".\"total\" FROM users u FULL OUTER JOIN orders o ON u.id = o.user_id", sql);
+        Assert.Equal("SELECT \"u\".\"name\", \"o\".\"total\" FROM \"users\" AS \"u\" FULL OUTER JOIN \"orders\" AS \"o\" ON \"u\".\"id\" = \"o\".\"user_id\"", sql);
     }
 
-     
     [Fact]
     public void DecimalFormatting_UsesInvariantCulture()
     {
@@ -861,14 +861,14 @@ public class QueryBuilderTests
     public void FullOuterJoin_WithNullCondition_Throws()
     {
         var query = new Query();
-        Assert.Throws<ArgumentException>(() => query.FullOuterJoin("orders", null!));
+        Assert.Throws<ArgumentException>(() => query.FullOuterJoinRaw("orders", null!));
     }
 
     [Fact]
     public void Join_WithNullCondition_Throws()
     {
         var query = new Query();
-        Assert.Throws<ArgumentException>(() => query.Join("users", null!));
+        Assert.Throws<ArgumentException>(() => query.JoinRaw("users", null!));
     }
 
     [Fact]

--- a/DbaClientX.Tests/QueryCompilerCacheTests.cs
+++ b/DbaClientX.Tests/QueryCompilerCacheTests.cs
@@ -80,4 +80,24 @@ public class QueryCompilerCacheTests
         Assert.Equal("SELECT \"COUNT(*)\" FROM \"users\"", identifierSql);
         Assert.Equal("SELECT COUNT(*) FROM \"users\"", rawSql);
     }
+
+    [Fact]
+    public void CompileWithParameters_DistinguishesRawPredicateSubqueries()
+    {
+        QueryCompiler.ClearCache();
+        var compiler = new QueryCompiler(SqlDialect.PostgreSql);
+        var activeUsers = new Query().Select("user_id").From("active_users").Where("enabled", true);
+        var archivedUsers = new Query().Select("user_id").From("archived_users").Where("enabled", true);
+        var first = new Query().Select("*").From("users").WhereRaw("LOWER(name)", "IN", activeUsers);
+        var second = new Query().Select("*").From("users").WhereRaw("LOWER(name)", "IN", archivedUsers);
+
+        var (firstSql, firstParameters) = compiler.CompileWithParameters(first);
+        var (secondSql, secondParameters) = compiler.CompileWithParameters(second);
+
+        Assert.Contains("FROM \"active_users\"", firstSql);
+        Assert.Contains("FROM \"archived_users\"", secondSql);
+        Assert.NotEqual(firstSql, secondSql);
+        Assert.Equal(new object[] { true }, firstParameters);
+        Assert.Equal(new object[] { true }, secondParameters);
+    }
 }

--- a/DbaClientX.Tests/QueryCompilerCacheTests.cs
+++ b/DbaClientX.Tests/QueryCompilerCacheTests.cs
@@ -59,12 +59,25 @@ public class QueryCompilerCacheTests
     {
         QueryCompiler.ClearCache();
         var compiler = new QueryCompiler(SqlDialect.PostgreSql);
-        var q1 = new Query().Select("u.id").From("users u").Join("orders o", "u.id = o.user_id");
-        var q2 = new Query().Select("u.id").From("users u").Join("orders o", "u.email = o.email");
+        var q1 = new Query().Select("u.id").From("users", "u").JoinRaw("orders o", "u.id = o.user_id");
+        var q2 = new Query().Select("u.id").From("users", "u").JoinRaw("orders o", "u.email = o.email");
 
         var (sql1, _) = compiler.CompileWithParameters(q1);
         var (sql2, _) = compiler.CompileWithParameters(q2);
 
         Assert.NotEqual(sql1, sql2);
+    }
+
+    [Fact]
+    public void CompileWithParameters_DistinguishesRawAndIdentifierExpressions()
+    {
+        QueryCompiler.ClearCache();
+        var compiler = new QueryCompiler(SqlDialect.PostgreSql);
+
+        var (identifierSql, _) = compiler.CompileWithParameters(new Query().Select("COUNT(*)").From("users"));
+        var (rawSql, _) = compiler.CompileWithParameters(new Query().SelectRaw("COUNT(*)").From("users"));
+
+        Assert.Equal("SELECT \"COUNT(*)\" FROM \"users\"", identifierSql);
+        Assert.Equal("SELECT COUNT(*) FROM \"users\"", rawSql);
     }
 }

--- a/README.md
+++ b/README.md
@@ -465,6 +465,24 @@ var query = new Query()
 var (sql, parameters) = QueryBuilder.CompileWithParameters(query);
 ```
 
+Identifier methods always quote identifiers. Use explicit raw methods for trusted SQL expressions, and never pass user input to them:
+
+```csharp
+var aggregate = new Query()
+    .Select("DepartmentId")
+    .SelectRaw("COUNT(*)")
+    .From("Employees")
+    .GroupBy("DepartmentId")
+    .HavingRaw("COUNT(*)", ">", 5);
+
+var joined = new Query()
+    .Select("u.Id", "o.Total")
+    .From("Users", "u")
+    .Join("Orders", "o", "u.Id", "=", "o.UserId");
+```
+
+Negative `Limit`, `Offset`, and `Top` values are rejected before compilation.
+
 ## Supported .NET Versions
 
 | Component | Windows | Linux/macOS |


### PR DESCRIPTION
## Summary

- make identifier-based query APIs quote identifiers consistently instead of inferring raw SQL from spaces or parentheses
- add explicit raw-expression methods and safe identifier-based join overloads
- validate comparison operators and reject negative pagination values
- emit Oracle table aliases without the unsupported AS keyword
- split query state, joins, ordering, tokens, identifier rendering, and value rendering into focused files

## Migration

- replace expressions such as `Select("COUNT(*)")` with `SelectRaw("COUNT(*)")`
- replace embedded aliases such as `From("users u")` with `From("users", "u")`
- replace the obsolete two-string join overload with an identifier-based overload, or use `JoinRaw` for trusted caller-authored SQL

The existing public WHERE token constructors remain unchanged. Raw methods must not receive untrusted input.

## Validation

- Release solution build across supported target frameworks
- 1,073 tests on .NET 8
- 1,073 tests on .NET 10
- packed and inspected DBAClientX.Core 0.13.0 for net472, net8.0, and net10.0 binaries plus XML documentation