### PR TITLE
Preserve SQLite options and async reader ownership

### DIFF
--- a/DbaClientX.Core/DbaDataReader.cs
+++ b/DbaClientX.Core/DbaDataReader.cs
@@ -1,148 +1,230 @@
 using System;
+using System.Collections;
 using System.Data;
 using System.Data.Common;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DBAClientX;
 
 /// <summary>
-/// Wraps a provider reader together with the command and owned connection resources that must stay alive while it is consumed.
+/// Owns a provider reader together with the command and connection resources that must remain alive while rows are consumed.
 /// </summary>
-public sealed class DbaDataReader : IDataReader
+/// <remarks>
+/// Both synchronous and asynchronous disposal are idempotent. Asynchronous disposal uses provider async cleanup when available
+/// and still invokes the post-reader callback before the command and owned connection are released.
+/// </remarks>
+public sealed class DbaDataReader : DbDataReader
 {
     private readonly IDataReader _reader;
+    private readonly DbDataReader? _dbReader;
     private readonly IDisposable? _command;
     private readonly DbConnection? _connection;
     private readonly bool _ownsConnection;
     private readonly Action<DbConnection>? _disposeConnection;
+    private readonly Func<DbConnection, ValueTask>? _disposeConnectionAsync;
     private readonly Action? _afterReaderDisposed;
-    private bool _disposed;
+    private readonly Func<ValueTask>? _afterReaderDisposedAsync;
+    private int _disposeState;
 
-    /// <summary>
-    /// Initializes a reader lease around an already-open provider reader.
-    /// </summary>
+    /// <summary>Initializes a reader lease around an already-open provider reader.</summary>
+    /// <param name="reader">Provider reader that supplies the rows.</param>
+    /// <param name="command">Optional command owned by this lease.</param>
+    /// <param name="connection">Optional connection associated with the reader.</param>
+    /// <param name="ownsConnection">Whether this lease must dispose <paramref name="connection"/>.</param>
+    /// <param name="disposeConnection">Optional provider-specific synchronous connection disposer.</param>
+    /// <param name="afterReaderDisposed">Optional synchronous callback invoked after the reader closes and before the command is disposed.</param>
+    /// <param name="disposeConnectionAsync">Optional provider-specific asynchronous connection disposer.</param>
+    /// <param name="afterReaderDisposedAsync">Optional asynchronous callback invoked after the reader closes and before the command is disposed.</param>
     public DbaDataReader(
         IDataReader reader,
         IDisposable? command = null,
         DbConnection? connection = null,
         bool ownsConnection = false,
         Action<DbConnection>? disposeConnection = null,
-        Action? afterReaderDisposed = null)
+        Action? afterReaderDisposed = null,
+        Func<DbConnection, ValueTask>? disposeConnectionAsync = null,
+        Func<ValueTask>? afterReaderDisposedAsync = null)
     {
         _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _dbReader = reader as DbDataReader;
         _command = command;
         _connection = connection;
         _ownsConnection = ownsConnection;
         _disposeConnection = disposeConnection;
         _afterReaderDisposed = afterReaderDisposed;
+        _disposeConnectionAsync = disposeConnectionAsync;
+        _afterReaderDisposedAsync = afterReaderDisposedAsync;
     }
 
     /// <inheritdoc />
-    public int Depth => _reader.Depth;
+    public override int Depth => _reader.Depth;
 
     /// <inheritdoc />
-    public bool IsClosed => _reader.IsClosed;
+    public override bool IsClosed => _reader.IsClosed;
 
     /// <inheritdoc />
-    public int RecordsAffected => _reader.RecordsAffected;
+    public override int RecordsAffected => _reader.RecordsAffected;
 
     /// <inheritdoc />
-    public int FieldCount => _reader.FieldCount;
+    public override int FieldCount => _reader.FieldCount;
 
     /// <inheritdoc />
-    public object this[int i] => _reader[i];
+    public override int VisibleFieldCount => _dbReader?.VisibleFieldCount ?? _reader.FieldCount;
 
     /// <inheritdoc />
-    public object this[string name] => _reader[name];
+    public override bool HasRows => _dbReader?.HasRows
+        ?? throw new NotSupportedException("HasRows is unavailable when the wrapped reader is not a DbDataReader.");
 
     /// <inheritdoc />
-    public void Close() => Dispose();
+    public override object this[int ordinal] => _reader[ordinal];
 
     /// <inheritdoc />
-    public DataTable? GetSchemaTable() => _reader.GetSchemaTable();
+    public override object this[string name] => _reader[name];
 
     /// <inheritdoc />
-    public bool NextResult() => _reader.NextResult();
+    public override void Close() => Dispose();
 
     /// <inheritdoc />
-    public bool Read() => _reader.Read();
+    public override DataTable? GetSchemaTable() => _reader.GetSchemaTable();
 
     /// <inheritdoc />
-    public bool GetBoolean(int i) => _reader.GetBoolean(i);
+    public override bool NextResult() => _reader.NextResult();
 
     /// <inheritdoc />
-    public byte GetByte(int i) => _reader.GetByte(i);
+    public override bool Read() => _reader.Read();
 
     /// <inheritdoc />
-    public long GetBytes(int i, long fieldOffset, byte[]? buffer, int bufferoffset, int length) => _reader.GetBytes(i, fieldOffset, buffer, bufferoffset, length);
+    public override bool GetBoolean(int ordinal) => _reader.GetBoolean(ordinal);
 
     /// <inheritdoc />
-    public char GetChar(int i) => _reader.GetChar(i);
+    public override byte GetByte(int ordinal) => _reader.GetByte(ordinal);
 
     /// <inheritdoc />
-    public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length) => _reader.GetChars(i, fieldoffset, buffer, bufferoffset, length);
+    public override long GetBytes(int ordinal, long dataOffset, byte[]? buffer, int bufferOffset, int length)
+        => _reader.GetBytes(ordinal, dataOffset, buffer, bufferOffset, length);
 
     /// <inheritdoc />
