### PR TITLE
Unify provider contracts and bound shared execution

### DIFF
--- a/DbaClientX.Core/DataMovement/DbaIdentifierPath.cs
+++ b/DbaClientX.Core/DataMovement/DbaIdentifierPath.cs
@@ -1,10 +1,12 @@
 namespace DBAClientX.DataMovement;
 
-internal static class DbaIdentifierPath
+/// <summary>Parses and normalizes multipart database identifiers across provider surfaces.</summary>
+public static class DbaIdentifierPath
 {
+    /// <summary>Quotes a plan segment only when it is not already delimited or a simple identifier.</summary>
     public static string QuotePlanSegment(string segment)
     {
-        var trimmed = segment.Trim();
+        var trimmed = ValidateAndTrimSegment(segment);
         if (IsDelimitedSegment(trimmed) || IsSimplePlanSegment(trimmed))
         {
             return trimmed;
@@ -13,12 +15,14 @@ internal static class DbaIdentifierPath
         return "\"" + trimmed.Replace("\"", "\"\"") + "\"";
     }
 
+    /// <summary>Quotes a plan segment when needed to preserve its case under default provider folding.</summary>
     public static string QuotePlanSegmentPreservingCase(string segment)
         => QuotePlanSegmentPreservingCase(segment, provider: null);
 
+    /// <summary>Quotes a plan segment when needed to preserve its case for the selected provider.</summary>
     public static string QuotePlanSegmentPreservingCase(string segment, DbaTableCopyProvider? provider)
     {
-        var trimmed = segment.Trim();
+        var trimmed = ValidateAndTrimSegment(segment);
         if (IsDelimitedSegment(trimmed))
         {
             return trimmed;
@@ -56,9 +60,10 @@ internal static class DbaIdentifierPath
         return "\"" + trimmed.Replace("\"", "\"\"") + "\"";
     }
 
+    /// <summary>Removes matching SQL identifier delimiters and unescapes their contents.</summary>
     public static string UnquoteSegment(string segment)
     {
-        var trimmed = segment.Trim();
+        var trimmed = ValidateAndTrimSegment(segment);
         if (trimmed.Length >= 2 && trimmed[0] == '"' && trimmed[trimmed.Length - 1] == '"')
         {
             return trimmed.Substring(1, trimmed.Length - 2).Replace("\"\"", "\"");
@@ -77,8 +82,14 @@ internal static class DbaIdentifierPath
         return trimmed;
     }
 
+    /// <summary>Splits a multipart identifier while preserving dots inside delimited segments.</summary>
     public static IReadOnlyList<string> SplitSegments(string identifierPath)
     {
+        if (string.IsNullOrWhiteSpace(identifierPath))
+        {
+            throw new ArgumentException("Identifier cannot be null or whitespace.", nameof(identifierPath));
+        }
+
         var parts = new List<string>();
         var start = 0;
         var quote = '\0';
@@ -144,12 +155,19 @@ internal static class DbaIdentifierPath
         }
 
         parts.Add(identifierPath.Substring(start));
+        if (parts.Any(static part => string.IsNullOrWhiteSpace(part)))
+        {
+            throw new ArgumentException($"Identifier '{identifierPath}' cannot contain empty path segments.", nameof(identifierPath));
+        }
+
         return parts;
     }
 
+    /// <summary>Removes segment delimiters while preserving the multipart path structure.</summary>
     public static string NormalizeForDuplicateCheck(string identifierPath)
         => string.Join(".", SplitSegments(identifierPath).Select(UnquoteSegment));
 
+    /// <summary>Returns whether an identifier is reserved by the selected provider.</summary>
     public static bool IsReservedIdentifier(string identifier, DbaTableCopyProvider provider)
         => provider switch
         {
@@ -158,11 +176,25 @@ internal static class DbaIdentifierPath
             _ => false
         };
 
-    private static bool IsDelimitedSegment(string segment)
-        => segment.Length >= 2 &&
-           ((segment[0] == '"' && segment[segment.Length - 1] == '"') ||
-            (segment[0] == '[' && segment[segment.Length - 1] == ']') ||
-            (segment[0] == '`' && segment[segment.Length - 1] == '`'));
+    /// <summary>Returns whether a segment has matching SQL identifier delimiters.</summary>
+    public static bool IsDelimitedSegment(string segment)
+    {
+        var trimmed = ValidateAndTrimSegment(segment);
+        return trimmed.Length >= 2 &&
+               ((trimmed[0] == '"' && trimmed[trimmed.Length - 1] == '"') ||
+                (trimmed[0] == '[' && trimmed[trimmed.Length - 1] == ']') ||
+               (trimmed[0] == '`' && trimmed[trimmed.Length - 1] == '`'));
+    }
+
+    private static string ValidateAndTrimSegment(string segment)
+    {
+        if (string.IsNullOrWhiteSpace(segment))
+        {
+            throw new ArgumentException("Identifier segment cannot be null or whitespace.", nameof(segment));
+        }
+
+        return segment.Trim();
+    }
 
     private static bool IsSimplePlanSegment(string segment)
     {

--- a/DbaClientX.Core/DataMovement/DbaIdentifierPath.cs
+++ b/DbaClientX.Core/DataMovement/DbaIdentifierPath.cs
@@ -93,6 +93,13 @@ public static class DbaIdentifierPath
 
     /// <summary>Splits a multipart identifier while preserving dots inside delimited segments.</summary>
     public static IReadOnlyList<string> SplitSegments(string identifierPath)
+        => SplitSegments(identifierPath, provider: null);
+
+    /// <summary>Splits a multipart identifier using only delimiters recognized by the selected provider.</summary>
+    public static IReadOnlyList<string> SplitSegments(string identifierPath, DbaTableCopyProvider provider)
+        => SplitSegments(identifierPath, (DbaTableCopyProvider?)provider);
+
+    private static IReadOnlyList<string> SplitSegments(string identifierPath, DbaTableCopyProvider? provider)
     {
         if (string.IsNullOrWhiteSpace(identifierPath))
         {
@@ -107,7 +114,7 @@ public static class DbaIdentifierPath
             var value = identifierPath[index];
             if (quote == '\0')
             {
-                if (value is '"' or '[' or '`')
+                if (IsDelimiterStart(value, provider))
                 {
                     quote = value;
                     continue;
@@ -171,6 +178,11 @@ public static class DbaIdentifierPath
 
         return parts;
     }
+
+    private static bool IsDelimiterStart(char value, DbaTableCopyProvider? provider)
+        => value == '"' ||
+           (value == '[' && (provider is null or DbaTableCopyProvider.SqlServer or DbaTableCopyProvider.SQLite)) ||
+           (value == '`' && (provider is null or DbaTableCopyProvider.MySql or DbaTableCopyProvider.SQLite));
 
     /// <summary>Removes segment delimiters while preserving the multipart path structure.</summary>
     public static string NormalizeForDuplicateCheck(string identifierPath)

--- a/DbaClientX.Core/DataMovement/DbaIdentifierPath.cs
+++ b/DbaClientX.Core/DataMovement/DbaIdentifierPath.cs
@@ -62,6 +62,13 @@ public static class DbaIdentifierPath
 
     /// <summary>Removes matching SQL identifier delimiters and unescapes their contents.</summary>
     public static string UnquoteSegment(string segment)
+        => UnquoteSegment(segment, provider: null);
+
+    /// <summary>Removes identifier delimiters recognized by the selected provider and unescapes their contents.</summary>
+    public static string UnquoteSegment(string segment, DbaTableCopyProvider provider)
+        => UnquoteSegment(segment, (DbaTableCopyProvider?)provider);
+
+    private static string UnquoteSegment(string segment, DbaTableCopyProvider? provider)
     {
         var trimmed = ValidateAndTrimSegment(segment);
         if (trimmed.Length >= 2 && trimmed[0] == '"' && trimmed[trimmed.Length - 1] == '"')
@@ -69,12 +76,14 @@ public static class DbaIdentifierPath
             return trimmed.Substring(1, trimmed.Length - 2).Replace("\"\"", "\"");
         }
 
-        if (trimmed.Length >= 2 && trimmed[0] == '[' && trimmed[trimmed.Length - 1] == ']')
+        if ((provider is null or DbaTableCopyProvider.SqlServer or DbaTableCopyProvider.SQLite) &&
+            trimmed.Length >= 2 && trimmed[0] == '[' && trimmed[trimmed.Length - 1] == ']')
         {
             return trimmed.Substring(1, trimmed.Length - 2).Replace("]]", "]");
         }
 
-        if (trimmed.Length >= 2 && trimmed[0] == '`' && trimmed[trimmed.Length - 1] == '`')
+        if ((provider is null or DbaTableCopyProvider.MySql or DbaTableCopyProvider.SQLite) &&
+            trimmed.Length >= 2 && trimmed[0] == '`' && trimmed[trimmed.Length - 1] == '`')
         {
             return trimmed.Substring(1, trimmed.Length - 2).Replace("``", "`");
         }

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -26,8 +26,6 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     private int _disposeSignaled;
 
     private const int MaxBackoffMilliseconds = 30000; // cap backoff to 30s
-    private static readonly ThreadLocal<Random> _rand = new(() => new Random(unchecked(Environment.TickCount * 31 + Thread.CurrentThread.ManagedThreadId)));
-
     /// <summary>
     /// Gets or sets the desired return type for query executions.
     /// </summary>
@@ -107,33 +105,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     /// <returns>The result of the successful operation.</returns>
     /// <exception cref="Exception">Thrown when all retry attempts fail.</exception>
     protected T ExecuteWithRetry<T>(Func<T> operation)
-    {
-        var attempts = 0;
-        Exception? lastException = null;
-        var maxAttempts = MaxRetryAttempts < 1 ? 1 : MaxRetryAttempts;
-        while (attempts < maxAttempts)
-        {
-            try
-            {
-                return operation();
-            }
-            catch (Exception ex) when (IsTransient(ex))
-            {
-                lastException = ex;
-                attempts++;
-                if (attempts >= maxAttempts)
-                {
-                    break;
-                }
-                var delay = ComputeBackoffDelay(attempts);
-                if (delay > TimeSpan.Zero)
-                {
-                    Thread.Sleep(delay);
-                }
-            }
-        }
-        throw lastException ?? new Exception("Operation failed.");
-    }
+        => TransientRetry.Run(operation, IsTransient, CreateTransientRetryOptions());
 
     /// <summary>
     /// Asynchronously executes an operation with retry logic for transient failures.
@@ -143,36 +115,12 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     /// <param name="cancellationToken">Token used to cancel the retries.</param>
     /// <returns>The result of the successful operation.</returns>
     /// <exception cref="Exception">Thrown when all retry attempts fail.</exception>
-    protected async Task<T> ExecuteWithRetryAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken = default)
-    {
-        var attempts = 0;
-        Exception? lastException = null;
-        var maxAttempts = MaxRetryAttempts < 1 ? 1 : MaxRetryAttempts;
-        while (attempts < maxAttempts)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            try
-            {
-                return await operation().ConfigureAwait(false);
-            }
-            catch (Exception ex) when (IsTransient(ex))
-            {
-                lastException = ex;
-                attempts++;
-                if (attempts >= maxAttempts)
-                {
-                    break;
-                }
-                var delay = ComputeBackoffDelay(attempts);
-                if (delay > TimeSpan.Zero)
-                {
-                    await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-                }
-            }
-        }
-        throw lastException ?? new Exception("Operation failed.");
-    }
+    protected Task<T> ExecuteWithRetryAsync<T>(Func<Task<T>> operation, CancellationToken cancellationToken = default)
+        => TransientRetry.RunAsync(
+            _ => operation(),
+            IsTransient,
+            CreateTransientRetryOptions(),
+            cancellationToken: cancellationToken);
 
     /// <summary>
     /// Asynchronously disposes a resource only when the current operation owns it.
@@ -368,20 +316,16 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     /// <param name="attempt">The one-based retry attempt number.</param>
     /// <returns>The delay before the next retry attempt.</returns>
     protected TimeSpan ComputeBackoffDelay(int attempt)
-    {
-        var baseDelay = RetryDelay;
-        if (baseDelay <= TimeSpan.Zero)
+        => TransientRetry.CalculateBackoffDelay(CreateTransientRetryOptions(), attempt);
+
+    /// <summary>Creates the shared retry options used by core execution and streaming paths.</summary>
+    protected virtual TransientRetryOptions CreateTransientRetryOptions()
+        => new()
         {
-            return TimeSpan.Zero;
-        }
-        // Exponential backoff with jitter (full jitter)
-        var factor = Math.Pow(2, Math.Max(0, attempt - 1));
-        var baseMilliseconds = baseDelay.TotalMilliseconds;
-        var ms = baseMilliseconds * factor;
-        var jitter = _rand.Value!.NextDouble() * baseMilliseconds; // 0..base
-        var total = Math.Min(ms + jitter, MaxBackoffMilliseconds);
-        return TimeSpan.FromMilliseconds(total);
-    }
+            MaxAttempts = Math.Max(1, MaxRetryAttempts),
+            BaseDelay = RetryDelay,
+            MaxDelay = TimeSpan.FromMilliseconds(MaxBackoffMilliseconds)
+        };
 
     /// <summary>
     /// Adds parameters created from dictionaries of values, types, and directions to the supplied command.
@@ -970,9 +914,6 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         CommandType commandType = CommandType.Text)
     {
         ValidateCommandText(query, commandType);
-        var maxAttempts = MaxRetryAttempts < 1 ? 1 : MaxRetryAttempts;
-        var attempt = 0;
-
         using var command = connection.CreateCommand();
         command.CommandText = query;
         command.Transaction = transaction;
@@ -985,26 +926,11 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             command.CommandTimeout = commandTimeout;
         }
 
-        async Task<DbDataReader> OpenReaderAsync()
-        {
-            while (true)
-            {
-                try
-                {
-                    return await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex) when (IsTransient(ex) && ++attempt < maxAttempts)
-                {
-                    var delay = ComputeBackoffDelay(attempt);
-                    if (delay > TimeSpan.Zero)
-                    {
-                        await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-                    }
-                }
-            }
-        }
-
-        await using var reader = await OpenReaderAsync().ConfigureAwait(false);
+        await using var reader = await TransientRetry.RunAsync(
+            ct => command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, ct),
+            IsTransient,
+            CreateTransientRetryOptions(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
 
         var table = new DataTable();
         for (int i = 0; i < reader.FieldCount; i++)
@@ -1060,9 +986,6 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         {
             throw new ArgumentNullException(nameof(map));
         }
-        var maxAttempts = MaxRetryAttempts < 1 ? 1 : MaxRetryAttempts;
-        var attempt = 0;
-
         using var command = connection.CreateCommand();
         command.CommandText = query;
         command.Transaction = transaction;
@@ -1075,26 +998,11 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             command.CommandTimeout = commandTimeout;
         }
 
-        async Task<DbDataReader> OpenReaderAsync()
-        {
-            while (true)
-            {
-                try
-                {
-                    return await command.ExecuteReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex) when (IsTransient(ex) && ++attempt < maxAttempts)
-                {
-                    var delay = ComputeBackoffDelay(attempt);
-                    if (delay > TimeSpan.Zero)
-                    {
-                        await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
-                    }
-                }
-            }
-        }
-
-        await using var reader = await OpenReaderAsync().ConfigureAwait(false);
+        await using var reader = await TransientRetry.RunAsync(
+            ct => command.ExecuteReaderAsync(CommandBehavior.Default, ct),
+            IsTransient,
+            CreateTransientRetryOptions(),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
         initialize?.Invoke(reader);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {

--- a/DbaClientX.Core/Invoker/DbInvoker.cs
+++ b/DbaClientX.Core/Invoker/DbInvoker.cs
@@ -219,16 +219,9 @@ public static class DbInvoker
 
     private static MethodInfo? ResolveExecutor(string providerAlias, Assembly? providerAssembly, string methodName)
     {
-        // Known type names for providers
-        string? typeName = providerAlias?.Trim().ToLowerInvariant() switch
-        {
-            "sqlite" => "DBAClientX.SQLiteGeneric.GenericExecutors",
-            "sqlserver" or "mssql" => "DBAClientX.SqlServerGeneric.GenericExecutors",
-            "postgresql" or "pgsql" or "postgres" => "DBAClientX.PostgreSqlGeneric.GenericExecutors",
-            "mysql" => "DBAClientX.MySqlGeneric.GenericExecutors",
-            "oracle" => "DBAClientX.OracleGeneric.GenericExecutors",
-            _ => null
-        };
+        var typeName = DbaConnectionFactory.TryGetProvider(providerAlias, out var provider)
+            ? provider.GenericExecutorTypeName
+            : null;
 
         // If assembly hint is provided, prefer it
         if (providerAssembly != null)

--- a/DbaClientX.Core/Invoker/DbInvoker.cs
+++ b/DbaClientX.Core/Invoker/DbInvoker.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX.Mapping;
@@ -20,6 +21,9 @@ public static class DbInvoker
     /// </summary>
     public sealed class DbExecutionOptions
     {
+        /// <summary>Maximum accepted parallel degree, preventing accidental creation of an unbounded worker set.</summary>
+        public const int MaximumParallelDegree = 1024;
+
         /// <summary>
         /// Optional batch size for processing items. When null or less than or equal to 0, processes all items in a single batch.
         /// </summary>
@@ -68,59 +72,16 @@ public static class DbInvoker
         {
             throw new InvalidOperationException($"GenericExecutors for provider '{providerAlias}' not found.");
         }
-        options ??= new DbParameterMapperOptions();
-        execOptions ??= new DbExecutionOptions();
-        var affected = 0;
-        var batchSize = execOptions.BatchSize.HasValue && execOptions.BatchSize.Value > 0
-            ? execOptions.BatchSize.Value
-            : (int?)null;
-
-        foreach (var batch in EnumerateBatches(items, batchSize))
-        {
-            ct.ThrowIfCancellationRequested();
-            int degree = execOptions.ParallelDegree.HasValue && execOptions.ParallelDegree.Value > 1 ? execOptions.ParallelDegree.Value : 1;
-            if (degree <= 1)
-            {
-                foreach (var item in batch)
-                {
-                    ct.ThrowIfCancellationRequested();
-                    var parameters = DbParameterMapper.MapItem(item, map, options, ambient);
-                    var task = InvokeExecutor(exec, connectionString, sql, parameters, ct);
-                    affected += await task.ConfigureAwait(false);
-                }
-            }
-            else
-            {
-                using var sem = new SemaphoreSlim(degree, degree);
-                var tasks = new List<Task>();
-                var local = 0;
-
-                async Task ExecuteItemAsync(object item)
-                {
-                    await sem.WaitAsync(ct).ConfigureAwait(false);
-                    try
-                    {
-                        ct.ThrowIfCancellationRequested();
-                        var parameters = DbParameterMapper.MapItem(item, map, options, ambient);
-                        var rows = await InvokeExecutor(exec, connectionString, sql, parameters, ct).ConfigureAwait(false);
-                        Interlocked.Add(ref local, rows);
-                    }
-                    finally
-                    {
-                        sem.Release();
-                    }
-                }
-
-                foreach (var item in batch)
-                {
-                    tasks.Add(ExecuteItemAsync(item));
-                }
-
-                await Task.WhenAll(tasks).ConfigureAwait(false);
-                affected += local;
-            }
-        }
-        return affected;
+        return await ExecuteItemsAsync(
+            exec,
+            connectionString,
+            sql,
+            items,
+            map,
+            options ?? new DbParameterMapperOptions(),
+            execOptions ?? new DbExecutionOptions(),
+            ct,
+            ambient).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -162,59 +123,137 @@ public static class DbInvoker
         {
             throw new InvalidOperationException($"GenericExecutors.ExecuteProcedureAsync for provider '{providerAlias}' not found.");
         }
-        options ??= new DbParameterMapperOptions();
-        execOptions ??= new DbExecutionOptions();
-        var affected = 0;
-        var batchSize = execOptions.BatchSize.HasValue && execOptions.BatchSize.Value > 0
-            ? execOptions.BatchSize.Value
-            : (int?)null;
+        return await ExecuteItemsAsync(
+            exec,
+            connectionString,
+            procedure,
+            items,
+            map,
+            options ?? new DbParameterMapperOptions(),
+            execOptions ?? new DbExecutionOptions(),
+            ct,
+            ambient).ConfigureAwait(false);
+    }
 
-        foreach (var batch in EnumerateBatches(items, batchSize))
+    [RequiresUnreferencedCode("DbInvoker maps object properties by reflection. Use a typed mapping surface when trimming.")]
+    private static async Task<int> ExecuteItemsAsync(
+        MethodInfo executor,
+        string connectionString,
+        string commandText,
+        IEnumerable<object> items,
+        IReadOnlyDictionary<string, string> map,
+        DbParameterMapperOptions mappingOptions,
+        DbExecutionOptions executionOptions,
+        CancellationToken cancellationToken,
+        IReadOnlyDictionary<string, object?>? ambient)
+    {
+        var degree = executionOptions.ParallelDegree.GetValueOrDefault(1);
+        if (degree <= 1)
         {
-            ct.ThrowIfCancellationRequested();
-            int degree = execOptions.ParallelDegree.HasValue && execOptions.ParallelDegree.Value > 1 ? execOptions.ParallelDegree.Value : 1;
-            if (degree <= 1)
+            degree = 1;
+        }
+        else if (degree > DbExecutionOptions.MaximumParallelDegree)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(DbExecutionOptions.ParallelDegree),
+                $"ParallelDegree cannot exceed {DbExecutionOptions.MaximumParallelDegree}.");
+        }
+
+        if (executionOptions.BatchSize is not > 0)
+        {
+            return await ExecuteBatchAsync(items, degree, cancellationToken).ConfigureAwait(false);
+        }
+
+        var total = 0;
+        foreach (var batch in EnumerateBatches(items, executionOptions.BatchSize.Value))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            total = checked(total + await ExecuteBatchAsync(batch, degree, cancellationToken).ConfigureAwait(false));
+        }
+
+        return total;
+
+        async Task<int> ExecuteBatchAsync(IEnumerable<object> batch, int parallelDegree, CancellationToken token)
+        {
+            if (parallelDegree == 1)
             {
+                var sequentialAffected = 0;
                 foreach (var item in batch)
                 {
-                    ct.ThrowIfCancellationRequested();
-                    var parameters = DbParameterMapper.MapItem(item, map, options, ambient);
-                    var task = InvokeExecutor(exec, connectionString, procedure, parameters, ct);
-                    affected += await task.ConfigureAwait(false);
+                    token.ThrowIfCancellationRequested();
+                    var parameters = DbParameterMapper.MapItem(item, map, mappingOptions, ambient);
+                    sequentialAffected = checked(sequentialAffected + await InvokeExecutor(executor, connectionString, commandText, parameters, token).ConfigureAwait(false));
                 }
+
+                return sequentialAffected;
             }
-            else
+
+            using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(token);
+            using var enumerator = batch.GetEnumerator();
+            var enumerationLock = new object();
+            var workerCount = batch switch
             {
-                using var sem = new SemaphoreSlim(degree, degree);
-                var tasks = new List<Task>();
-                var local = 0;
+                IReadOnlyCollection<object> readOnlyCollection => Math.Min(parallelDegree, readOnlyCollection.Count),
+                ICollection<object> collection => Math.Min(parallelDegree, collection.Count),
+                _ => parallelDegree
+            };
+            if (workerCount == 0)
+            {
+                return 0;
+            }
 
-                async Task ExecuteItemAsync(object item)
+            var workers = new Task<int>[workerCount];
+            for (var index = 0; index < workers.Length; index++)
+            {
+                workers[index] = RunWorkerAsync();
+            }
+
+            var results = await Task.WhenAll(workers).ConfigureAwait(false);
+            var parallelAffected = 0;
+            foreach (var result in results)
+            {
+                parallelAffected = checked(parallelAffected + result);
+            }
+
+            return parallelAffected;
+
+            async Task<int> RunWorkerAsync()
+            {
+                var localAffected = 0;
+                try
                 {
-                    await sem.WaitAsync(ct).ConfigureAwait(false);
-                    try
+                    while (true)
                     {
-                        ct.ThrowIfCancellationRequested();
-                        var parameters = DbParameterMapper.MapItem(item, map, options, ambient);
-                        var rows = await InvokeExecutor(exec, connectionString, procedure, parameters, ct).ConfigureAwait(false);
-                        Interlocked.Add(ref local, rows);
-                    }
-                    finally
-                    {
-                        sem.Release();
-                    }
-                }
+                        object item;
+                        lock (enumerationLock)
+                        {
+                            linkedCancellation.Token.ThrowIfCancellationRequested();
+                            if (!enumerator.MoveNext())
+                            {
+                                break;
+                            }
 
-                foreach (var item in batch)
+                            item = enumerator.Current;
+                        }
+
+                        var parameters = DbParameterMapper.MapItem(item, map, mappingOptions, ambient);
+                        localAffected = checked(localAffected + await InvokeExecutor(
+                            executor,
+                            connectionString,
+                            commandText,
+                            parameters,
+                            linkedCancellation.Token).ConfigureAwait(false));
+                    }
+
+                    return localAffected;
+                }
+                catch
                 {
-                    tasks.Add(ExecuteItemAsync(item));
+                    linkedCancellation.Cancel();
+                    throw;
                 }
-
-                await Task.WhenAll(tasks).ConfigureAwait(false);
-                affected += local;
             }
         }
-        return affected;
     }
 
     private static MethodInfo? ResolveExecutor(string providerAlias, Assembly? providerAssembly, string methodName)
@@ -317,7 +356,7 @@ public static class DbInvoker
         if (pars.Length == 4 && pars[0].ParameterType == typeof(string))
         {
             // (string connectionString, string sql, IDictionary<string,object?>?, CancellationToken)
-            resultTask = exec.Invoke(null, new object?[] { connectionString, sql, parameters, ct });
+            resultTask = InvokeReflectedExecutor(exec, new object?[] { connectionString, sql, parameters, ct });
         }
         else if (pars.Length == 7)
         {
@@ -329,7 +368,7 @@ public static class DbInvoker
             string service = Try(dict, "service") ?? Try(dict, "servicename") ?? Try(dict, "sid") ?? parsedService;
             string user = Try(dict, "user") ?? Try(dict, "userid") ?? Try(dict, "username") ?? string.Empty;
             string pass = Try(dict, "password") ?? string.Empty;
-            resultTask = exec.Invoke(null, new object?[] { host, service, user, pass, sql, parameters, ct });
+            resultTask = InvokeReflectedExecutor(exec, new object?[] { host, service, user, pass, sql, parameters, ct });
         }
         else
         {
@@ -348,6 +387,19 @@ public static class DbInvoker
         }
 
         throw new InvalidOperationException($"Executor '{exec.DeclaringType?.FullName}.{exec.Name}' returned '{resultTask.GetType().FullName}' instead of a task.");
+    }
+
+    private static object? InvokeReflectedExecutor(MethodInfo executor, object?[] arguments)
+    {
+        try
+        {
+            return executor.Invoke(null, arguments);
+        }
+        catch (TargetInvocationException exception) when (exception.InnerException != null)
+        {
+            ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+            throw;
+        }
     }
 
     private static async Task<int> AwaitAndZero(Task t)
@@ -415,28 +467,17 @@ public static class DbInvoker
         return (value, value);
     }
 
-    private static IEnumerable<IReadOnlyList<object>> EnumerateBatches(IEnumerable<object> items, int? batchSize)
+    private static IEnumerable<IReadOnlyList<object>> EnumerateBatches(IEnumerable<object> items, int batchSize)
     {
-        if (!batchSize.HasValue || batchSize.Value <= 0)
-        {
-            var allItems = items as IReadOnlyList<object> ?? items.ToList();
-            if (allItems.Count > 0)
-            {
-                yield return allItems;
-            }
-
-            yield break;
-        }
-
-        var size = batchSize.Value;
-        var batch = new List<object>(size);
+        var initialCapacity = Math.Min(batchSize, 4096);
+        var batch = new List<object>(initialCapacity);
         foreach (var item in items)
         {
             batch.Add(item);
-            if (batch.Count == size)
+            if (batch.Count == batchSize)
             {
                 yield return batch;
-                batch = new List<object>(size);
+                batch = new List<object>(initialCapacity);
             }
         }
 

--- a/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
+++ b/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
@@ -249,11 +249,12 @@ public static class DbaConnectionFactory
 
     private static ConnectionValidationResult? ValidateOracleAuthentication(DbConnectionStringBuilder builder)
     {
-        if (TryGetNonEmptyValue(builder, "External Authentication", out var externalAuthentication)
-            && bool.TryParse(externalAuthentication, out var usesExternalAuthentication)
-            && usesExternalAuthentication)
+        if (TryGetNonEmptyValue(builder, "External Authentication", out _))
         {
-            return null;
+            return new ConnectionValidationResult(
+                ConnectionValidationErrorCode.UnsupportedOption,
+                "Oracle external authentication must use User Id=/; External Authentication is not an ODP.NET connection attribute.",
+                "External Authentication");
         }
 
         if (TryGetNonEmptyValue(builder, "User Id", out var userId)
@@ -263,6 +264,15 @@ public static class DbaConnectionFactory
         {
             if (string.Equals(userId, "/", StringComparison.Ordinal))
             {
+                if (TryGetNonEmptyValue(builder, "Proxy User Id", out _)
+                    || TryGetNonEmptyValue(builder, "Proxy Password", out _))
+                {
+                    return new ConnectionValidationResult(
+                        ConnectionValidationErrorCode.InvalidParameterValue,
+                        "Oracle User Id=/ cannot be combined with proxy authentication.",
+                        "User Id");
+                }
+
                 return null;
             }
 
@@ -275,7 +285,7 @@ public static class DbaConnectionFactory
             return new ConnectionValidationResult(ConnectionValidationErrorCode.MissingRequiredParameter, "Oracle password authentication requires Password.", "Password");
         }
 
-        return new ConnectionValidationResult(ConnectionValidationErrorCode.MissingRequiredParameter, "Oracle connections must include User Id or enable external authentication.", "User Id");
+        return new ConnectionValidationResult(ConnectionValidationErrorCode.MissingRequiredParameter, "Oracle connections must include User Id; use User Id=/ for external authentication.", "User Id");
     }
 
     private static ConnectionValidationResult? ValidateSqlitePath(DbConnectionStringBuilder builder)

--- a/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
+++ b/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
@@ -316,6 +316,8 @@ public static class DbaConnectionFactory
             candidate = candidate.Substring("file:".Length);
         }
 
+        candidate = Uri.UnescapeDataString(candidate);
+
         if (candidate.Length >= 2 && char.IsLetter(candidate[0]) && candidate[1] == ':')
         {
             candidate = candidate.Substring(2);

--- a/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
+++ b/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Globalization;
 using System.Linq;
-using System.Threading;
 
 namespace DBAClientX.Invoker;
 
@@ -11,11 +11,11 @@ namespace DBAClientX.Invoker;
 /// </summary>
 public static class DbaConnectionFactory
 {
-    static DbaConnectionFactory()
-    {
-        AppDomain.CurrentDomain.ProcessExit += (_, _) => BuilderCache.Dispose();
-        AppDomain.CurrentDomain.DomainUnload += (_, _) => BuilderCache.Dispose();
-    }
+    /// <summary>Describes a supported provider and the shared aliases used to resolve it.</summary>
+    public sealed record ProviderDescriptor(
+        string CanonicalName,
+        IReadOnlyList<string> Aliases,
+        string GenericExecutorTypeName);
 
     /// <summary>
     /// Represents the type of validation failure encountered while preparing a connection.
@@ -57,7 +57,7 @@ public static class DbaConnectionFactory
         IReadOnlyList<string[]> RequiredParameters,
         Func<DbConnectionStringBuilder, ConnectionValidationResult?>? AdditionalValidation = null);
 
-    private static readonly IReadOnlyList<string[]> RequiredServerAndDatabase = new List<string[]>
+    private static readonly IReadOnlyList<string[]> RequiredServerAndDatabase = new[]
     {
         new[] { "Server", "Data Source", "Host" },
         new[] { "Database", "Initial Catalog", "DB" }
@@ -68,31 +68,26 @@ public static class DbaConnectionFactory
         ["sqlserver"] = new("sqlserver", RequiredServerAndDatabase, ValidateSqlServerOptions),
         ["postgresql"] = new("postgresql", RequiredServerAndDatabase, builder => ValidatePortRange(builder) ?? ValidatePostgreSqlOptions(builder)),
         ["mysql"] = new("mysql", RequiredServerAndDatabase, builder => ValidatePortRange(builder) ?? ValidateMySqlOptions(builder)),
-        ["sqlite"] = new("sqlite", new List<string[]>
+        ["sqlite"] = new("sqlite", new[]
         {
             new[] { "Data Source", "DataSource", "Filename", "FullUri" }
         }, ValidateSqlitePath),
-        ["oracle"] = new("oracle", new List<string[]>
+        ["oracle"] = new("oracle", new[]
         {
-            new[] { "Data Source", "DataSource" },
-            new[] { "User Id", "UserID", "User ID", "UID" },
-            new[] { "Password", "Pwd" }
-        })
+            new[] { "Data Source", "DataSource" }
+        }, ValidateOracleAuthentication)
     };
 
-    private static readonly Dictionary<string, string> ProviderAliases = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly IReadOnlyList<ProviderDescriptor> ProviderDescriptorList = Array.AsReadOnly(new[]
     {
-        ["sqlserver"] = "sqlserver",
-        ["mssql"] = "sqlserver",
-        ["postgres"] = "postgresql",
-        ["postgresql"] = "postgresql",
-        ["pgsql"] = "postgresql",
-        ["mysql"] = "mysql",
-        ["sqlite"] = "sqlite",
-        ["oracle"] = "oracle"
-    };
+        new ProviderDescriptor("sqlserver", Array.AsReadOnly(new[] { "sqlserver", "mssql" }), "DBAClientX.SqlServerGeneric.GenericExecutors"),
+        new ProviderDescriptor("postgresql", Array.AsReadOnly(new[] { "postgresql", "postgres", "pgsql" }), "DBAClientX.PostgreSqlGeneric.GenericExecutors"),
+        new ProviderDescriptor("mysql", Array.AsReadOnly(new[] { "mysql" }), "DBAClientX.MySqlGeneric.GenericExecutors"),
+        new ProviderDescriptor("sqlite", Array.AsReadOnly(new[] { "sqlite" }), "DBAClientX.SQLiteGeneric.GenericExecutors"),
+        new ProviderDescriptor("oracle", Array.AsReadOnly(new[] { "oracle" }), "DBAClientX.OracleGeneric.GenericExecutors")
+    });
 
-    private static readonly ThreadLocal<DbConnectionStringBuilder> BuilderCache = new(() => new DbConnectionStringBuilder());
+    private static readonly Dictionary<string, ProviderDescriptor> ProvidersByAlias = CreateProviderAliasMap();
 
     private static readonly Dictionary<string, string> DisallowedOptions = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -101,6 +96,25 @@ public static class DbaConnectionFactory
         ["LoadLocalInfile"] = "Loading local files is disabled for security reasons.",
         ["Use Procedure Bodies"] = "Using procedure bodies is disallowed due to injection risk."
     };