-    public IDataReader GetData(int i) => _reader.GetData(i);
+    public override char GetChar(int ordinal) => _reader.GetChar(ordinal);
 
     /// <inheritdoc />
-    public string GetDataTypeName(int i) => _reader.GetDataTypeName(i);
+    public override long GetChars(int ordinal, long dataOffset, char[]? buffer, int bufferOffset, int length)
+        => _reader.GetChars(ordinal, dataOffset, buffer, bufferOffset, length);
 
     /// <inheritdoc />
-    public DateTime GetDateTime(int i) => _reader.GetDateTime(i);
+    public override string GetDataTypeName(int ordinal) => _reader.GetDataTypeName(ordinal);
 
     /// <inheritdoc />
-    public decimal GetDecimal(int i) => _reader.GetDecimal(i);
+    public override DateTime GetDateTime(int ordinal) => _reader.GetDateTime(ordinal);
 
     /// <inheritdoc />
-    public double GetDouble(int i) => _reader.GetDouble(i);
+    public override decimal GetDecimal(int ordinal) => _reader.GetDecimal(ordinal);
+
+    /// <inheritdoc />
+    public override double GetDouble(int ordinal) => _reader.GetDouble(ordinal);
 
     /// <inheritdoc />
 #pragma warning disable IL2093, IL2073
-    public Type GetFieldType(int i) => _reader.GetFieldType(i);
+    public override Type GetFieldType(int ordinal) => _reader.GetFieldType(ordinal);
 #pragma warning restore IL2093, IL2073
 
     /// <inheritdoc />
-    public float GetFloat(int i) => _reader.GetFloat(i);
+    public override float GetFloat(int ordinal) => _reader.GetFloat(ordinal);
 
     /// <inheritdoc />
-    public Guid GetGuid(int i) => _reader.GetGuid(i);
+    public override Guid GetGuid(int ordinal) => _reader.GetGuid(ordinal);
 
     /// <inheritdoc />
-    public short GetInt16(int i) => _reader.GetInt16(i);
+    public override short GetInt16(int ordinal) => _reader.GetInt16(ordinal);
 
     /// <inheritdoc />
-    public int GetInt32(int i) => _reader.GetInt32(i);
+    public override int GetInt32(int ordinal) => _reader.GetInt32(ordinal);
 
     /// <inheritdoc />
-    public long GetInt64(int i) => _reader.GetInt64(i);
+    public override long GetInt64(int ordinal) => _reader.GetInt64(ordinal);
 
     /// <inheritdoc />
-    public string GetName(int i) => _reader.GetName(i);
+    public override string GetName(int ordinal) => _reader.GetName(ordinal);
 
     /// <inheritdoc />
-    public int GetOrdinal(string name) => _reader.GetOrdinal(name);
+    public override int GetOrdinal(string name) => _reader.GetOrdinal(name);
 
     /// <inheritdoc />
-    public string GetString(int i) => _reader.GetString(i);
+    public override string GetString(int ordinal) => _reader.GetString(ordinal);
 
     /// <inheritdoc />
-    public object GetValue(int i) => _reader.GetValue(i);
+    public override object GetValue(int ordinal) => _reader.GetValue(ordinal);
 
     /// <inheritdoc />
-    public int GetValues(object[] values) => _reader.GetValues(values);
+    public override int GetValues(object[] values) => _reader.GetValues(values);
 
     /// <inheritdoc />
-    public bool IsDBNull(int i) => _reader.IsDBNull(i);
+    public override bool IsDBNull(int ordinal) => _reader.IsDBNull(ordinal);
 
     /// <inheritdoc />
-    public void Dispose()
+    protected override DbDataReader GetDbDataReader(int ordinal)
     {
-        if (_disposed)
+        var nestedReader = _reader.GetData(ordinal);
+        return nestedReader as DbDataReader
+            ?? throw new NotSupportedException("The nested reader is not a DbDataReader.");
+    }
+
+    /// <inheritdoc />
+    public override IEnumerator GetEnumerator() => _dbReader?.GetEnumerator() ?? new DbEnumerator(this, closeReader: false);
+
+    /// <inheritdoc />
+    public override T GetFieldValue<T>(int ordinal)
+        => _dbReader != null ? _dbReader.GetFieldValue<T>(ordinal) : (T)GetValue(ordinal);
+
+    /// <inheritdoc />
+    public override Stream GetStream(int ordinal)
+        => _dbReader != null ? _dbReader.GetStream(ordinal) : base.GetStream(ordinal);
+
+    /// <inheritdoc />
+    public override TextReader GetTextReader(int ordinal)
+        => _dbReader != null ? _dbReader.GetTextReader(ordinal) : base.GetTextReader(ordinal);
+
+    /// <inheritdoc />
+    public override Task<bool> ReadAsync(CancellationToken cancellationToken)
+        => _dbReader?.ReadAsync(cancellationToken) ?? base.ReadAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public override Task<bool> NextResultAsync(CancellationToken cancellationToken)
+        => _dbReader?.NextResultAsync(cancellationToken) ?? base.NextResultAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public override Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
+        => _dbReader?.IsDBNullAsync(ordinal, cancellationToken) ?? base.IsDBNullAsync(ordinal, cancellationToken);
+
+    /// <inheritdoc />
+    public override Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken)
+        => _dbReader?.GetFieldValueAsync<T>(ordinal, cancellationToken) ?? base.GetFieldValueAsync<T>(ordinal, cancellationToken);
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            DisposeOwnedResources();
+        }
+    }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+    /// <inheritdoc />
+    public override ValueTask DisposeAsync() => DisposeOwnedResourcesAsync();
+#else
+    /// <summary>Asynchronously disposes the reader lease and its owned resources.</summary>
+    public ValueTask DisposeAsync() => DisposeOwnedResourcesAsync();
+#endif
+
+    private void DisposeOwnedResources()
+    {
+        if (Interlocked.Exchange(ref _disposeState, 1) != 0)
         {
             return;
         }
 
-        _disposed = true;
         try
         {
             try
@@ -168,6 +250,68 @@ public sealed class DbaDataReader : IDataReader
                     _connection.Dispose();
                 }
             }