+
+    /// <summary>Gets the providers supported by the shared validation and invoker surfaces.</summary>
+    public static IReadOnlyList<ProviderDescriptor> SupportedProviders => ProviderDescriptorList;
+
+    /// <summary>Resolves a provider alias to its shared descriptor.</summary>
+    public static bool TryGetProvider(
+        string? providerAlias,
+        out ProviderDescriptor descriptor)
+    {
+        descriptor = null!;
+        if (string.IsNullOrWhiteSpace(providerAlias)
+            || !ProvidersByAlias.TryGetValue(providerAlias!.Trim(), out var resolved))
+        {
+            return false;
+        }
+
+        descriptor = resolved;
+        return true;
+    }
 
     /// <summary>
     /// Validates a provider alias and connection string combination and returns a structured result describing any issues.
@@ -128,13 +142,12 @@ public static class DbaConnectionFactory
             return new ConnectionValidationResult(ConnectionValidationErrorCode.MissingConnectionString, "Connection string is required.");
         }
 
-        if (!ProviderAliases.TryGetValue(providerAlias, out var normalized))
+        if (!TryGetProvider(providerAlias, out var provider))
         {
             return new ConnectionValidationResult(ConnectionValidationErrorCode.UnsupportedProvider, $"Provider '{providerAlias}' is not supported.");
         }
 
-        var builder = BuilderCache.Value!;
-        builder.Clear();
+        var builder = new DbConnectionStringBuilder();
         try
         {
             builder.ConnectionString = connectionString;
@@ -158,8 +171,8 @@ public static class DbaConnectionFactory
             return disallowedResult;
         }
 
-        ProviderProfiles.TryGetValue(normalized, out var profile);
-        profile ??= new ProviderValidationProfile(normalized, RequiredServerAndDatabase);
+        ProviderProfiles.TryGetValue(provider.CanonicalName, out var profile);
+        profile ??= new ProviderValidationProfile(provider.CanonicalName, RequiredServerAndDatabase);
 
         var requiredParameterResult = ValidateRequiredParameters(profile, builder);
         if (requiredParameterResult != null)
@@ -208,7 +221,7 @@ public static class DbaConnectionFactory
     {
         foreach (var alternatives in profile.RequiredParameters)
         {
-            if (!alternatives.Any(builder.ContainsKey))
+            if (!alternatives.Any(key => TryGetNonEmptyValue(builder, key, out _)))
             {
                 return new ConnectionValidationResult(ConnectionValidationErrorCode.MissingRequiredParameter, $"{profile.NormalizedName} connection strings must include {alternatives[0]}.", alternatives[0]);
             }
@@ -221,35 +234,66 @@ public static class DbaConnectionFactory
     {
         foreach (var key in new[] { "Port", "PortNumber", "Port No" })
         {
-            if (builder.ContainsKey(key) && builder[key] is string value && !string.IsNullOrWhiteSpace(value))
+            if (TryGetNonEmptyValue(builder, key, out var value))
             {
-                if (!int.TryParse(value, out var port) || port is < 1 or > 65535)
+                if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var port) || port is < 1 or > 65535)
                 {
                     return new ConnectionValidationResult(ConnectionValidationErrorCode.InvalidParameterValue, "Port must be between 1 and 65535.", key);
                 }
 
-                if (port < 1024)
-                {
-                    return new ConnectionValidationResult(ConnectionValidationErrorCode.InvalidParameterValue, "Port is within the reserved system range (1-1023).", key);
-                }
             }
         }
 
         return null;
     }
 