+        }
+    }
+
+    private async ValueTask DisposeOwnedResourcesAsync()
+    {
+        if (Interlocked.Exchange(ref _disposeState, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            try
+            {
+                await DisposeAsyncResource(_reader).ConfigureAwait(false);
+                if (_afterReaderDisposedAsync != null)
+                {
+                    await _afterReaderDisposedAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    _afterReaderDisposed?.Invoke();
+                }
+            }
+            finally
+            {
+                await DisposeAsyncResource(_command).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            if (_ownsConnection && _connection != null)
+            {
+                if (_disposeConnectionAsync != null)
+                {
+                    await _disposeConnectionAsync(_connection).ConfigureAwait(false);
+                }
+                else if (_connection is IAsyncDisposable asyncConnection)
+                {
+                    await asyncConnection.DisposeAsync().ConfigureAwait(false);
+                }
+                else if (_disposeConnection != null)
+                {
+                    _disposeConnection(_connection);
+                }
+                else
+                {
+                    _connection.Dispose();
+                }
+            }
+        }
+    }
+
+    private static async ValueTask DisposeAsyncResource(object? resource)
+    {
+        if (resource is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        }
+        else if (resource is IDisposable disposable)
+        {
+            disposable.Dispose();
         }
     }
 }

--- a/DbaClientX.SQLite/GenericExecutors.cs
+++ b/DbaClientX.SQLite/GenericExecutors.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX.Invoker;
-using Microsoft.Data.Sqlite;
 
 namespace DBAClientX.SQLiteGeneric;
 
@@ -14,6 +13,8 @@ namespace DBAClientX.SQLiteGeneric;
 /// </summary>
 public static class GenericExecutors
 {
+    internal static Func<DBAClientX.SQLite> ClientFactory { get; set; } = static () => new DBAClientX.SQLite();
+
     /// <summary>
     /// Executes a parameterized SQL statement against the provided database.
     /// </summary>
@@ -23,16 +24,30 @@ public static class GenericExecutors
     /// <param name="ct">Token used to cancel the operation.</param>
     /// <returns>A task producing the number of rows affected by the command.</returns>
     /// <remarks>
-    /// The helper instantiates a new <see cref="DBAClientX.SQLite"/> instance for each invocation, making it suitable for
-    /// dynamic scenarios where maintaining state is impractical. It leverages <see cref="DBAClientX.SQLite.ExecuteNonQueryAsync"/>
-    /// internally, meaning that standard validation and exception behaviors are preserved.
+    /// The helper instantiates and asynchronously disposes a new <see cref="DBAClientX.SQLite"/> instance for each invocation.
+    /// Paths use <see cref="DBAClientX.SQLite.ExecuteNonQueryAsync"/>; full connection strings use
+    /// <see cref="DBAClientX.SQLite.ExecuteNonQueryWithConnectionStringAsync"/> so provider options are preserved.
     /// </remarks>
-    public static Task<int> ExecuteSqlAsync(string connectionStringOrPath, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
+    public static async Task<int> ExecuteSqlAsync(string connectionStringOrPath, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
     {
+        ValidateConnectionStringOrPath(connectionStringOrPath);
         ValidateCommandText(sql, nameof(sql), "SQL text");
-        var db = ResolveDatabasePath(connectionStringOrPath);
-        var cli = new DBAClientX.SQLite();
-        return cli.ExecuteNonQueryAsync(db, sql, parameters, cancellationToken: ct);
+        await using var client = ClientFactory();
+        if (DBAClientX.SQLite.IsConnectionString(connectionStringOrPath))
+        {
+            ValidateConnectionString(connectionStringOrPath);
+            return await client.ExecuteNonQueryWithConnectionStringAsync(
+                connectionStringOrPath,
+                sql,
+                parameters,
+                cancellationToken: ct).ConfigureAwait(false);
+        }
+
+        return await client.ExecuteNonQueryAsync(
+            connectionStringOrPath,
+            sql,
+            parameters,
+            cancellationToken: ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -42,25 +57,21 @@ public static class GenericExecutors
     public static Task<int> ExecuteProcedureAsync(string connectionStringOrPath, string procedure, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
         => Task.FromException<int>(new NotSupportedException("SQLite does not support stored procedures."));
 
-    private static string ResolveDatabasePath(string connectionStringOrPath)
+    private static void ValidateConnectionStringOrPath(string connectionStringOrPath)
     {
         if (string.IsNullOrWhiteSpace(connectionStringOrPath))
         {
             throw new ArgumentException("Connection string or database path cannot be null or whitespace.", nameof(connectionStringOrPath));
         }
+    }
 
-        if (connectionStringOrPath.IndexOf('=') >= 0)
+    private static void ValidateConnectionString(string connectionString)
+    {
+        var validationResult = DbaConnectionFactory.Validate("sqlite", connectionString);
+        if (!validationResult.IsValid)
         {
-            var validationResult = DbaConnectionFactory.Validate("sqlite", connectionStringOrPath);
-            if (!validationResult.IsValid)
-            {
-                throw new ArgumentException(DbaConnectionFactory.ToUserMessage(validationResult), nameof(connectionStringOrPath));
-            }
-
-            var b = new SqliteConnectionStringBuilder(connectionStringOrPath);
-            return b.DataSource;
+            throw new ArgumentException(DbaConnectionFactory.ToUserMessage(validationResult), "connectionStringOrPath");
         }
-        return connectionStringOrPath;
     }
 
     private static void ValidateCommandText(string value, string paramName, string displayName)

--- a/DbaClientX.SQLite/Properties/AssemblyInfo.cs
+++ b/DbaClientX.SQLite/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DbaClientX.Tests")]

--- a/DbaClientX.SQLite/README.md
+++ b/DbaClientX.SQLite/README.md
@@ -50,6 +50,27 @@ var rows = await sq.QueryAsListAsync(
 
 For larger result sets, use `QueryStreamAsync<T>` with the same mapper shape to avoid buffering all rows.
 
+Execute against a full connection string without losing provider options:
+
+```csharp
+var connectionString = new SqliteConnectionStringBuilder
+{
+    DataSource = "app.db",
+    Mode = SqliteOpenMode.ReadWrite,
+    Cache = SqliteCacheMode.Shared,
+    Pooling = false,
+    DefaultTimeout = 15
+}.ConnectionString;
+
+await sq.ExecuteNonQueryWithConnectionStringAsync(
+    connectionString,
+    "UPDATE Users SET Name = @name WHERE Id = @id",
+    new Dictionary<string, object?> { ["@name"] = "Alice", ["@id"] = 1 },
+    cancellationToken: ct);
+```
+
+`SQLiteGeneric.GenericExecutors.ExecuteSqlAsync` accepts either a path or a full connection string. Full connection strings preserve mode, cache, pooling, timeout, password, foreign-key, trigger, and VFS settings. File paths containing `=` remain valid paths.
+
 Graceful shutdown maintenance:
 
 ```csharp

--- a/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
@@ -312,10 +312,6 @@ public partial class SQLite
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await base.ExecuteNonQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (DbaTransactionException)
-        {
-            throw;
-        }
         catch (Exception ex)
         {
             throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
@@ -385,7 +381,10 @@ public partial class SQLite
         try
         {
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-            await ApplyBusyTimeoutAsync(connection, busyTimeoutMs, cancellationToken).ConfigureAwait(false);
+            await ApplyBusyTimeoutAsync(
+                connection,
+                ResolveConnectionBusyTimeout(connectionString, busyTimeoutMs),
+                cancellationToken).ConfigureAwait(false);
             return (connection, null, true);
         }
         catch

--- a/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
@@ -260,7 +260,49 @@ public partial class SQLite
     {
         ValidateCommandText(query);
         var connectionString = BuildOperationalConnectionString(database);
+        return await ExecuteNonQueryCoreAsync(
+            connectionString,
+            query,
+            parameters,
+            useTransaction,
+            cancellationToken,
+            parameterTypes,
+            parameterDirections).ConfigureAwait(false);
+    }
 
+    /// <summary>
+    /// Asynchronously executes a SQL statement using a full SQLite connection string.
+    /// </summary>
+    public virtual async Task<int> ExecuteNonQueryWithConnectionStringAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        CancellationToken cancellationToken = default,
+        IDictionary<string, SqliteType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateCommandText(query);
+        var normalizedConnectionString = NormalizeConnectionString(connectionString);
+        return await ExecuteNonQueryCoreAsync(
+            normalizedConnectionString,
+            query,
+            parameters,
+            useTransaction,
+            cancellationToken,
+            parameterTypes,
+            parameterDirections).ConfigureAwait(false);
+    }
+
+    private async Task<int> ExecuteNonQueryCoreAsync(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters,
+        bool useTransaction,
+        CancellationToken cancellationToken,
+        IDictionary<string, SqliteType>? parameterTypes,
+        IDictionary<string, ParameterDirection>? parameterDirections)
+    {
         SqliteConnection? connection = null;
         SqliteTransaction? transaction = null;
         var dispose = false;
@@ -269,6 +311,10 @@ public partial class SQLite
             (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await base.ExecuteNonQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+        }
+        catch (DbaTransactionException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/DbaClientX.SQLite/SQLite.CommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.CommandExecution.cs
@@ -131,7 +131,33 @@ public partial class SQLite
     {
         ValidateCommandText(query);
         var connectionString = BuildOperationalConnectionString(database);
+        return ExecuteNonQueryCore(connectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
 
+    /// <summary>
+    /// Executes a SQL statement that does not return rows using a full SQLite connection string.
+    /// </summary>
+    public virtual int ExecuteNonQueryWithConnectionString(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters = null,
+        bool useTransaction = false,
+        IDictionary<string, SqliteType>? parameterTypes = null,
+        IDictionary<string, ParameterDirection>? parameterDirections = null)
+    {
+        ValidateCommandText(query);
+        var normalizedConnectionString = NormalizeConnectionString(connectionString);
+        return ExecuteNonQueryCore(normalizedConnectionString, query, parameters, useTransaction, parameterTypes, parameterDirections);
+    }
+
+    private int ExecuteNonQueryCore(
+        string connectionString,
+        string query,
+        IDictionary<string, object?>? parameters,
+        bool useTransaction,
+        IDictionary<string, SqliteType>? parameterTypes,
+        IDictionary<string, ParameterDirection>? parameterDirections)
+    {
         SqliteConnection? connection = null;
         SqliteTransaction? transaction = null;
         var dispose = false;
@@ -140,6 +166,10 @@ public partial class SQLite
             (connection, transaction, dispose) = ResolveConnection(connectionString, useTransaction);
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return base.ExecuteNonQuery(connection, transaction, query, parameters, dbTypes, parameterDirections);
+        }
+        catch (DbaTransactionException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/DbaClientX.SQLite/SQLite.CommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.CommandExecution.cs
@@ -167,10 +167,6 @@ public partial class SQLite
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return base.ExecuteNonQuery(connection, transaction, query, parameters, dbTypes, parameterDirections);
         }
-        catch (DbaTransactionException)
-        {
-            throw;
-        }
         catch (Exception ex)
         {
             throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
@@ -209,7 +205,7 @@ public partial class SQLite
         try
         {
             connection.Open();
-            ApplyBusyTimeout(connection, busyTimeoutMs);
+            ApplyBusyTimeout(connection, ResolveConnectionBusyTimeout(connectionString, busyTimeoutMs));
             return (connection, null, true);
         }
         catch

--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -283,6 +283,17 @@ public partial class SQLite : DatabaseClientBase
         return effectiveTimeout;
     }
 
+    private static int? ResolveConnectionBusyTimeout(string connectionString, int? busyTimeoutMs)
+    {
+        if (busyTimeoutMs.HasValue)
+        {
+            return busyTimeoutMs;
+        }
+
+        var builder = new SqliteConnectionStringBuilder(connectionString);
+        return builder.ContainsKey("Default Timeout") ? 0 : null;
+    }
+
     private void ApplyBusyTimeout(SqliteConnection connection, int? busyTimeoutMs = null)
     {
         var effectiveTimeout = ResolveBusyTimeoutMs(busyTimeoutMs);

--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -13,6 +13,14 @@ namespace DBAClientX;
 /// </summary>
 public partial class SQLite : DatabaseClientBase
 {
+    private static readonly HashSet<string> ConnectionStringSourceKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Data Source",
+        "DataSource",
+        "Filename",
+        "FullUri"
+    };
+
     /// <summary>
     /// Default busy timeout used for operational commands when a per-instance value is not overridden.
     /// </summary>
@@ -131,6 +139,20 @@ public partial class SQLite : DatabaseClientBase
         }
 
         return builder.ToString();
+    }
+
+    internal static bool IsConnectionString(string connectionStringOrPath)
+    {
+        foreach (var segment in connectionStringOrPath.Split(';'))
+        {
+            var separator = segment.IndexOf('=');
+            if (separator > 0 && ConnectionStringSourceKeys.Contains(segment.Substring(0, separator).Trim()))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     internal static string TranslateSQLiteFullUri(string connectionString)

--- a/DbaClientX.SqlServer/README.md
+++ b/DbaClientX.SqlServer/README.md
@@ -2,7 +2,7 @@
 
 SQL Server provider for DbaClientX. Thin, fast ADO.NET wrapper with streaming, retries, and transactions.
 
-- Target Frameworks: `net8.0`, `net472`
+- Target Frameworks: `net472`, `net8.0`, `net10.0`
 - NuGet: `DBAClientX.SqlServer`
 
 ## Install
@@ -49,6 +49,23 @@ var rows = await cli.QueryAsListAsync(
 ```
 
 For larger result sets, use `QueryStreamAsync<T>` with the same mapper shape to avoid buffering all rows.
+
+Use the owned `DbDataReader` surface when another API consumes a reader directly:
+
+```csharp
+await using var reader = await cli.QueryReaderAsync(
+    connectionString: "Server=.;Database=App;Integrated Security=True;Encrypt=True",
+    query: "SELECT Id, Name FROM dbo.Users ORDER BY Id",
+    cancellationToken: ct);
+
+while (await reader.ReadAsync(ct))
+{
+    var id = reader.GetInt32(0);
+    var name = reader.GetString(1);
+}
+```
+
+Disposing the reader also disposes its command and any connection opened for it. Output parameters are copied back after the provider reader closes. `DisposeAsync` uses provider asynchronous cleanup when available.
 
 Non-query from a full connection string:
 

--- a/DbaClientX.SqlServer/SqlServer.DataReader.cs
+++ b/DbaClientX.SqlServer/SqlServer.DataReader.cs
@@ -11,13 +11,13 @@ namespace DBAClientX;
 public partial class SqlServer
 {
     /// <summary>
-    /// Opens a SQL Server query as a streaming <see cref="IDataReader"/>.
+    /// Opens a SQL Server query as a streaming <see cref="DbDataReader"/>.
     /// </summary>
     /// <remarks>
     /// The returned reader owns the command and, when DbaClientX opened it, the connection. Dispose the reader after
     /// the consuming API has finished reading.
     /// </remarks>
-    public virtual IDataReader QueryReader(
+    public virtual DbDataReader QueryReader(
         string serverOrInstance,
         string database,
         bool integratedSecurity,
@@ -35,13 +35,13 @@ public partial class SqlServer
     }
 
     /// <summary>
-    /// Opens a SQL Server query as a streaming <see cref="IDataReader"/> using a full connection string.
+    /// Opens a SQL Server query as a streaming <see cref="DbDataReader"/> using a full connection string.
     /// </summary>
     /// <remarks>
     /// The returned reader owns the command and, when DbaClientX opened it, the connection. Dispose the reader after
     /// the consuming API has finished reading.
     /// </remarks>
-    public virtual IDataReader QueryReader(
+    public virtual DbDataReader QueryReader(
         string connectionString,
         string query,
         IDictionary<string, object?>? parameters = null,
@@ -67,7 +67,8 @@ public partial class SqlServer
                 connection,
                 dispose,
                 resource => DisposeConnection((SqlConnection)resource),
-                () => UpdateOutputParameters(command, parameters));
+                () => UpdateOutputParameters(command, parameters),
+                resource => DisposeConnectionAsync((SqlConnection)resource));
         }
         catch (Exception ex)
         {
@@ -82,13 +83,13 @@ public partial class SqlServer
     }
 
     /// <summary>
-    /// Opens a SQL Server query as a streaming <see cref="IDataReader"/> asynchronously.
+    /// Opens a SQL Server query as a streaming <see cref="DbDataReader"/> asynchronously.
     /// </summary>
     /// <remarks>
     /// The returned reader owns the command and, when DbaClientX opened it, the connection. Dispose the reader after
     /// the consuming API has finished reading.
     /// </remarks>
-    public virtual async Task<IDataReader> QueryReaderAsync(
+    public virtual async Task<DbDataReader> QueryReaderAsync(
         string serverOrInstance,
         string database,
         bool integratedSecurity,
@@ -107,13 +108,13 @@ public partial class SqlServer
     }
 
     /// <summary>
-    /// Opens a SQL Server query as a streaming <see cref="IDataReader"/> asynchronously using a full connection string.
+    /// Opens a SQL Server query as a streaming <see cref="DbDataReader"/> asynchronously using a full connection string.
     /// </summary>
     /// <remarks>
     /// The returned reader owns the command and, when DbaClientX opened it, the connection. Dispose the reader after
     /// the consuming API has finished reading.
     /// </remarks>
-    public virtual async Task<IDataReader> QueryReaderAsync(
+    public virtual async Task<DbDataReader> QueryReaderAsync(
         string connectionString,
         string query,
         IDictionary<string, object?>? parameters = null,
@@ -140,7 +141,8 @@ public partial class SqlServer
                 connection,
                 dispose,
                 resource => DisposeConnection((SqlConnection)resource),
-                () => UpdateOutputParameters(command, parameters));
+                () => UpdateOutputParameters(command, parameters),
+                resource => DisposeConnectionAsync((SqlConnection)resource));
         }
         catch (Exception ex)
         {

--- a/DbaClientX.SqlServer/SqlServer.DataReader.cs
+++ b/DbaClientX.SqlServer/SqlServer.DataReader.cs
@@ -83,13 +83,13 @@ public partial class SqlServer
     }
 
     /// <summary>
-    /// Opens a SQL Server query as a streaming <see cref="DbDataReader"/> asynchronously.
+    /// Opens a SQL Server query as an asynchronously disposable streaming <see cref="DbaDataReader"/>.
     /// </summary>
     /// <remarks>
     /// The returned reader owns the command and, when DbaClientX opened it, the connection. Dispose the reader after
     /// the consuming API has finished reading.
     /// </remarks>
-    public virtual async Task<DbDataReader> QueryReaderAsync(
+    public virtual async Task<DbaDataReader> QueryReaderAsync(
         string serverOrInstance,
         string database,
         bool integratedSecurity,
@@ -108,13 +108,13 @@ public partial class SqlServer
     }
 
     /// <summary>
-    /// Opens a SQL Server query as a streaming <see cref="DbDataReader"/> asynchronously using a full connection string.
+    /// Opens a SQL Server query as an asynchronously disposable streaming <see cref="DbaDataReader"/> using a full connection string.
     /// </summary>
     /// <remarks>
     /// The returned reader owns the command and, when DbaClientX opened it, the connection. Dispose the reader after
     /// the consuming API has finished reading.
     /// </remarks>
-    public virtual async Task<DbDataReader> QueryReaderAsync(
+    public virtual async Task<DbaDataReader> QueryReaderAsync(
         string connectionString,
         string query,
         IDictionary<string, object?>? parameters = null,

--- a/DbaClientX.Tests/DbaDataReaderTests.cs
+++ b/DbaClientX.Tests/DbaDataReaderTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Data;
+using System.Data.Common;
 using Microsoft.Data.SqlClient;
 using Xunit;
 
@@ -87,10 +88,96 @@ public class DbaDataReaderTests
         Assert.Equal(1, connectionDisposeCount);
     }
 
-    private sealed class DisposableCommand : IDisposable
+    [Fact]
+    public async Task DisposeAsync_UsesAsyncResourcesAndIsIdempotent()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Rows.Add(1);
+        var sourceReader = table.CreateDataReader();
+        var connection = new SqlConnection();
+        var command = new DisposableCommand();
+        var syncConnectionDisposeCount = 0;
+        var asyncConnectionDisposeCount = 0;
+        var syncAfterReaderDisposedCount = 0;
+        var asyncAfterReaderDisposedCount = 0;
+
+        var reader = new DBAClientX.DbaDataReader(
+            sourceReader,
+            command,
+            connection,
+            ownsConnection: true,
+            disposeConnection: _ => syncConnectionDisposeCount++,
+            afterReaderDisposed: () => syncAfterReaderDisposedCount++,
+            disposeConnectionAsync: resource =>
+            {
+                Assert.Same(connection, resource);
+                asyncConnectionDisposeCount++;
+                return default;
+            },
+            afterReaderDisposedAsync: () =>
+            {
+                Assert.True(sourceReader.IsClosed);
+                asyncAfterReaderDisposedCount++;
+                return default;
+            });
+
+        Assert.IsAssignableFrom<DbDataReader>(reader);
+        Assert.True(reader.HasRows);
+        Assert.True(await reader.ReadAsync(CancellationToken.None));
+        Assert.Equal(1, await reader.GetFieldValueAsync<int>(0, CancellationToken.None));
+
+        await reader.DisposeAsync();
+        await reader.DisposeAsync();
+        reader.Dispose();
+
+        Assert.True(sourceReader.IsClosed);
+        Assert.Equal(0, command.DisposeCount);
+        Assert.Equal(1, command.AsyncDisposeCount);
+        Assert.Equal(0, syncAfterReaderDisposedCount);
+        Assert.Equal(1, asyncAfterReaderDisposedCount);
+        Assert.Equal(0, syncConnectionDisposeCount);
+        Assert.Equal(1, asyncConnectionDisposeCount);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_PreservesSynchronousPostReaderCallback()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Rows.Add(1);
+        var sourceReader = table.CreateDataReader();
+        var command = new DisposableCommand();
+        var afterReaderDisposedCount = 0;
+
+        var reader = new DBAClientX.DbaDataReader(
+            sourceReader,
+            command,
+            afterReaderDisposed: () =>
+            {
+                Assert.True(sourceReader.IsClosed);
+                afterReaderDisposedCount++;
+            });
+
+        await reader.DisposeAsync();
+
+        Assert.Equal(1, afterReaderDisposedCount);
+        Assert.Equal(0, command.DisposeCount);
+        Assert.Equal(1, command.AsyncDisposeCount);
+    }
+
+    private sealed class DisposableCommand : IDisposable, IAsyncDisposable
     {
         public int DisposeCount { get; private set; }
 
+        public int AsyncDisposeCount { get; private set; }
+
         public void Dispose() => DisposeCount++;
+
+        public ValueTask DisposeAsync()
+        {
+            AsyncDisposeCount++;
+            return default;
+        }
     }
 }

--- a/DbaClientX.Tests/DbaDataReaderTests.cs
+++ b/DbaClientX.Tests/DbaDataReaderTests.cs
@@ -9,6 +9,19 @@ namespace DbaClientX.Tests;
 public class DbaDataReaderTests
 {
     [Fact]
+    public void SqlServerAsyncReaderApis_ReturnOwnedReaderType()
+    {
+        var methods = typeof(DBAClientX.SqlServer)
+            .GetMethods()
+            .Where(method => method.Name == nameof(DBAClientX.SqlServer.QueryReaderAsync))
+            .ToArray();
+
+        Assert.NotEmpty(methods);
+        Assert.All(methods, method =>
+            Assert.Equal(typeof(Task<DBAClientX.DbaDataReader>), method.ReturnType));
+    }
+
+    [Fact]
     public void Dispose_DisposesReaderCommandAndOwnedConnectionOnce()
     {
         var table = new DataTable();

--- a/DbaClientX.Tests/SQLiteGenericExecutorsTests.cs
+++ b/DbaClientX.Tests/SQLiteGenericExecutorsTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Diagnostics;
 using Microsoft.Data.Sqlite;
 
 namespace DbaClientX.Tests;
@@ -179,5 +180,93 @@ public sealed class SQLiteGenericExecutorsTests
             SqliteConnection.ClearAllPools();
             File.Delete(path);
         }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteNonQueryWithConnectionString_PreservesExplicitDefaultTimeout(bool asyncExecution)
+    {
+        var path = Path.Join(Path.GetTempPath(), $"dbax-timeout-{Guid.NewGuid():N}.db");
+        try
+        {
+            using var blocker = new SqliteConnection($"Data Source={path};Pooling=False");
+            blocker.Open();
+            using (var setup = blocker.CreateCommand())
+            {
+                setup.CommandText = "CREATE TABLE timeout_contract (id INTEGER NOT NULL);";
+                setup.ExecuteNonQuery();
+            }
+
+            using var transaction = blocker.BeginTransaction();
+            using (var acquireWriteLock = blocker.CreateCommand())
+            {
+                acquireWriteLock.Transaction = transaction;
+                acquireWriteLock.CommandText = "INSERT INTO timeout_contract (id) VALUES (1);";
+                acquireWriteLock.ExecuteNonQuery();
+            }
+
+            using var sqlite = new DBAClientX.SQLite { BusyTimeoutMs = 10000 };
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = path,
+                Pooling = false,
+                DefaultTimeout = 1
+            }.ConnectionString;
+            var stopwatch = Stopwatch.StartNew();
+
+            if (asyncExecution)
+            {
+                await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(() =>
+                    sqlite.ExecuteNonQueryWithConnectionStringAsync(
+                        connectionString,
+                        "INSERT INTO timeout_contract (id) VALUES (2);"));
+            }
+            else
+            {
+                Assert.Throws<DBAClientX.DbaQueryExecutionException>(() =>
+                    sqlite.ExecuteNonQueryWithConnectionString(
+                        connectionString,
+                        "INSERT INTO timeout_contract (id) VALUES (2);"));
+            }
+
+            stopwatch.Stop();
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(5),
+                $"Explicit one-second timeout was overwritten; execution took {stopwatch.Elapsed}.");
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ExecuteNonQuery_WhenTransactionIsMissing_PreservesExecutionExceptionContract(bool asyncExecution)
+    {
+        using var sqlite = new DBAClientX.SQLite();
+        DBAClientX.DbaQueryExecutionException exception;
+
+        if (asyncExecution)
+        {
+            exception = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(() =>
+                sqlite.ExecuteNonQueryWithConnectionStringAsync(
+                    "Data Source=:memory:;Pooling=False",
+                    "UPDATE items SET id = 1;",
+                    useTransaction: true));
+        }
+        else
+        {
+            exception = Assert.Throws<DBAClientX.DbaQueryExecutionException>(() =>
+                sqlite.ExecuteNonQuery(
+                    ":memory:",
+                    "UPDATE items SET id = 1;",
+                    useTransaction: true));
+        }
+
+        Assert.IsType<DBAClientX.DbaTransactionException>(exception.InnerException);
     }
 }

--- a/DbaClientX.Tests/SQLiteGenericExecutorsTests.cs
+++ b/DbaClientX.Tests/SQLiteGenericExecutorsTests.cs
@@ -1,0 +1,183 @@
+using System.Data;
+using Microsoft.Data.Sqlite;
+
+namespace DbaClientX.Tests;
+
+[CollectionDefinition(nameof(SQLiteGenericExecutorsCollection), DisableParallelization = true)]
+public sealed class SQLiteGenericExecutorsCollection;
+
+[Collection(nameof(SQLiteGenericExecutorsCollection))]
+public sealed class SQLiteGenericExecutorsTests
+{
+    private sealed class CaptureSQLite : DBAClientX.SQLite
+    {
+        public string? LastConnectionString { get; private set; }
+
+        public string? LastDatabasePath { get; private set; }
+
+        public bool AsyncDisposed { get; private set; }
+
+        public bool SyncDisposed { get; private set; }
+
+        public override Task<int> ExecuteNonQueryWithConnectionStringAsync(
+            string connectionString,
+            string query,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, SqliteType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            LastConnectionString = connectionString;
+            return Task.FromResult(7);
+        }
+
+        public override Task<int> ExecuteNonQueryAsync(
+            string database,
+            string query,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, SqliteType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            LastDatabasePath = database;
+            return Task.FromResult(8);
+        }
+
+        protected override async ValueTask DisposeAsyncCore()
+        {
+            AsyncDisposed = true;
+            await base.DisposeAsyncCore().ConfigureAwait(false);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                SyncDisposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteSqlAsync_PreservesFullConnectionStringAndUsesAsyncDisposal()
+    {
+        var builder = new SqliteConnectionStringBuilder
+        {
+            DataSource = "data.db",
+            Mode = SqliteOpenMode.ReadOnly,
+            Cache = SqliteCacheMode.Shared,
+            Pooling = false,
+            DefaultTimeout = 17,
+            ForeignKeys = true,
+            RecursiveTriggers = true
+        };
+        var client = new CaptureSQLite();
+        var originalFactory = DBAClientX.SQLiteGeneric.GenericExecutors.ClientFactory;
+        DBAClientX.SQLiteGeneric.GenericExecutors.ClientFactory = () => client;
+
+        try
+        {
+            var affected = await DBAClientX.SQLiteGeneric.GenericExecutors.ExecuteSqlAsync(
+                builder.ConnectionString,
+                "UPDATE items SET name = @name",
+                new Dictionary<string, object?> { ["@name"] = "updated" });
+
+            Assert.Equal(7, affected);
+            Assert.Equal(builder.ConnectionString, client.LastConnectionString);
+            Assert.Null(client.LastDatabasePath);
+            Assert.True(client.AsyncDisposed);
+            Assert.False(client.SyncDisposed);
+        }
+        finally
+        {
+            DBAClientX.SQLiteGeneric.GenericExecutors.ClientFactory = originalFactory;
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteSqlAsync_PathContainingEquals_IsTreatedAsDatabasePath()
+    {
+        var path = Path.Join(Path.GetTempPath(), $"dbax={Guid.NewGuid():N}.db");
+        try
+        {
+            await DBAClientX.SQLiteGeneric.GenericExecutors.ExecuteSqlAsync(
+                path,
+                "CREATE TABLE path_contract (id INTEGER NOT NULL);");
+
+            using var sqlite = new DBAClientX.SQLite();
+            var count = sqlite.ExecuteScalar(path, "SELECT COUNT(*) FROM sqlite_master WHERE name = 'path_contract';");
+            Assert.Equal(1L, count);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task ExecuteSqlAsync_FullReadOnlyConnectionStringPreservesProviderMode()
+    {
+        var path = Path.Join(Path.GetTempPath(), $"dbax-readonly-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var sqlite = new DBAClientX.SQLite())
+            {
+                sqlite.ExecuteNonQuery(path, "CREATE TABLE mode_contract (id INTEGER NOT NULL);");
+            }
+
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = path,
+                Mode = SqliteOpenMode.ReadOnly,
+                Pooling = false
+            }.ConnectionString;
+
+            await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(() =>
+                DBAClientX.SQLiteGeneric.GenericExecutors.ExecuteSqlAsync(
+                    connectionString,
+                    "INSERT INTO mode_contract (id) VALUES (1);"));
+
+            using var verifier = new DBAClientX.SQLite();
+            Assert.Equal(0L, verifier.ExecuteScalar(path, "SELECT COUNT(*) FROM mode_contract;"));
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void ExecuteNonQueryWithConnectionString_FullReadOnlyConnectionStringPreservesProviderMode()
+    {
+        var path = Path.Join(Path.GetTempPath(), $"dbax-readonly-sync-{Guid.NewGuid():N}.db");
+        try
+        {
+            using var sqlite = new DBAClientX.SQLite();
+            sqlite.ExecuteNonQuery(path, "CREATE TABLE sync_mode_contract (id INTEGER NOT NULL);");
+            var connectionString = new SqliteConnectionStringBuilder
+            {
+                DataSource = path,
+                Mode = SqliteOpenMode.ReadOnly,
+                Pooling = false
+            }.ConnectionString;
+
+            Assert.Throws<DBAClientX.DbaQueryExecutionException>(() =>
+                sqlite.ExecuteNonQueryWithConnectionString(
+                    connectionString,
+                    "INSERT INTO sync_mode_contract (id) VALUES (1);"));
+
+            Assert.Equal(0L, sqlite.ExecuteScalar(path, "SELECT COUNT(*) FROM sync_mode_contract;"));
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            File.Delete(path);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ $rows | Export-OfficeCsv -Path .\Users.csv
 $rows | Export-OfficeCsv -Path .\Users.csv.gz -CompressionType GZip
 ```
 
-For the fastest SQL Server to CSV export path, stream an `IDataReader` from DbaClientX directly into PSWriteOffice and dispose the reader when the file writer is done:
+For the fastest SQL Server to CSV export path, stream an owned `DbDataReader` from DbaClientX directly into PSWriteOffice and dispose the reader when the file writer is done:
 
 ```powershell
 $connectionString = [DBAClientX.SqlServer]::BuildConnectionString(


### PR DESCRIPTION
## Summary

- preserve complete SQLite connection strings in the generic executor, including mode, cache, pooling, timeout, foreign-key, trigger, password, and VFS options
- keep an explicit SQLite `Default Timeout` authoritative instead of overwriting it with the client-wide busy timeout; path-based calls still use `BusyTimeoutMs`
- distinguish full connection strings from valid file paths containing `=` and provide synchronous/asynchronous non-query entry points for full connection strings
- preserve `DbaQueryExecutionException` wrapping for non-query transaction resolution failures
- make the owned reader lease a `DbDataReader` with idempotent asynchronous disposal of the provider reader, command, callbacks, and owned connection
- return `DbaDataReader` from SQL Server async reader APIs so pattern-based `await using` also compiles for `net472`

## Compatibility

`SqlServer.QueryReader` now returns `DbDataReader`, while `QueryReaderAsync` returns `Task<DbaDataReader>`. Direct consumption remains straightforward, but callers that explicitly stored `IDataReader`, `Task<IDataReader>`, or `Task<DbDataReader>` may need to update their declared type and rebuild. The concrete async return type is intentional so `net472` consumers can see `DisposeAsync`.

## Validation

- full tests: 1,069 passed on `net8.0` and 1,069 passed on `net10.0`
- focused reader and SQLite execution contracts: 13 passed
- solution builds across `net472`, `net8.0`, and `net10.0`
- locked-database integration checks prove explicit one-second connection-string timeouts are not replaced by a ten-second client timeout
- a disposable `net472` consumer compiles the documented `await using` reader pattern