+    private static ConnectionValidationResult? ValidateOracleAuthentication(DbConnectionStringBuilder builder)
+    {
+        if (TryGetNonEmptyValue(builder, "External Authentication", out var externalAuthentication)
+            && bool.TryParse(externalAuthentication, out var usesExternalAuthentication)
+            && usesExternalAuthentication)
+        {
+            return null;
+        }
+
+        if (TryGetNonEmptyValue(builder, "User Id", out var userId)
+            || TryGetNonEmptyValue(builder, "UserID", out userId)
+            || TryGetNonEmptyValue(builder, "User ID", out userId)
+            || TryGetNonEmptyValue(builder, "UID", out userId))
+        {
+            if (string.Equals(userId, "/", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            if (TryGetNonEmptyValue(builder, "Password", out _)
+                || TryGetNonEmptyValue(builder, "Pwd", out _))
+            {
+                return null;
+            }
+
+            return new ConnectionValidationResult(ConnectionValidationErrorCode.MissingRequiredParameter, "Oracle password authentication requires Password.", "Password");
+        }
+
+        return new ConnectionValidationResult(ConnectionValidationErrorCode.MissingRequiredParameter, "Oracle connections must include User Id or enable external authentication.", "User Id");
+    }
+
     private static ConnectionValidationResult? ValidateSqlitePath(DbConnectionStringBuilder builder)
     {
         foreach (var key in new[] { "Data Source", "DataSource", "Filename", "FullUri" })
         {
-            if (builder.ContainsKey(key) && builder[key] is string path)
+            if (!TryGetNonEmptyValue(builder, key, out var path))
             {
-                if (path.IndexOf("..", StringComparison.Ordinal) >= 0)
-                {
-                    return new ConnectionValidationResult(ConnectionValidationErrorCode.InvalidParameterValue, "SQLite data source contains an unsafe relative path.", key);
-                }
-                break;
+                continue;
             }
+
+            if (path.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries)
+                .Any(static segment => string.Equals(segment, "..", StringComparison.Ordinal)))
+            {
+                return new ConnectionValidationResult(ConnectionValidationErrorCode.InvalidParameterValue, "SQLite data source contains an unsafe relative path.", key);
+            }
+
+            break;
         }
 
         return null;
@@ -259,7 +303,7 @@ public static class DbaConnectionFactory
     {
         foreach (var key in new[] { "Encrypt", "Encryption" })
         {
-            if (builder.TryGetValue(key, out var encrypt) && encrypt is string encryptValue)
+            if (TryGetNonEmptyValue(builder, key, out var encryptValue))
             {
                 if (encryptValue.Equals("False", StringComparison.OrdinalIgnoreCase)
                     || encryptValue.Equals("No", StringComparison.OrdinalIgnoreCase)
@@ -367,4 +411,30 @@ public static class DbaConnectionFactory
 
     private static string SanitizeExceptionMessage(Exception ex)
         => ex.GetType().Name;
+
+    private static bool TryGetNonEmptyValue(DbConnectionStringBuilder builder, string key, out string value)
+    {
+        value = string.Empty;
+        if (!builder.TryGetValue(key, out var rawValue))
+        {
+            return false;
+        }
+
+        value = Convert.ToString(rawValue, CultureInfo.InvariantCulture) ?? string.Empty;
+        return !string.IsNullOrWhiteSpace(value);
+    }
+
+    private static Dictionary<string, ProviderDescriptor> CreateProviderAliasMap()
+    {
+        var aliases = new Dictionary<string, ProviderDescriptor>(StringComparer.OrdinalIgnoreCase);
+        foreach (var descriptor in ProviderDescriptorList)
+        {
+            foreach (var alias in descriptor.Aliases)
+            {
+                aliases.Add(alias, descriptor);
+            }
+        }
+
+        return aliases;
+    }
 }

--- a/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
+++ b/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
@@ -287,8 +287,7 @@ public static class DbaConnectionFactory
                 continue;
             }
 
-            if (path.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries)
-                .Any(static segment => string.Equals(segment, "..", StringComparison.Ordinal)))
+            if (ContainsUnsafeSqliteParentTraversal(path))
             {
                 return new ConnectionValidationResult(ConnectionValidationErrorCode.InvalidParameterValue, "SQLite data source contains an unsafe relative path.", key);
             }
@@ -297,6 +296,23 @@ public static class DbaConnectionFactory
         }
 
         return null;
+    }
+
+    private static bool ContainsUnsafeSqliteParentTraversal(string path)
+    {
+        var candidate = path;
+        if (candidate.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+        {
+            candidate = candidate.Substring("file:".Length);
+        }
+
+        if (candidate.Length >= 2 && char.IsLetter(candidate[0]) && candidate[1] == ':')
+        {
+            candidate = candidate.Substring(2);
+        }
+
+        return candidate.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries)
+            .Any(static segment => string.Equals(segment, "..", StringComparison.Ordinal));
     }
 
     private static ConnectionValidationResult? ValidateSqlServerOptions(DbConnectionStringBuilder builder)

--- a/DbaClientX.Core/README.md
+++ b/DbaClientX.Core/README.md
@@ -32,6 +32,8 @@ await DbInvoker.ExecuteSqlAsync(
 
 Provider aliases, canonical names, and generic executor type names come from `DbaConnectionFactory.SupportedProviders`. Use `DbaConnectionFactory.TryGetProvider` when a host needs to normalize user input without maintaining its own alias switch.
 
+`DbInvoker` enumerates input lazily when no batch size is set. Parallel execution uses a fixed worker set, so the number of queued operations does not grow with the input sequence; `ParallelDegree` is capped by `DbExecutionOptions.MaximumParallelDegree`.
+
 ## Query builder (string-safe, provider-aware quoting)
 
 ```csharp

--- a/DbaClientX.Core/README.md
+++ b/DbaClientX.Core/README.md
@@ -2,7 +2,7 @@
 
 Core building blocks for DbaClientX: retryable execution pipeline, parameter mapping for POCOs/dictionaries, SQL query builder/compiler, and light utilities.
 
-- Target Frameworks: `net8.0`, `net472`
+- Target Frameworks: `net472`, `net8.0`, `net10.0`
 - NuGet: `DBAClientX.Core`
 
 ## Install
@@ -21,7 +21,7 @@ var items = new [] { new { Id = 1, Name = "Alice" } };
 var map   = new Dictionary<string,string> { ["Id"] = "@Id", ["Name"] = "@Name" };
 
 await DbInvoker.ExecuteSqlAsync(
-    providerAlias: "sqlserver",          // mssql|sqlserver|postgres|pgsql|mysql|sqlite|oracle
+    providerAlias: "sqlserver",          // sqlserver|mssql|postgresql|postgres|pgsql|mysql|sqlite|oracle
     connectionString: "Server=.;Database=App;Trusted_Connection=True;",
     sql: "INSERT INTO Users(Id,Name) VALUES(@Id,@Name)",
     items: items,
@@ -29,6 +29,8 @@ await DbInvoker.ExecuteSqlAsync(
     options: new DbParameterMapperOptions { DateTimeOffsetAsUtcDateTime = true }
 );
 ```
+
+Provider aliases, canonical names, and generic executor type names come from `DbaConnectionFactory.SupportedProviders`. Use `DbaConnectionFactory.TryGetProvider` when a host needs to normalize user input without maintaining its own alias switch.
 
 ## Query builder (string-safe, provider-aware quoting)
 
@@ -43,7 +45,12 @@ var sql = QueryBuilder
     .Compile(SqlDialect.SqlServer);
 ```
 
+For multipart table or schema names, `DbaIdentifierPath` provides the shared delimiter-aware split and unquote behavior used by bulk operations and table-copy planning.
+
+## Retry behavior
+
+Provider clients and streaming-reader startup use the same `TransientRetry` engine. `MaxRetryAttempts` includes the first attempt, `RetryDelay` is the exponential-backoff base, and non-query retries remain disabled by default to avoid replaying a write that may already have succeeded.
+
 ## Notes
 - Ship a per-provider package alongside Core for ADO.NET specifics (see provider READMEs).
 - `DbParameterMapper` supports dotted paths and ambient values.
-

--- a/DbaClientX.Core/TransientRetry.cs
+++ b/DbaClientX.Core/TransientRetry.cs
@@ -66,7 +66,7 @@ public static class TransientRetry {
                     break;
                 }
 
-                var delay = ComputeBackoffDelay(options, attempt);
+                var delay = CalculateBackoffDelay(options, attempt);
                 onRetry?.Invoke(new TransientRetryAttempt(attempt, delay, ex));
                 if (delay > TimeSpan.Zero) {
                     Thread.Sleep(delay);
@@ -143,7 +143,7 @@ public static class TransientRetry {
                     break;
                 }
 
-                var delay = ComputeBackoffDelay(options, attempt);
+                var delay = CalculateBackoffDelay(options, attempt);
                 onRetry?.Invoke(new TransientRetryAttempt(attempt, delay, ex));
 
                 if (delay > TimeSpan.Zero) {
@@ -159,7 +159,7 @@ public static class TransientRetry {
         throw last ?? new InvalidOperationException("Operation failed.");
     }
 
-    private static TimeSpan ComputeBackoffDelay(TransientRetryOptions options, int attempt) {
+    internal static TimeSpan CalculateBackoffDelay(TransientRetryOptions options, int attempt) {
         if (options.BaseDelay <= TimeSpan.Zero || options.MaxDelay <= TimeSpan.Zero) {
             return TimeSpan.Zero;
         }

--- a/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using DBAClientX.DataMovement;
 using Npgsql;
 
 namespace DBAClientX;
@@ -298,71 +299,8 @@ public partial class PostgreSql
             throw new ArgumentException("Identifier cannot be null or whitespace.", nameof(identifierPath));
         }
 
-        return string.Join(".", SplitIdentifierPath(identifierPath).Select(static part => QuoteIdentifier(part.Value)));
-    }
-
-    private static IReadOnlyList<IdentifierSegment> SplitIdentifierPath(string identifierPath)
-    {
-        var parts = new List<IdentifierSegment>();
-        var start = 0;
-        var quoted = false;
-        for (var index = 0; index < identifierPath.Length; index++)
-        {
-            var value = identifierPath[index];
-            if (quoted)
-            {
-                if (value == '"')
-                {
-                    if (index + 1 < identifierPath.Length && identifierPath[index + 1] == '"')
-                    {
-                        index++;
-                        continue;
-                    }
-
-                    quoted = false;
-                }
-
-                continue;
-            }
-
-            if (value == '"')
-            {
-                quoted = true;
-                continue;
-            }
-
-            if (value == '.')
-            {
-                parts.Add(NormalizeIdentifierSegment(identifierPath.Substring(start, index - start), identifierPath));
-                start = index + 1;
-            }
-        }
-
-        if (quoted)
-        {
-            throw new ArgumentException($"Identifier '{identifierPath}' contains an unterminated quoted segment.", nameof(identifierPath));
-        }
-
-        parts.Add(NormalizeIdentifierSegment(identifierPath.Substring(start), identifierPath));
-        return parts;
-    }
-
-    private static IdentifierSegment NormalizeIdentifierSegment(string value, string identifierPath)
-    {
-        var trimmed = value.Trim();
-        if (trimmed.Length == 0)
-        {
-            throw new ArgumentException($"Identifier '{identifierPath}' cannot contain empty segments.", nameof(identifierPath));
-        }
-
-        if (trimmed.Length >= 2 &&
-            trimmed[0] == '"' &&
-            trimmed[trimmed.Length - 1] == '"')
-        {
-            return new IdentifierSegment(trimmed.Substring(1, trimmed.Length - 2).Replace("\"\"", "\""));
-        }
-
-        return new IdentifierSegment(trimmed);
+        return string.Join(".", DbaIdentifierPath.SplitSegments(identifierPath)
+            .Select(static part => QuoteIdentifier(DbaIdentifierPath.UnquoteSegment(part))));
     }
 
     private static void ValidateBulkInsertInputs(DataTable table, string destinationTable, int? batchSize, int? bulkCopyTimeout)
@@ -393,13 +331,4 @@ public partial class PostgreSql
         }
     }
 
-    private readonly struct IdentifierSegment
-    {
-        internal IdentifierSegment(string value)
-        {
-            Value = value;
-        }
-
-        internal string Value { get; }
-    }
 }

--- a/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
@@ -300,7 +300,7 @@ public partial class PostgreSql
         }
 
         return string.Join(".", DbaIdentifierPath.SplitSegments(identifierPath)
-            .Select(static part => QuoteIdentifier(DbaIdentifierPath.UnquoteSegment(part))));
+            .Select(static part => QuoteIdentifier(DbaIdentifierPath.UnquoteSegment(part, DbaTableCopyProvider.PostgreSql))));
     }
 
     private static void ValidateBulkInsertInputs(DataTable table, string destinationTable, int? batchSize, int? bulkCopyTimeout)

--- a/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
@@ -299,7 +299,7 @@ public partial class PostgreSql
             throw new ArgumentException("Identifier cannot be null or whitespace.", nameof(identifierPath));
         }
 
-        return string.Join(".", DbaIdentifierPath.SplitSegments(identifierPath)
+        return string.Join(".", DbaIdentifierPath.SplitSegments(identifierPath, DbaTableCopyProvider.PostgreSql)
             .Select(static part => QuoteIdentifier(DbaIdentifierPath.UnquoteSegment(part, DbaTableCopyProvider.PostgreSql))));
     }
 

--- a/DbaClientX.PowerShell/CmdletCopyDbaXTableData.cs
+++ b/DbaClientX.PowerShell/CmdletCopyDbaXTableData.cs
@@ -609,13 +609,5 @@ public sealed class CmdletCopyDbaXTableData : PSCmdlet
         };
 
     private static string GetProviderAlias(DbaXBulkProvider provider)
-        => provider switch
-        {
-            DbaXBulkProvider.SqlServer => "sqlserver",
-            DbaXBulkProvider.PostgreSql => "postgresql",
-            DbaXBulkProvider.MySql => "mysql",
-            DbaXBulkProvider.Oracle => "oracle",
-            DbaXBulkProvider.SQLite => "sqlite",
-            _ => throw new PSArgumentException($"Provider '{provider}' is not supported.")
-        };
+        => DbaXProviderHelpers.GetAlias(provider.ToString(), nameof(provider));
 }

--- a/DbaClientX.PowerShell/CmdletWriteDbaXTableData.cs
+++ b/DbaClientX.PowerShell/CmdletWriteDbaXTableData.cs
@@ -375,15 +375,7 @@ public sealed class CmdletWriteDbaXTableData : PSCmdlet
     }
 
     private static string GetProviderAlias(DbaXBulkProvider provider)
-        => provider switch
-        {
-            DbaXBulkProvider.SqlServer => "sqlserver",
-            DbaXBulkProvider.PostgreSql => "postgresql",
-            DbaXBulkProvider.MySql => "mysql",
-            DbaXBulkProvider.Oracle => "oracle",
-            DbaXBulkProvider.SQLite => "sqlite",
-            _ => throw new PSArgumentException($"Provider '{provider}' is not supported.", nameof(provider))
-        };
+        => DbaXProviderHelpers.GetAlias(provider.ToString(), nameof(provider));
 
     private DataTable PrepareProviderBulkTable(DataTable table)
         => Provider == DbaXBulkProvider.PostgreSql

--- a/DbaClientX.PowerShell/Communication/DbaXProviderHelpers.cs
+++ b/DbaClientX.PowerShell/Communication/DbaXProviderHelpers.cs
@@ -14,15 +14,17 @@ namespace DBAClientX.PowerShell;
 internal static class DbaXProviderHelpers
 {
     internal static string GetAlias(DbaXProvider provider)
-        => provider switch
+        => GetAlias(provider.ToString(), nameof(provider));
+
+    internal static string GetAlias(string providerName, string parameterName)
+    {
+        if (DbaConnectionFactory.TryGetProvider(providerName, out var descriptor))
         {
-            DbaXProvider.SqlServer => "sqlserver",
-            DbaXProvider.PostgreSql => "postgresql",
-            DbaXProvider.MySql => "mysql",
-            DbaXProvider.Oracle => "oracle",
-            DbaXProvider.SQLite => "sqlite",
-            _ => throw new PSArgumentException($"Provider '{provider}' is not supported.", nameof(provider))
-        };
+            return descriptor.CanonicalName;
+        }
+
+        throw new PSArgumentException($"Provider '{providerName}' is not supported.", parameterName);
+    }
 
     internal static DbaTableCopyProvider ToTableCopyProvider(DbaXProvider provider)
         => provider switch

--- a/DbaClientX.SQLite/SQLite.BulkOperations.cs
+++ b/DbaClientX.SQLite/SQLite.BulkOperations.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
+using DBAClientX.DataMovement;
 using Microsoft.Data.Sqlite;
 
 namespace DBAClientX;
@@ -429,109 +430,14 @@ public partial class SQLite
             throw new ArgumentException("Identifier cannot be null or whitespace.", nameof(identifierPath));
         }
 
-        var parts = SplitIdentifierPath(identifierPath);
-        for (var i = 0; i < parts.Length; i++)
+        var parts = DbaIdentifierPath.SplitSegments(identifierPath);
+        var quotedParts = new string[parts.Count];
+        for (var i = 0; i < parts.Count; i++)
         {
-            if (string.IsNullOrWhiteSpace(parts[i]))
-            {
-                throw new ArgumentException("Identifier cannot contain empty segments.", nameof(identifierPath));
-            }
-
-            parts[i] = QuoteIdentifier(parts[i].Trim());
+            quotedParts[i] = QuoteIdentifier(DbaIdentifierPath.UnquoteSegment(parts[i]));
         }
 
-        return string.Join(".", parts);
-    }
-
-    private static string[] SplitIdentifierPath(string identifierPath)
-    {
-        var parts = new List<string>();
-        var start = 0;
-        var quote = '\0';
-        for (var index = 0; index < identifierPath.Length; index++)
-        {
-            var value = identifierPath[index];
-            if (quote == '\0')
-            {
-                if (value is '"' or '[' or '`')
-                {
-                    quote = value;
-                    continue;
-                }
-
-                if (value == '.')
-                {
-                    parts.Add(NormalizeIdentifierPathSegment(identifierPath.Substring(start, index - start)));
-                    start = index + 1;
-                }
-
-                continue;
-            }
-
-            if (quote == '"' && value == '"')
-            {
-                if (index + 1 < identifierPath.Length && identifierPath[index + 1] == '"')
-                {
-                    index++;
-                    continue;
-                }
-
-                quote = '\0';
-                continue;
-            }
-
-            if (quote == '[' && value == ']')
-            {
-                if (index + 1 < identifierPath.Length && identifierPath[index + 1] == ']')
-                {
-                    index++;
-                    continue;
-                }
-
-                quote = '\0';
-                continue;
-            }
-
-            if (quote == '`' && value == '`')
-            {
-                if (index + 1 < identifierPath.Length && identifierPath[index + 1] == '`')
-                {
-                    index++;
-                    continue;
-                }
-
-                quote = '\0';
-            }
-        }
-
-        if (quote != '\0')
-        {
-            throw new ArgumentException($"Identifier '{identifierPath}' contains an unterminated delimited path segment.", nameof(identifierPath));
-        }
-
-        parts.Add(NormalizeIdentifierPathSegment(identifierPath.Substring(start)));
-        return parts.ToArray();
-    }
-
-    private static string NormalizeIdentifierPathSegment(string segment)
-    {
-        var trimmed = segment.Trim();
-        if (trimmed.Length >= 2 && trimmed[0] == '"' && trimmed[trimmed.Length - 1] == '"')
-        {
-            return trimmed.Substring(1, trimmed.Length - 2).Replace("\"\"", "\"");
-        }
-
-        if (trimmed.Length >= 2 && trimmed[0] == '[' && trimmed[trimmed.Length - 1] == ']')
-        {
-            return trimmed.Substring(1, trimmed.Length - 2).Replace("]]", "]");
-        }
-
-        if (trimmed.Length >= 2 && trimmed[0] == '`' && trimmed[trimmed.Length - 1] == '`')
-        {
-            return trimmed.Substring(1, trimmed.Length - 2).Replace("``", "`");
-        }
-
-        return trimmed;
+        return string.Join(".", quotedParts);
     }
 
     private static void ApplyBatchValues(SqliteCommand command, DataColumn[] columns, DataTable table, int offset, int rowsPerBatch)

--- a/DbaClientX.SqlServer/SqlServer.BulkAutoCreate.cs
+++ b/DbaClientX.SqlServer/SqlServer.BulkAutoCreate.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using DBAClientX.DataMovement;
 using Microsoft.Data.SqlClient;
 
 namespace DBAClientX;
@@ -383,104 +384,13 @@ public partial class SqlServer
 
         internal static SqlServerDestinationTable Parse(string destinationTable)
         {
-            var segments = SplitIdentifierPath(destinationTable);
+            var segments = DbaIdentifierPath.SplitSegments(destinationTable);
             return segments.Count switch
             {
-                1 => new SqlServerDestinationTable("dbo", UnquoteIdentifierSegment(segments[0])),
-                2 => new SqlServerDestinationTable(UnquoteIdentifierSegment(segments[0]), UnquoteIdentifierSegment(segments[1])),
+                1 => new SqlServerDestinationTable("dbo", DbaIdentifierPath.UnquoteSegment(segments[0])),
+                2 => new SqlServerDestinationTable(DbaIdentifierPath.UnquoteSegment(segments[0]), DbaIdentifierPath.UnquoteSegment(segments[1])),
                 _ => throw new ArgumentException("AutoCreateTable supports one-part or two-part SQL Server destination table names.", nameof(destinationTable))
             };
-        }
-
-        private static IReadOnlyList<string> SplitIdentifierPath(string identifierPath)
-        {
-            var parts = new List<string>();
-            var start = 0;
-            var quote = '\0';
-            for (var index = 0; index < identifierPath.Length; index++)
-            {
-                var value = identifierPath[index];
-                if (quote == '\0')
-                {
-                    if (value is '"' or '[' or '`')
-                    {
-                        quote = value;
-                        continue;
-                    }
-
-                    if (value == '.')
-                    {
-                        parts.Add(identifierPath.Substring(start, index - start));
-                        start = index + 1;
-                    }
-
-                    continue;
-                }
-
-                if (quote == '"' && value == '"')
-                {
-                    if (index + 1 < identifierPath.Length && identifierPath[index + 1] == '"')
-                    {
-                        index++;
-                        continue;
-                    }
-
-                    quote = '\0';
-                    continue;
-                }
-
-                if (quote == '[' && value == ']')
-                {
-                    if (index + 1 < identifierPath.Length && identifierPath[index + 1] == ']')
-                    {
-                        index++;
-                        continue;
-                    }
-
-                    quote = '\0';
-                    continue;
-                }
-
-                if (quote == '`' && value == '`')
-                {
-                    if (index + 1 < identifierPath.Length && identifierPath[index + 1] == '`')
-                    {
-                        index++;
-                        continue;
-                    }
-
-                    quote = '\0';
-                }
-            }
-
-            if (quote != '\0')
-            {
-                throw new ArgumentException($"Identifier '{identifierPath}' contains an unterminated delimited path segment.", nameof(identifierPath));
-            }
-
-            parts.Add(identifierPath.Substring(start));
-            return parts;
-        }
-
-        private static string UnquoteIdentifierSegment(string segment)
-        {
-            var trimmed = segment.Trim();
-            if (trimmed.Length >= 2 && trimmed[0] == '"' && trimmed[trimmed.Length - 1] == '"')
-            {
-                return trimmed.Substring(1, trimmed.Length - 2).Replace("\"\"", "\"");
-            }
-
-            if (trimmed.Length >= 2 && trimmed[0] == '[' && trimmed[trimmed.Length - 1] == ']')
-            {
-                return trimmed.Substring(1, trimmed.Length - 2).Replace("]]", "]");
-            }
-
-            if (trimmed.Length >= 2 && trimmed[0] == '`' && trimmed[trimmed.Length - 1] == '`')
-            {
-                return trimmed.Substring(1, trimmed.Length - 2).Replace("``", "`");
-            }
-
-            return trimmed;
         }
     }
 }

--- a/DbaClientX.Tests/DbInvokerTests.cs
+++ b/DbaClientX.Tests/DbInvokerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX.Invoker;
@@ -71,6 +72,87 @@ namespace DbaClientX.Tests
             var call = Assert.Single(DBAClientX.SqlServerGeneric.GenericExecutors.Calls);
             Assert.Equal(1, call.Parameters["@Id"]);
             Assert.Equal("Alice", call.Parameters["@Name"]);
+        }
+
+        [Fact]
+        public async Task ExecuteSqlAsync_WithoutBatching_StreamsItemsInsteadOfMaterializingWholeSequence()
+        {
+            DBAClientX.SqlServerGeneric.GenericExecutors.Reset();
+
+            IEnumerable<object> Items()
+            {
+                yield return new { Id = 1 };
+                throw new InvalidOperationException("boom");
+            }
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                DbInvoker.ExecuteSqlAsync(
+                    "sqlserver",
+                    "Server=.;Database=app;",
+                    "UPDATE t SET Value = 1 WHERE Id = @Id",
+                    Items(),
+                    new Dictionary<string, string> { ["Id"] = "@Id" },
+                    providerAssembly: typeof(DBAClientX.SqlServerGeneric.GenericExecutors).Assembly));
+
+            var call = Assert.Single(DBAClientX.SqlServerGeneric.GenericExecutors.Calls);
+            Assert.Equal(1, call.Parameters["@Id"]);
+        }
+
+        [Fact]
+        public async Task ExecuteSqlAsync_ParallelExecutionNeverExceedsConfiguredDegree()
+        {
+            DBAClientX.SqlServerGeneric.GenericExecutors.Reset();
+            DBAClientX.SqlServerGeneric.GenericExecutors.BeforeReturnAsync = token => Task.Delay(15, token);
+
+            try
+            {
+                var items = Enumerable.Range(1, 24).Select(static id => (object)new { Id = id });
+                var affected = await DbInvoker.ExecuteSqlAsync(
+                    "sqlserver",
+                    "Server=.;Database=app;",
+                    "UPDATE t SET Value = 1 WHERE Id = @Id",
+                    items,
+                    new Dictionary<string, string> { ["Id"] = "@Id" },
+                    execOptions: new DbInvoker.DbExecutionOptions { ParallelDegree = 3 },
+                    providerAssembly: typeof(DBAClientX.SqlServerGeneric.GenericExecutors).Assembly);
+
+                Assert.Equal(24, affected);
+                Assert.InRange(DBAClientX.SqlServerGeneric.GenericExecutors.MaximumConcurrency, 2, 3);
+            }
+            finally
+            {
+                DBAClientX.SqlServerGeneric.GenericExecutors.Reset();
+            }
+        }
+
+        [Fact]
+        public async Task ExecuteSqlAsync_RejectsExcessiveParallelDegreeBeforeEnumeration()
+        {
+            DBAClientX.SqlServerGeneric.GenericExecutors.Reset();
+            var enumerated = false;
+
+            IEnumerable<object> Items()
+            {
+                enumerated = true;
+                yield return new { Id = 1 };
+            }
+
+            var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+                DbInvoker.ExecuteSqlAsync(
+                    "sqlserver",
+                    "Server=.;Database=app;",
+                    "UPDATE t SET Value = 1 WHERE Id = @Id",
+                    Items(),
+                    new Dictionary<string, string> { ["Id"] = "@Id" },
+                    execOptions: new DbInvoker.DbExecutionOptions
+                    {
+                        ParallelDegree = DbInvoker.DbExecutionOptions.MaximumParallelDegree + 1
+                    },
+                    providerAssembly: typeof(DBAClientX.SqlServerGeneric.GenericExecutors).Assembly));
+
+            Assert.Equal("ParallelDegree", exception.ParamName);
+            Assert.False(enumerated);
+            Assert.Empty(DBAClientX.SqlServerGeneric.GenericExecutors.Calls);
         }
 
         [Fact]
@@ -213,6 +295,32 @@ namespace DbaClientX.Tests
 
             Assert.Contains("returned null", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
+
+        [Fact]
+        public async Task ExecuteSqlAsync_UnwrapsSynchronousExecutorFailures()
+        {
+            var asmName = new AssemblyName("DynamicDbInvokerThrowingExecutorTests");
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run);
+            var moduleBuilder = assemblyBuilder.DefineDynamicModule("main");
+            var typeBuilder = moduleBuilder.DefineType("DBAClientX.SqlServerGeneric.GenericExecutors", TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed);
+            var methodBuilder = typeBuilder.DefineMethod("ExecuteSqlAsync", MethodAttributes.Public | MethodAttributes.Static, typeof(Task<int>), new[] { typeof(string), typeof(string), typeof(IDictionary<string, object?>), typeof(CancellationToken) });
+            var il = methodBuilder.GetILGenerator();
+            il.Emit(OpCodes.Ldstr, "executor failed");
+            il.Emit(OpCodes.Newobj, typeof(InvalidOperationException).GetConstructor(new[] { typeof(string) })!);
+            il.Emit(OpCodes.Throw);
+            var dynamicType = typeBuilder.CreateType();
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                DbInvoker.ExecuteSqlAsync(
+                    "sqlserver",
+                    "Server=.;Database=app;",
+                    "UPDATE t SET Value = 1 WHERE Id = @Id",
+                    new object[] { new { Id = 1 } },
+                    new Dictionary<string, string> { ["Id"] = "@Id" },
+                    providerAssembly: dynamicType!.Assembly));
+
+            Assert.Equal("executor failed", exception.Message);
+        }
     }
 }
 
@@ -224,15 +332,51 @@ namespace DBAClientX.SqlServerGeneric
 
         public static ConcurrentBag<Invocation> Calls { get; } = new();
 
+        public static Func<CancellationToken, Task>? BeforeReturnAsync { get; set; }
+
+        public static int MaximumConcurrency => _maximumConcurrency;
+
+        private static int _currentConcurrency;
+        private static int _maximumConcurrency;
+
         public static void Reset()
         {
             while (Calls.TryTake(out _)) { }
+            BeforeReturnAsync = null;
+            _maximumConcurrency = 0;
+            _currentConcurrency = 0;
         }
 
-        public static Task<int> ExecuteSqlAsync(string connectionString, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
+        public static async Task<int> ExecuteSqlAsync(string connectionString, string sql, IDictionary<string, object?>? parameters = null, CancellationToken ct = default)
         {
-            Calls.Add(new Invocation(connectionString, sql, parameters ?? new Dictionary<string, object?>()));
-            return Task.FromResult(1);
+            var concurrency = Interlocked.Increment(ref _currentConcurrency);
+            UpdateMaximumConcurrency(concurrency);
+            try
+            {
+                if (BeforeReturnAsync != null)
+                {
+                    await BeforeReturnAsync(ct);
+                }
+
+                Calls.Add(new Invocation(connectionString, sql, parameters ?? new Dictionary<string, object?>()));
+                return 1;
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _currentConcurrency);
+            }
+        }
+
+        private static void UpdateMaximumConcurrency(int concurrency)
+        {
+            while (true)
+            {
+                var observed = _maximumConcurrency;
+                if (observed >= concurrency || Interlocked.CompareExchange(ref _maximumConcurrency, concurrency, observed) == observed)
+                {
+                    return;
+                }
+            }
         }
     }
 }

--- a/DbaClientX.Tests/DbaConnectionFactoryTests.cs
+++ b/DbaClientX.Tests/DbaConnectionFactoryTests.cs
@@ -319,6 +319,28 @@ public class DbaConnectionFactoryTests
     }
 
     [Fact]
+    public void Validate_OracleSyntheticExternalAuthenticationOption_IsRejected()
+    {
+        var result = DbaConnectionFactory.Validate("oracle", "Data Source=dbhost/service;External Authentication=true");
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.UnsupportedOption, result.Code);
+        Assert.Equal("External Authentication", result.Details);
+        Assert.Contains("User Id=/", result.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("Proxy User Id=proxy")]
+    [InlineData("Proxy Password=secret")]
+    public void Validate_OracleExternalAuthenticationWithProxyAttributes_IsRejected(string proxyAttribute)
+    {
+        var result = DbaConnectionFactory.Validate("oracle", $"Data Source=dbhost/service;User Id=/;{proxyAttribute}");
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.InvalidParameterValue, result.Code);
+        Assert.Equal("User Id", result.Details);
+        Assert.Contains("proxy authentication", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Validate_OraclePasswordAuthenticationRequiresPassword()
     {
         var result = DbaConnectionFactory.Validate("oracle", "Data Source=dbhost/service;User Id=user");

--- a/DbaClientX.Tests/DbaConnectionFactoryTests.cs
+++ b/DbaClientX.Tests/DbaConnectionFactoryTests.cs
@@ -245,6 +245,18 @@ public class DbaConnectionFactoryTests
         Assert.True(result.IsValid);
     }
 
+    [Theory]
+    [InlineData("FullUri=file:../secrets.db")]
+    [InlineData("Data Source=C:..\\secrets.db")]
+    [InlineData("FullUri=file:C:../secrets.db")]
+    public void Validate_SqlitePrefixedParentTraversal_IsRejected(string connectionString)
+    {
+        var result = DbaConnectionFactory.Validate("sqlite", connectionString);
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.InvalidParameterValue, result.Code);
+        Assert.Contains("unsafe relative path", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void Validate_Success()
     {

--- a/DbaClientX.Tests/DbaConnectionFactoryTests.cs
+++ b/DbaClientX.Tests/DbaConnectionFactoryTests.cs
@@ -50,6 +50,17 @@ public class DbaConnectionFactoryTests
     }
 
     [Theory]
+    [InlineData("Server=;Database=app;", "Server")]
+    [InlineData("Server=dbhost;Database=;", "Database")]
+    public void Validate_EmptyRequiredParameterIsMissing(string connectionString, string expectedParameter)
+    {
+        var result = DbaConnectionFactory.Validate("sqlserver", connectionString);
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.MissingRequiredParameter, result.Code);
+        Assert.Equal(expectedParameter, result.Details);
+    }
+
+    [Theory]
     [InlineData("AllowLoadLocalInfile")]
     [InlineData("Allow Load Local Infile")]
     [InlineData("LoadLocalInfile")]
@@ -226,6 +237,15 @@ public class DbaConnectionFactoryTests
     }
 
     [Fact]
+    public void Validate_SqliteDottedFilenameIsAllowed()
+    {
+        var result = DbaConnectionFactory.Validate("sqlite", "Data Source=data..archive.db");
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.None, result.Code);
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
     public void Validate_Success()
     {
         var result = DbaConnectionFactory.Validate("sqlserver", "Server=.;Database=app;");
@@ -244,12 +264,27 @@ public class DbaConnectionFactoryTests
     }
 
     [Fact]
-    public void Validate_ReservedPort()
+    public void Validate_PrivilegedPort_IsAllowedWhenOtherwiseValid()
     {
-        var result = DbaConnectionFactory.Validate("postgresql", "Server=.;Database=app;Port=22");
-        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.InvalidParameterValue, result.Code);
-        Assert.Equal("Port", result.Details, StringComparer.OrdinalIgnoreCase);
-        Assert.Contains("reserved system range", result.Message, StringComparison.OrdinalIgnoreCase);
+        var result = DbaConnectionFactory.Validate("postgresql", "Server=.;Database=app;Port=22;SslMode=Require");
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.None, result.Code);
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData("sqlserver", "sqlserver", "DBAClientX.SqlServerGeneric.GenericExecutors")]
+    [InlineData("mssql", "sqlserver", "DBAClientX.SqlServerGeneric.GenericExecutors")]
+    [InlineData("postgres", "postgresql", "DBAClientX.PostgreSqlGeneric.GenericExecutors")]
+    [InlineData("pgsql", "postgresql", "DBAClientX.PostgreSqlGeneric.GenericExecutors")]
+    [InlineData("mysql", "mysql", "DBAClientX.MySqlGeneric.GenericExecutors")]
+    [InlineData("sqlite", "sqlite", "DBAClientX.SQLiteGeneric.GenericExecutors")]
+    [InlineData("oracle", "oracle", "DBAClientX.OracleGeneric.GenericExecutors")]
+    public void TryGetProvider_UsesSharedAliasAndExecutorDescriptor(string alias, string canonicalName, string executorTypeName)
+    {
+        Assert.True(DbaConnectionFactory.TryGetProvider(alias, out var descriptor));
+        Assert.Equal(canonicalName, descriptor.CanonicalName);
+        Assert.Equal(executorTypeName, descriptor.GenericExecutorTypeName);
     }
 
     [Fact]
@@ -260,6 +295,24 @@ public class DbaConnectionFactoryTests
 
         Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.None, result.Code);
         Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_OracleExternalAuthenticationDoesNotRequirePassword()
+    {
+        var result = DbaConnectionFactory.Validate("oracle", "Data Source=dbhost/service;User Id=/");
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.None, result.Code);
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void Validate_OraclePasswordAuthenticationRequiresPassword()
+    {
+        var result = DbaConnectionFactory.Validate("oracle", "Data Source=dbhost/service;User Id=user");
+
+        Assert.Equal(DbaConnectionFactory.ConnectionValidationErrorCode.MissingRequiredParameter, result.Code);
+        Assert.Equal("Password", result.Details);
     }
 
     [Fact]

--- a/DbaClientX.Tests/DbaConnectionFactoryTests.cs
+++ b/DbaClientX.Tests/DbaConnectionFactoryTests.cs
@@ -249,6 +249,9 @@ public class DbaConnectionFactoryTests
     [InlineData("FullUri=file:../secrets.db")]
     [InlineData("Data Source=C:..\\secrets.db")]
     [InlineData("FullUri=file:C:../secrets.db")]
+    [InlineData("FullUri=file:..%2Fsecrets.db")]
+    [InlineData("FullUri=file:..%5Csecrets.db")]
+    [InlineData("FullUri=file:%2E%2E/secrets.db")]
     public void Validate_SqlitePrefixedParentTraversal_IsRejected(string connectionString)
     {
         var result = DbaConnectionFactory.Validate("sqlite", connectionString);

--- a/DbaClientX.Tests/DbaIdentifierPathTests.cs
+++ b/DbaClientX.Tests/DbaIdentifierPathTests.cs
@@ -1,0 +1,28 @@
+using DBAClientX.DataMovement;
+
+namespace DbaClientX.Tests;
+
+public sealed class DbaIdentifierPathTests
+{
+    [Theory]
+    [InlineData("schema.table", "schema", "table")]
+    [InlineData("[schema.v1].[table.current]", "schema.v1", "table.current")]
+    [InlineData("\"schema.v1\".\"table.current\"", "schema.v1", "table.current")]
+    [InlineData("`schema.v1`.`table.current`", "schema.v1", "table.current")]
+    public void SplitSegments_PreservesDelimitedDotsAndUnquotes(string path, string expectedSchema, string expectedTable)
+    {
+        var segments = DbaIdentifierPath.SplitSegments(path);
+
+        Assert.Equal(2, segments.Count);
+        Assert.Equal(expectedSchema, DbaIdentifierPath.UnquoteSegment(segments[0]));
+        Assert.Equal(expectedTable, DbaIdentifierPath.UnquoteSegment(segments[1]));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("schema..table")]
+    [InlineData("schema.")]
+    [InlineData("\"unterminated")]
+    public void SplitSegments_RejectsInvalidPaths(string path)
+        => Assert.Throws<ArgumentException>(() => DbaIdentifierPath.SplitSegments(path));
+}

--- a/DbaClientX.Tests/DbaXProviderHelpersTests.cs
+++ b/DbaClientX.Tests/DbaXProviderHelpersTests.cs
@@ -355,6 +355,15 @@ public class DbaXProviderHelpersTests
     }
 
     [Theory]
+    [InlineData(DbaXProvider.SqlServer, "sqlserver")]
+    [InlineData(DbaXProvider.PostgreSql, "postgresql")]
+    [InlineData(DbaXProvider.MySql, "mysql")]
+    [InlineData(DbaXProvider.Oracle, "oracle")]
+    [InlineData(DbaXProvider.SQLite, "sqlite")]
+    public void GetAlias_UsesSharedProviderRegistry(DbaXProvider provider, string expectedAlias)
+        => Assert.Equal(expectedAlias, DbaXProviderHelpers.GetAlias(provider));
+
+    [Theory]
     [InlineData(":memory:", false)]
     [InlineData("Data Source=:memory:", false)]
     [InlineData("Data Source=shared;Mode=Memory;Cache=Shared", false)]

--- a/DbaClientX.Tests/PostgreSqlBulkInsertTests.cs
+++ b/DbaClientX.Tests/PostgreSqlBulkInsertTests.cs
@@ -266,6 +266,8 @@ public class PostgreSqlBulkInsertTests
     [Theory]
     [InlineData("[orders]", "COPY \"[orders]\" (\"Id\") FROM STDIN (FORMAT BINARY)")]
     [InlineData("`orders`", "COPY \"`orders`\" (\"Id\") FROM STDIN (FORMAT BINARY)")]
+    [InlineData("orders[2024", "COPY \"orders[2024\" (\"Id\") FROM STDIN (FORMAT BINARY)")]
+    [InlineData("orders`2024", "COPY \"orders`2024\" (\"Id\") FROM STDIN (FORMAT BINARY)")]
     public void BuildCopyCommand_PreservesProviderLiteralBracketAndBacktickNames(string destination, string expectedCommand)
     {
         using var pg = new InspectingPostgreSql();

--- a/DbaClientX.Tests/PostgreSqlBulkInsertTests.cs
+++ b/DbaClientX.Tests/PostgreSqlBulkInsertTests.cs
@@ -263,6 +263,20 @@ public class PostgreSqlBulkInsertTests
         Assert.Equal("COPY \"tenant.v1\".\"Rows.Current\" (\"Id\") FROM STDIN (FORMAT BINARY)", command);
     }
 
+    [Theory]
+    [InlineData("[orders]", "COPY \"[orders]\" (\"Id\") FROM STDIN (FORMAT BINARY)")]
+    [InlineData("`orders`", "COPY \"`orders`\" (\"Id\") FROM STDIN (FORMAT BINARY)")]
+    public void BuildCopyCommand_PreservesProviderLiteralBracketAndBacktickNames(string destination, string expectedCommand)
+    {
+        using var pg = new InspectingPostgreSql();
+        using var table = new DataTable();
+        table.Columns.Add("Id");
+
+        var command = pg.BuildCommand(table.Columns, destination);
+
+        Assert.Equal(expectedCommand, command);
+    }
+
     [Fact]
     public void BulkInsert_WithEmptyDestination_Throws()
     {

--- a/DbaClientX.Tests/RetryTests.cs
+++ b/DbaClientX.Tests/RetryTests.cs
@@ -115,6 +115,25 @@ public class RetryTests
         public Task<T> RunOperationAsync<T>(Func<Task<T>> operation, CancellationToken token = default) => ExecuteWithRetryAsync(operation, token);
     }
 
+    private sealed class DeterministicRetryClient : RetryClient
+    {
+        public List<TimeSpan> Delays { get; } = new();
+
+        protected override DBAClientX.TransientRetryOptions CreateTransientRetryOptions()
+            => new()
+            {
+                MaxAttempts = Math.Max(1, MaxRetryAttempts),
+                BaseDelay = RetryDelay,
+                MaxDelay = TimeSpan.FromSeconds(30),
+                JitterFactorProvider = _ => 0,
+                DelayAsync = (delay, _) =>
+                {
+                    Delays.Add(delay);
+                    return Task.CompletedTask;
+                }
+            };
+    }
+
     private class RetryNonQueryClient : DBAClientX.DatabaseClientBase
     {
         protected override bool IsTransient(Exception ex) => ex is TransientTestException;
@@ -244,5 +263,31 @@ public class RetryTests
             }, cts.Token));
 
         Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public async Task ExecuteWithRetryAsync_UsesSharedRetryOptionsAndDelayHook()
+    {
+        using var client = new DeterministicRetryClient
+        {
+            MaxRetryAttempts = 3,
+            RetryDelay = TimeSpan.FromMilliseconds(10)
+        };
+        var attempts = 0;
+
+        var result = await client.RunOperationAsync(() =>
+        {
+            attempts++;
+            if (attempts < 3)
+            {
+                throw new TransientTestException();
+            }
+
+            return Task.FromResult(42);
+        });
+
+        Assert.Equal(42, result);
+        Assert.Equal(3, attempts);
+        Assert.Equal(new[] { TimeSpan.FromMilliseconds(10), TimeSpan.FromMilliseconds(20) }, client.Delays);
     }
 }


### PR DESCRIPTION
## Summary

- add one shared provider registry for canonical names, aliases, connection validation, and generic executor discovery; PowerShell and `DbInvoker` consume it instead of maintaining separate alias switches
- route client execution and streaming-reader startup through the public `TransientRetry` engine while preserving provider classifiers, retry limits, backoff settings, cancellation, and write-retry opt-in
- make `DbInvoker` enumerate inputs lazily, share SQL/procedure execution logic, use a fixed bounded worker set, reject excessive parallelism, check affected-row overflow, and surface original synchronous executor exceptions
- promote delimiter-aware, provider-specific identifier splitting and unquoting to the Core owner; PostgreSQL COPY targets preserve both matched and unmatched literal bracket/backtick characters
- validate non-empty required connection values, accept valid privileged ports, require Oracle external authentication to use the documented `User Id=/` form without proxy attributes, and reject SQLite parent traversal hidden behind file URI, drive, or percent-encoded prefixes
- refresh the Core package documentation for current frameworks and public ownership seams

## Validation

- integrated Release solution build passed for `net472`, `net8.0`, and `net10.0` with zero warnings and errors
- full integrated tests passed: 1,130 on `net8.0` and 1,130 on `net10.0`
- focused provider, retry, identifier, invoker, bulk, table-copy, PowerShell helper, and connection-validation tests passed on both modern target frameworks
- Core, SQLite, PostgreSQL, and SQL Server packages were packed and inspected for all three target assemblies, XML docs, and README content