### PR TITLE
Preserve caller cancellation across provider APIs

### DIFF
--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -99,6 +99,10 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     /// <returns><c>true</c> when the exception is transient; otherwise, <c>false</c>.</returns>
     protected virtual bool IsTransient(Exception ex) => false;
 
+    /// <summary>Returns whether an exception represents cancellation requested through the caller's token.</summary>
+    protected static bool IsCallerCancellation(Exception exception, CancellationToken cancellationToken)
+        => exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
+
     /// <summary>
     /// Executes an operation with retry logic for transient failures.
     /// </summary>

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -874,12 +874,16 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             }
 
             object? result;
-            using (var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false))
+            using (var reader = await AwaitWithCallerCancellationAsync(
+                () => command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken),
+                cancellationToken).ConfigureAwait(false))
             {
                 var returnType = ReturnType;
                 if (returnType == ReturnType.DataRow)
                 {
-                    if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                    if (await AwaitWithCallerCancellationAsync(
+                        () => reader.ReadAsync(cancellationToken),
+                        cancellationToken).ConfigureAwait(false))
                     {
                         var table = new DataTable("Table0");
                         for (int i = 0; i < reader.FieldCount; i++)
@@ -911,7 +915,9 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
                         var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
                         dataSet.Tables.Add(table);
                         tableIndex++;
-                    } while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+                    } while (!reader.IsClosed && await AwaitWithCallerCancellationAsync(
+                        () => reader.NextResultAsync(cancellationToken),
+                        cancellationToken).ConfigureAwait(false));
 
                     result = BuildResult(dataSet);
                 }
@@ -966,10 +972,14 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             }
 
             var rows = new List<T>();
-            using (var reader = await command.ExecuteReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false))
+            using (var reader = await AwaitWithCallerCancellationAsync(
+                () => command.ExecuteReaderAsync(CommandBehavior.Default, cancellationToken),
+                cancellationToken).ConfigureAwait(false))
             {
                 initialize?.Invoke(reader);
-                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                while (await AwaitWithCallerCancellationAsync(
+                    () => reader.ReadAsync(cancellationToken),
+                    cancellationToken).ConfigureAwait(false))
                 {
                     rows.Add(map(reader));
                 }
@@ -1013,7 +1023,9 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
                 command.CommandTimeout = commandTimeout;
             }
 
-            var affected = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            var affected = await AwaitWithCallerCancellationAsync(
+                () => command.ExecuteNonQueryAsync(cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             UpdateOutputParameters(command, parameters);
             return affected;
         }
@@ -1052,7 +1064,9 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
                 command.CommandTimeout = commandTimeout;
             }
 
-            var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            var result = await AwaitWithCallerCancellationAsync(
+                () => command.ExecuteScalarAsync(cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             UpdateOutputParameters(command, parameters);
             return result;
         }, cancellationToken).ConfigureAwait(false);
@@ -1329,7 +1343,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         table.BeginLoadData();
         try
         {
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            while (await ReadWithCallerCancellationAsync(reader, cancellationToken).ConfigureAwait(false))
             {
                 reader.GetValues(values);
                 table.Rows.Add(values);
@@ -1341,6 +1355,22 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         }
 
         return table;
+    }
+
+    private static async Task<bool> ReadWithCallerCancellationAsync(
+        DbDataReader reader,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException ex) when (
+            cancellationToken.IsCancellationRequested &&
+            ex.CancellationToken != cancellationToken)
+        {
+            throw CreateCallerCancellationException(ex, cancellationToken);
+        }
     }
 
     private static string GetUniqueColumnName(string? columnName, int ordinal, HashSet<string> usedNames)

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -102,9 +102,8 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     /// <summary>Returns whether an exception carries the caller's cancellation token.</summary>
     protected static bool IsCallerCancellation(Exception exception, CancellationToken cancellationToken)
         => cancellationToken.IsCancellationRequested &&
-           ExceptionChainContains<OperationCanceledException>(
-               exception,
-               cancellationException => cancellationException.CancellationToken == cancellationToken);
+           exception is OperationCanceledException cancellationException &&
+           cancellationException.CancellationToken == cancellationToken;
 
     /// <summary>Returns whether an exception is a provider-specific representation of command cancellation.</summary>
     protected virtual bool IsProviderCancellationException(Exception exception)
@@ -1355,6 +1354,34 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         }
 
         return table;
+    }
+
+    /// <summary>
+    /// Executes a stored-procedure reader and materializes all result sets while preserving caller cancellation.
+    /// </summary>
+    /// <param name="command">Configured stored-procedure command.</param>
+    /// <param name="cancellationToken">Token used to cancel provider reader operations.</param>
+    /// <returns>A data set containing every result set returned by the command.</returns>
+    protected async Task<DataSet> ReadStoredProcedureResultsAsync(
+        DbCommand command,
+        CancellationToken cancellationToken)
+    {
+        var dataSet = new DataSet();
+        using var reader = await AwaitWithCallerCancellationAsync(
+            () => command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken),
+            cancellationToken).ConfigureAwait(false);
+        var tableIndex = 0;
+        do
+        {
+            var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
+            dataSet.Tables.Add(table);
+            tableIndex++;
+        }
+        while (!reader.IsClosed && await AwaitWithCallerCancellationAsync(
+            () => reader.NextResultAsync(cancellationToken),
+            cancellationToken).ConfigureAwait(false));
+
+        return dataSet;
     }
 
     private static async Task<bool> ReadWithCallerCancellationAsync(

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -99,13 +99,16 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     /// <returns><c>true</c> when the exception is transient; otherwise, <c>false</c>.</returns>
     protected virtual bool IsTransient(Exception ex) => false;
 
-    /// <summary>Returns whether an exception represents cancellation requested through the caller's token.</summary>
+    /// <summary>Returns whether an exception carries the caller's cancellation token.</summary>
     protected static bool IsCallerCancellation(Exception exception, CancellationToken cancellationToken)
-        => exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
+        => cancellationToken.IsCancellationRequested &&
+           ExceptionChainContains<OperationCanceledException>(
+               exception,
+               cancellationException => cancellationException.CancellationToken == cancellationToken);
 
     /// <summary>Returns whether an exception is a provider-specific representation of command cancellation.</summary>
     protected virtual bool IsProviderCancellationException(Exception exception)
-        => ExceptionChainContains<OperationCanceledException>(exception, static _ => true);
+        => false;
 
     /// <summary>Searches an exception and its inner-exception chain for a matching provider failure.</summary>
     protected static bool ExceptionChainContains<TException>(
@@ -169,8 +172,15 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         {
             return await operation().ConfigureAwait(false);
         }
-        catch (Exception ex) when (
+        catch (OperationCanceledException ex) when (
             !IsCallerCancellation(ex, cancellationToken) &&
+            cancellationToken.IsCancellationRequested)
+        {
+            // This wrapper encloses only the provider await, so an unassociated OCE still has
+            // provider provenance. Do not apply this inference around user callbacks.
+            throw CreateCallerCancellationException(ex, cancellationToken);
+        }
+        catch (Exception ex) when (
             cancellationToken.IsCancellationRequested &&
             IsProviderCancellationException(ex))
         {
@@ -187,8 +197,15 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         {
             await operation().ConfigureAwait(false);
         }
-        catch (Exception ex) when (
+        catch (OperationCanceledException ex) when (
             !IsCallerCancellation(ex, cancellationToken) &&
+            cancellationToken.IsCancellationRequested)
+        {
+            // This wrapper encloses only the provider await, so an unassociated OCE still has
+            // provider provenance. Do not apply this inference around user callbacks.
+            throw CreateCallerCancellationException(ex, cancellationToken);
+        }
+        catch (Exception ex) when (
             cancellationToken.IsCancellationRequested &&
             IsProviderCancellationException(ex))
         {

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -103,6 +103,32 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     protected static bool IsCallerCancellation(Exception exception, CancellationToken cancellationToken)
         => exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
 
+    /// <summary>Returns whether an exception is a provider-specific representation of command cancellation.</summary>
+    protected virtual bool IsProviderCancellationException(Exception exception)
+        => ExceptionChainContains<OperationCanceledException>(exception, static _ => true);
+
+    /// <summary>Searches an exception and its inner-exception chain for a matching provider failure.</summary>
+    protected static bool ExceptionChainContains<TException>(
+        Exception exception,
+        Func<TException, bool> predicate)
+        where TException : Exception
+    {
+        if (predicate == null)
+        {
+            throw new ArgumentNullException(nameof(predicate));
+        }
+
+        for (Exception? current = exception; current != null; current = current.InnerException)
+        {
+            if (current is TException candidate && predicate(candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// Creates the public exception for a failed asynchronous database operation while preserving caller cancellation.
     /// </summary>
@@ -111,13 +137,13 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
     /// <see cref="OperationCanceledException"/>. Once the caller's token is canceled, normalize that provider-specific
     /// failure back to the standard cancellation contract and retain the original exception as diagnostic context.
     /// </remarks>
-    protected static Exception CreateQueryExecutionOrCancellationException(
+    protected Exception CreateQueryExecutionOrCancellationException(
         string message,
         string commandText,
         Exception exception,
         CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested)
+        if (cancellationToken.IsCancellationRequested && IsProviderCancellationException(exception))
         {
             return CreateCallerCancellationException(exception, cancellationToken);
         }
@@ -135,7 +161,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             cancellationToken);
 
     /// <summary>Awaits an ADO.NET operation and normalizes provider-specific cancellation failures.</summary>
-    protected static async Task<T> AwaitWithCallerCancellationAsync<T>(
+    protected async Task<T> AwaitWithCallerCancellationAsync<T>(
         Func<Task<T>> operation,
         CancellationToken cancellationToken)
     {
@@ -143,14 +169,17 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         {
             return await operation().ConfigureAwait(false);
         }
-        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken) && cancellationToken.IsCancellationRequested)
+        catch (Exception ex) when (
+            !IsCallerCancellation(ex, cancellationToken) &&
+            cancellationToken.IsCancellationRequested &&
+            IsProviderCancellationException(ex))
         {
             throw CreateCallerCancellationException(ex, cancellationToken);
         }
     }
 
     /// <summary>Awaits a non-result ADO.NET operation and normalizes provider-specific cancellation failures.</summary>
-    protected static async Task AwaitWithCallerCancellationAsync(
+    protected async Task AwaitWithCallerCancellationAsync(
         Func<Task> operation,
         CancellationToken cancellationToken)
     {
@@ -158,7 +187,10 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         {
             await operation().ConfigureAwait(false);
         }
-        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken) && cancellationToken.IsCancellationRequested)
+        catch (Exception ex) when (
+            !IsCallerCancellation(ex, cancellationToken) &&
+            cancellationToken.IsCancellationRequested &&
+            IsProviderCancellationException(ex))
         {
             throw CreateCallerCancellationException(ex, cancellationToken);
         }
@@ -1280,9 +1312,7 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         table.BeginLoadData();
         try
         {
-            while (await AwaitWithCallerCancellationAsync(
-                () => reader.ReadAsync(cancellationToken),
-                cancellationToken).ConfigureAwait(false))
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 reader.GetValues(values);
                 table.Rows.Add(values);

--- a/DbaClientX.Core/DatabaseClientBase.cs
+++ b/DbaClientX.Core/DatabaseClientBase.cs
@@ -104,6 +104,67 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         => exception is OperationCanceledException && cancellationToken.IsCancellationRequested;
 
     /// <summary>
+    /// Creates the public exception for a failed asynchronous database operation while preserving caller cancellation.
+    /// </summary>
+    /// <remarks>
+    /// Some ADO.NET providers report a canceled command as a provider exception instead of
+    /// <see cref="OperationCanceledException"/>. Once the caller's token is canceled, normalize that provider-specific
+    /// failure back to the standard cancellation contract and retain the original exception as diagnostic context.
+    /// </remarks>
+    protected static Exception CreateQueryExecutionOrCancellationException(
+        string message,
+        string commandText,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return CreateCallerCancellationException(exception, cancellationToken);
+        }
+
+        return new DbaQueryExecutionException(message, commandText, exception);
+    }
+
+    /// <summary>Creates a standard caller-cancellation exception while retaining the provider failure.</summary>
+    protected static OperationCanceledException CreateCallerCancellationException(
+        Exception exception,
+        CancellationToken cancellationToken)
+        => new(
+            "The database operation was canceled by the caller.",
+            exception,
+            cancellationToken);
+
+    /// <summary>Awaits an ADO.NET operation and normalizes provider-specific cancellation failures.</summary>
+    protected static async Task<T> AwaitWithCallerCancellationAsync<T>(
+        Func<Task<T>> operation,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await operation().ConfigureAwait(false);
+        }
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken) && cancellationToken.IsCancellationRequested)
+        {
+            throw CreateCallerCancellationException(ex, cancellationToken);
+        }
+    }
+
+    /// <summary>Awaits a non-result ADO.NET operation and normalizes provider-specific cancellation failures.</summary>
+    protected static async Task AwaitWithCallerCancellationAsync(
+        Func<Task> operation,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await operation().ConfigureAwait(false);
+        }
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken) && cancellationToken.IsCancellationRequested)
+        {
+            throw CreateCallerCancellationException(ex, cancellationToken);
+        }
+    }
+
+    /// <summary>
     /// Executes an operation with retry logic for transient failures.
     /// </summary>
     /// <typeparam name="T">The type of the result produced by the operation.</typeparam>
@@ -995,7 +1056,9 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             {
                 try
                 {
-                    return await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
+                    return await AwaitWithCallerCancellationAsync(
+                        () => command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken),
+                        cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (IsTransient(ex) && ++attempt < maxAttempts)
                 {
@@ -1016,7 +1079,9 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             table.Columns.Add(reader.GetName(i), reader.GetFieldType(i));
         }
 
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        while (await AwaitWithCallerCancellationAsync(
+            () => reader.ReadAsync(cancellationToken),
+            cancellationToken).ConfigureAwait(false))
         {
             var row = table.NewRow();
             for (int i = 0; i < reader.FieldCount; i++)
@@ -1085,7 +1150,9 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
             {
                 try
                 {
-                    return await command.ExecuteReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false);
+                    return await AwaitWithCallerCancellationAsync(
+                        () => command.ExecuteReaderAsync(CommandBehavior.Default, cancellationToken),
+                        cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (IsTransient(ex) && ++attempt < maxAttempts)
                 {
@@ -1100,7 +1167,9 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
 
         await using var reader = await OpenReaderAsync().ConfigureAwait(false);
         initialize?.Invoke(reader);
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        while (await AwaitWithCallerCancellationAsync(
+            () => reader.ReadAsync(cancellationToken),
+            cancellationToken).ConfigureAwait(false))
         {
             yield return map(reader);
         }
@@ -1211,7 +1280,9 @@ public abstract class DatabaseClientBase : IDisposable, IAsyncDisposable
         table.BeginLoadData();
         try
         {
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            while (await AwaitWithCallerCancellationAsync(
+                () => reader.ReadAsync(cancellationToken),
+                cancellationToken).ConfigureAwait(false))
             {
                 reader.GetValues(values);
                 table.Rows.Add(values);

--- a/DbaClientX.MySql/MySql.AsyncCommandExecution.cs
+++ b/DbaClientX.MySql/MySql.AsyncCommandExecution.cs
@@ -54,7 +54,7 @@ public partial class MySql
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
         }
@@ -146,7 +146,7 @@ public partial class MySql
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteMappedQueryAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
         }
@@ -199,7 +199,7 @@ public partial class MySql
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await base.ExecuteNonQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
         }
@@ -253,7 +253,7 @@ public partial class MySql
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteScalarAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
         }

--- a/DbaClientX.MySql/MySql.AsyncCommandExecution.cs
+++ b/DbaClientX.MySql/MySql.AsyncCommandExecution.cs
@@ -56,7 +56,7 @@ public partial class MySql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -148,7 +148,7 @@ public partial class MySql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute mapped query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -201,7 +201,7 @@ public partial class MySql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute non-query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -255,7 +255,7 @@ public partial class MySql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute scalar query.", query, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.MySql/MySql.AsyncCommandExecution.cs
+++ b/DbaClientX.MySql/MySql.AsyncCommandExecution.cs
@@ -287,7 +287,9 @@ public partial class MySql
         var connection = CreateConnection(connectionString);
         try
         {
-            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => OpenConnectionAsync(connection, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             return (connection, null, true);
         }
         catch

--- a/DbaClientX.MySql/MySql.BulkOperations.cs
+++ b/DbaClientX.MySql/MySql.BulkOperations.cs
@@ -146,7 +146,7 @@ public partial class MySql
         {
             throw;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
         }

--- a/DbaClientX.MySql/MySql.BulkOperations.cs
+++ b/DbaClientX.MySql/MySql.BulkOperations.cs
@@ -148,7 +148,7 @@ public partial class MySql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute bulk insert.", destinationTable, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.MySql/MySql.Cancellation.cs
+++ b/DbaClientX.MySql/MySql.Cancellation.cs
@@ -1,0 +1,20 @@
+using System;
+using MySqlConnector;
+
+namespace DBAClientX;
+
+public partial class MySql
+{
+    /// <inheritdoc />
+    protected override bool IsProviderCancellationException(Exception exception)
+    {
+        if (base.IsProviderCancellationException(exception))
+        {
+            return true;
+        }
+
+        return ExceptionChainContains<MySqlException>(
+            exception,
+            static mySqlException => mySqlException.ErrorCode == MySqlErrorCode.QueryInterrupted);
+    }
+}

--- a/DbaClientX.MySql/MySql.StoredProcedures.cs
+++ b/DbaClientX.MySql/MySql.StoredProcedures.cs
@@ -151,7 +151,7 @@ public partial class MySql
             UpdateOutputParameters(command, parameters);
             return result;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
         }
@@ -259,7 +259,7 @@ public partial class MySql
 
             return BuildResult(dataSet);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
         }

--- a/DbaClientX.MySql/MySql.StoredProcedures.cs
+++ b/DbaClientX.MySql/MySql.StoredProcedures.cs
@@ -153,7 +153,7 @@ public partial class MySql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute stored procedure.", procedure, ex, cancellationToken);
         }
         finally
         {
@@ -261,7 +261,7 @@ public partial class MySql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute stored procedure.", procedure, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.MySql/MySql.StoredProcedures.cs
+++ b/DbaClientX.MySql/MySql.StoredProcedures.cs
@@ -136,16 +136,7 @@ public partial class MySql
             AddParameters(command, parameters, dbTypes, parameterDirections);
             ApplyCommandTimeout(command);
 
-            var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
-            var tableIndex = 0;
-            do
-            {
-                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
-                dataSet.Tables.Add(table);
-                tableIndex++;
-            }
-            while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+            var dataSet = await ReadStoredProcedureResultsAsync(command, cancellationToken).ConfigureAwait(false);
 
             var result = BuildResult(dataSet);
             UpdateOutputParameters(command, parameters);
@@ -246,16 +237,7 @@ public partial class MySql
             AddParameters(command, parameters);
             ApplyCommandTimeout(command);
 
-            var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
-            var tableIndex = 0;
-            do
-            {
-                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
-                dataSet.Tables.Add(table);
-                tableIndex++;
-            }
-            while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+            var dataSet = await ReadStoredProcedureResultsAsync(command, cancellationToken).ConfigureAwait(false);
 
             return BuildResult(dataSet);
         }

--- a/DbaClientX.MySql/MySql.Transactions.cs
+++ b/DbaClientX.MySql/MySql.Transactions.cs
@@ -95,7 +95,9 @@ public partial class MySql
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
 
             connection = CreateConnection(connectionString);
-            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => OpenConnectionAsync(connection, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             transaction = await BeginDbTransactionAsync(connection, isolationLevel, cancellationToken).ConfigureAwait(false);
 
             lock (_syncRoot)

--- a/DbaClientX.Oracle/Oracle.AsyncCommandExecution.cs
+++ b/DbaClientX.Oracle/Oracle.AsyncCommandExecution.cs
@@ -54,7 +54,7 @@ public partial class Oracle
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
         }
@@ -146,7 +146,7 @@ public partial class Oracle
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteMappedQueryAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
         }
@@ -200,7 +200,7 @@ public partial class Oracle
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteScalarAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
         }
@@ -234,7 +234,7 @@ public partial class Oracle
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await base.ExecuteNonQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
         }
@@ -271,7 +271,7 @@ public partial class Oracle
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteNonQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
         }

--- a/DbaClientX.Oracle/Oracle.AsyncCommandExecution.cs
+++ b/DbaClientX.Oracle/Oracle.AsyncCommandExecution.cs
@@ -56,7 +56,7 @@ public partial class Oracle
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -148,7 +148,7 @@ public partial class Oracle
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute mapped query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -202,7 +202,7 @@ public partial class Oracle
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute scalar query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -236,7 +236,7 @@ public partial class Oracle
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute non-query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -273,7 +273,7 @@ public partial class Oracle
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute non-query.", query, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.Oracle/Oracle.AsyncCommandExecution.cs
+++ b/DbaClientX.Oracle/Oracle.AsyncCommandExecution.cs
@@ -305,7 +305,9 @@ public partial class Oracle
         var connection = CreateConnection(connectionString);
         try
         {
-            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => OpenConnectionAsync(connection, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             return (connection, null, true);
         }
         catch

--- a/DbaClientX.Oracle/Oracle.BulkOperations.cs
+++ b/DbaClientX.Oracle/Oracle.BulkOperations.cs
@@ -160,7 +160,7 @@ public partial class Oracle
         {
             throw;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
         }

--- a/DbaClientX.Oracle/Oracle.BulkOperations.cs
+++ b/DbaClientX.Oracle/Oracle.BulkOperations.cs
@@ -162,7 +162,7 @@ public partial class Oracle
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute bulk insert.", destinationTable, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.Oracle/Oracle.Cancellation.cs
+++ b/DbaClientX.Oracle/Oracle.Cancellation.cs
@@ -1,0 +1,22 @@
+using System;
+using Oracle.ManagedDataAccess.Client;
+
+namespace DBAClientX;
+
+public partial class Oracle
+{
+    private const int UserRequestedCancellationErrorNumber = 1013;
+
+    /// <inheritdoc />
+    protected override bool IsProviderCancellationException(Exception exception)
+    {
+        if (base.IsProviderCancellationException(exception))
+        {
+            return true;
+        }
+
+        return ExceptionChainContains<OracleException>(
+            exception,
+            static oracleException => oracleException.Number == UserRequestedCancellationErrorNumber);
+    }
+}

--- a/DbaClientX.Oracle/Oracle.Cancellation.cs
+++ b/DbaClientX.Oracle/Oracle.Cancellation.cs
@@ -1,22 +1,9 @@
 using System;
-using Oracle.ManagedDataAccess.Client;
-
 namespace DBAClientX;
 
 public partial class Oracle
 {
-    private const int UserRequestedCancellationErrorNumber = 1013;
-
     /// <inheritdoc />
     protected override bool IsProviderCancellationException(Exception exception)
-    {
-        if (base.IsProviderCancellationException(exception))
-        {
-            return true;
-        }
-
-        return ExceptionChainContains<OracleException>(
-            exception,
-            static oracleException => oracleException.Number == UserRequestedCancellationErrorNumber);
-    }
+        => base.IsProviderCancellationException(exception);
 }

--- a/DbaClientX.Oracle/Oracle.StoredProcedures.cs
+++ b/DbaClientX.Oracle/Oracle.StoredProcedures.cs
@@ -116,16 +116,7 @@ public partial class Oracle
             AddParameters(command, parameters, dbTypes, parameterDirections);
             ApplyCommandTimeout(command);
 
-            var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
-            var tableIndex = 0;
-            do
-            {
-                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
-                dataSet.Tables.Add(table);
-                tableIndex++;
-            }
-            while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+            var dataSet = await ReadStoredProcedureResultsAsync(command, cancellationToken).ConfigureAwait(false);
 
             var result = BuildResult(dataSet);
             UpdateOutputParameters(command, parameters);
@@ -246,16 +237,7 @@ public partial class Oracle
             AddParameters(command, parameters);
             ApplyCommandTimeout(command);
 
-            var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
-            var tableIndex = 0;
-            do
-            {
-                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
-                dataSet.Tables.Add(table);
-                tableIndex++;
-            }
-            while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+            var dataSet = await ReadStoredProcedureResultsAsync(command, cancellationToken).ConfigureAwait(false);
 
             return BuildResult(dataSet);
         }

--- a/DbaClientX.Oracle/Oracle.StoredProcedures.cs
+++ b/DbaClientX.Oracle/Oracle.StoredProcedures.cs
@@ -133,7 +133,7 @@ public partial class Oracle
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute stored procedure.", procedure, ex, cancellationToken);
         }
         finally
         {
@@ -261,7 +261,7 @@ public partial class Oracle
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute stored procedure.", procedure, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.Oracle/Oracle.StoredProcedures.cs
+++ b/DbaClientX.Oracle/Oracle.StoredProcedures.cs
@@ -131,7 +131,7 @@ public partial class Oracle
             UpdateOutputParameters(command, parameters);
             return result;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
         }
@@ -259,16 +259,13 @@ public partial class Oracle
 
             return BuildResult(dataSet);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
         }
         finally
         {
-            if (dispose)
-            {
-                DisposeConnection(connection!);
-            }
+            await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
         }
     }
 

--- a/DbaClientX.Oracle/Oracle.Transactions.cs
+++ b/DbaClientX.Oracle/Oracle.Transactions.cs
@@ -94,7 +94,9 @@ public partial class Oracle
 
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
             connection = CreateConnection(connectionString);
-            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => OpenConnectionAsync(connection, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             transaction = await BeginDbTransactionAsync(connection, isolationLevel, cancellationToken).ConfigureAwait(false);
             lock (_syncRoot)
             {

--- a/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
@@ -56,7 +56,7 @@ public partial class PostgreSql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -148,7 +148,7 @@ public partial class PostgreSql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute mapped query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -202,7 +202,7 @@ public partial class PostgreSql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute non-query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -256,7 +256,7 @@ public partial class PostgreSql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute scalar query.", query, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
@@ -54,7 +54,7 @@ public partial class PostgreSql
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
         }
@@ -146,7 +146,7 @@ public partial class PostgreSql
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteMappedQueryAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
         }
@@ -200,7 +200,7 @@ public partial class PostgreSql
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await base.ExecuteNonQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
         }
@@ -254,7 +254,7 @@ public partial class PostgreSql
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteScalarAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
         }

--- a/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.AsyncCommandExecution.cs
@@ -288,7 +288,9 @@ public partial class PostgreSql
         var connection = CreateConnection(connectionString);
         try
         {
-            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => OpenConnectionAsync(connection, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             return (connection, null, true);
         }
         catch

--- a/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
@@ -142,7 +142,7 @@ public partial class PostgreSql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute bulk insert.", destinationTable, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.BulkOperations.cs
@@ -140,7 +140,7 @@ public partial class PostgreSql
         {
             throw;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
         }

--- a/DbaClientX.PostgreSql/PostgreSql.Cancellation.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.Cancellation.cs
@@ -15,9 +15,12 @@ public partial class PostgreSql
 
         return ExceptionChainContains<PostgresException>(
             exception,
-            static postgresException => string.Equals(
-                postgresException.SqlState,
-                PostgresErrorCodes.QueryCanceled,
-                StringComparison.Ordinal));
+            static postgresException =>
+                string.Equals(
+                    postgresException.SqlState,
+                    PostgresErrorCodes.QueryCanceled,
+                    StringComparison.Ordinal) &&
+                (postgresException.MessageText.IndexOf("user request", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                 (postgresException.Detail?.IndexOf("user request", StringComparison.OrdinalIgnoreCase) ?? -1) >= 0));
     }
 }

--- a/DbaClientX.PostgreSql/PostgreSql.Cancellation.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.Cancellation.cs
@@ -1,0 +1,23 @@
+using System;
+using Npgsql;
+
+namespace DBAClientX;
+
+public partial class PostgreSql
+{
+    /// <inheritdoc />
+    protected override bool IsProviderCancellationException(Exception exception)
+    {
+        if (base.IsProviderCancellationException(exception))
+        {
+            return true;
+        }
+
+        return ExceptionChainContains<PostgresException>(
+            exception,
+            static postgresException => string.Equals(
+                postgresException.SqlState,
+                PostgresErrorCodes.QueryCanceled,
+                StringComparison.Ordinal));
+    }
+}

--- a/DbaClientX.PostgreSql/PostgreSql.StoredProcedures.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.StoredProcedures.cs
@@ -117,16 +117,7 @@ public partial class PostgreSql
             AddParameters(command, parameters, dbTypes, parameterDirections);
             ApplyCommandTimeout(command);
 
-            var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
-            var tableIndex = 0;
-            do
-            {
-                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
-                dataSet.Tables.Add(table);
-                tableIndex++;
-            }
-            while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+            var dataSet = await ReadStoredProcedureResultsAsync(command, cancellationToken).ConfigureAwait(false);
 
             var result = BuildResult(dataSet);
             UpdateOutputParameters(command, parameters);
@@ -247,16 +238,7 @@ public partial class PostgreSql
             AddParameters(command, parameters);
             ApplyCommandTimeout(command);
 
-            var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
-            var tableIndex = 0;
-            do
-            {
-                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
-                dataSet.Tables.Add(table);
-                tableIndex++;
-            }
-            while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+            var dataSet = await ReadStoredProcedureResultsAsync(command, cancellationToken).ConfigureAwait(false);
 
             return BuildResult(dataSet);
         }

--- a/DbaClientX.PostgreSql/PostgreSql.StoredProcedures.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.StoredProcedures.cs
@@ -132,7 +132,7 @@ public partial class PostgreSql
             UpdateOutputParameters(command, parameters);
             return result;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
         }
@@ -260,16 +260,13 @@ public partial class PostgreSql
 
             return BuildResult(dataSet);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
         }
         finally
         {
-            if (dispose)
-            {
-                DisposeConnection(connection!);
-            }
+            await DisposeOwnedResourceAsync(connection, dispose, DisposeConnectionAsync).ConfigureAwait(false);
         }
     }
 

--- a/DbaClientX.PostgreSql/PostgreSql.StoredProcedures.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.StoredProcedures.cs
@@ -134,7 +134,7 @@ public partial class PostgreSql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute stored procedure.", procedure, ex, cancellationToken);
         }
         finally
         {
@@ -262,7 +262,7 @@ public partial class PostgreSql
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute stored procedure.", procedure, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.PostgreSql/PostgreSql.Transactions.cs
+++ b/DbaClientX.PostgreSql/PostgreSql.Transactions.cs
@@ -95,7 +95,9 @@ public partial class PostgreSql
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
 
             connection = CreateConnection(connectionString);
-            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => OpenConnectionAsync(connection, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             transaction = await BeginDbTransactionAsync(connection, isolationLevel, cancellationToken).ConfigureAwait(false);
 
             lock (_syncRoot)

--- a/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
@@ -36,7 +36,7 @@ public partial class SQLite
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -126,7 +126,7 @@ public partial class SQLite
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute mapped query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -159,7 +159,7 @@ public partial class SQLite
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -238,7 +238,7 @@ public partial class SQLite
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute mapped query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -272,7 +272,7 @@ public partial class SQLite
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute non-query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -306,7 +306,7 @@ public partial class SQLite
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute scalar query.", query, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
@@ -217,11 +217,15 @@ public partial class SQLite
                     command.CommandTimeout = commandTimeout;
                 }
 
-                using var reader = await command.ExecuteReaderAsync(CommandBehavior.SingleResult, cancellationToken).ConfigureAwait(false);
+                using var reader = await AwaitWithCallerCancellationAsync(
+                    () => command.ExecuteReaderAsync(CommandBehavior.SingleResult, cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
                 initialize?.Invoke(reader);
 
                 var results = new List<T>();
-                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                while (await AwaitWithCallerCancellationAsync(
+                    () => reader.ReadAsync(cancellationToken),
+                    cancellationToken).ConfigureAwait(false))
                 {
                     results.Add(map(reader));
                 }
@@ -380,7 +384,9 @@ public partial class SQLite
         var connection = new SqliteConnection(connectionString);
         try
         {
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => connection.OpenAsync(cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             await ApplyBusyTimeoutAsync(
                 connection,
                 ResolveConnectionBusyTimeout(connectionString, busyTimeoutMs),

--- a/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
@@ -232,7 +232,7 @@ public partial class SQLite
 
             return list;
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException ex) when (IsCallerCancellation(ex, cancellationToken))
         {
             throw;
         }

--- a/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
@@ -34,7 +34,7 @@ public partial class SQLite
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await base.ExecuteQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
         }
@@ -72,7 +72,7 @@ public partial class SQLite
         {
             throw;
         }
-        catch (Exception ex) when (ex is DbException or InvalidOperationException or ArgumentException)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken) && (ex is DbException or InvalidOperationException or ArgumentException))
         {
             throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
         }
@@ -124,7 +124,7 @@ public partial class SQLite
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteMappedQueryAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
         }
@@ -157,7 +157,7 @@ public partial class SQLite
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await base.ExecuteQueryAsync(connection, null, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
         }
@@ -236,7 +236,7 @@ public partial class SQLite
         {
             throw;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
         }
@@ -270,7 +270,7 @@ public partial class SQLite
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await base.ExecuteNonQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
         }
@@ -304,7 +304,7 @@ public partial class SQLite
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await base.ExecuteScalarAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
         }

--- a/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
@@ -32,7 +32,7 @@ public partial class SQLite
         {
             (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             var dbTypes = ConvertParameterTypes(parameterTypes);
-            return await base.ExecuteQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+            return await ExecuteResolvedQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
@@ -66,7 +66,7 @@ public partial class SQLite
         {
             (connection, transaction, dispose) = await ResolveConnectionAsync(normalizedConnectionString, useTransaction, cancellationToken).ConfigureAwait(false);
             var dbTypes = ConvertParameterTypes(parameterTypes);
-            return await base.ExecuteQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+            return await ExecuteResolvedQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
         catch (DbaTransactionException)
         {
@@ -74,7 +74,7 @@ public partial class SQLite
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken) && (ex is DbException or InvalidOperationException or ArgumentException))
         {
-            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -155,7 +155,7 @@ public partial class SQLite
         {
             (connection, _, dispose) = await ResolveConnectionAsync(connectionString, useTransaction: false, cancellationToken, busyTimeoutMs).ConfigureAwait(false);
             var dbTypes = ConvertParameterTypes(parameterTypes);
-            return await base.ExecuteQueryAsync(connection, null, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
+            return await ExecuteResolvedQueryAsync(connection, null, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
@@ -348,6 +348,24 @@ public partial class SQLite
             throw;
         }
     }
+
+    /// <summary>Executes a query after the SQLite connection and optional transaction have been resolved.</summary>
+    protected virtual Task<object?> ExecuteResolvedQueryAsync(
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        string query,
+        IDictionary<string, object?>? parameters,
+        CancellationToken cancellationToken,
+        IDictionary<string, DbType>? parameterTypes,
+        IDictionary<string, ParameterDirection>? parameterDirections)
+        => base.ExecuteQueryAsync(
+            connection,
+            transaction,
+            query,
+            parameters,
+            cancellationToken,
+            parameterTypes,
+            parameterDirections);
 
     private static ValueTask DisposeSQLiteConnectionAsync(SqliteConnection connection)
     {

--- a/DbaClientX.SQLite/SQLite.AsyncSession.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncSession.cs
@@ -42,8 +42,8 @@ public partial class SQLite {
                 query,
                 parameters,
                 cancellationToken).ConfigureAwait(false);
-        } catch (Exception ex) when (ex is SqliteException or InvalidOperationException) {
-            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+        } catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken) && ex is (SqliteException or InvalidOperationException)) {
+            throw CreateQueryExecutionOrCancellationException("Failed to execute non-query.", query, ex, cancellationToken);
         }
     }
 
@@ -61,8 +61,8 @@ public partial class SQLite {
                 query,
                 parameters,
                 cancellationToken).ConfigureAwait(false);
-        } catch (Exception ex) when (ex is SqliteException or InvalidOperationException) {
-            throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
+        } catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken) && ex is (SqliteException or InvalidOperationException)) {
+            throw CreateQueryExecutionOrCancellationException("Failed to execute scalar query.", query, ex, cancellationToken);
         }
     }
 
@@ -88,8 +88,8 @@ public partial class SQLite {
                 initialize,
                 parameters,
                 cancellationToken).ConfigureAwait(false);
-        } catch (Exception ex) when (ex is SqliteException or InvalidOperationException) {
-            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
+        } catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken) && ex is (SqliteException or InvalidOperationException)) {
+            throw CreateQueryExecutionOrCancellationException("Failed to execute mapped query.", query, ex, cancellationToken);
         }
     }
 

--- a/DbaClientX.SQLite/SQLite.BulkOperations.cs
+++ b/DbaClientX.SQLite/SQLite.BulkOperations.cs
@@ -236,7 +236,7 @@ public partial class SQLite
                 throw;
             }
 
-            throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute bulk insert.", destinationTable, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.SQLite/SQLite.BulkOperations.cs
+++ b/DbaClientX.SQLite/SQLite.BulkOperations.cs
@@ -231,6 +231,11 @@ public partial class SQLite
 #endif
             }
 
+            if (IsCallerCancellation(ex, cancellationToken))
+            {
+                throw;
+            }
+
             throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
         }
         finally

--- a/DbaClientX.SQLite/SQLite.Cancellation.cs
+++ b/DbaClientX.SQLite/SQLite.Cancellation.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.Data.Sqlite;
+
+namespace DBAClientX;
+
+public partial class SQLite
+{
+    private const int SqliteInterruptErrorCode = 9;
+
+    /// <inheritdoc />
+    protected override bool IsProviderCancellationException(Exception exception)
+    {
+        if (base.IsProviderCancellationException(exception))
+        {
+            return true;
+        }
+
+        return ExceptionChainContains<SqliteException>(
+            exception,
+            static sqliteException => sqliteException.SqliteErrorCode == SqliteInterruptErrorCode);
+    }
+}

--- a/DbaClientX.SQLite/SQLite.Diagnostics.cs
+++ b/DbaClientX.SQLite/SQLite.Diagnostics.cs
@@ -39,7 +39,9 @@ public partial class SQLite
             }
 
             using var connection = new SqliteConnection(BuildConnectionString(fullPath, readOnly: true, busyTimeoutMs: busyTimeoutMs));
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => connection.OpenAsync(cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             await ApplyBusyTimeoutAsync(connection, busyTimeoutMs, cancellationToken).ConfigureAwait(false);
 
             diagnostics.CanConnect = true;

--- a/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.Execution.cs
@@ -112,9 +112,11 @@ public partial class SQLite
                 }
             }
         }
-        catch (SqliteException) when (cancellationToken.IsCancellationRequested)
+        catch (SqliteException ex) when (
+            cancellationToken.IsCancellationRequested &&
+            IsProviderCancellationException(ex))
         {
-            throw new OperationCanceledException(cancellationToken);
+            throw CreateCallerCancellationException(ex, cancellationToken);
         }
 
         stopwatch.Stop();
@@ -277,9 +279,11 @@ public partial class SQLite
                 Elapsed = stopwatch.Elapsed
             };
         }
-        catch (SqliteException) when (cancellationToken.IsCancellationRequested)
+        catch (SqliteException ex) when (
+            cancellationToken.IsCancellationRequested &&
+            IsProviderCancellationException(ex))
         {
-            throw new OperationCanceledException(cancellationToken);
+            throw CreateCallerCancellationException(ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.SQLite/SQLite.Maintenance.cs
+++ b/DbaClientX.SQLite/SQLite.Maintenance.cs
@@ -199,9 +199,11 @@ public partial class SQLite
             command.ExecuteNonQuery();
             cancellationToken.ThrowIfCancellationRequested();
         }
-        catch (SqliteException) when (cancellationToken.IsCancellationRequested)
+        catch (SqliteException ex) when (
+            cancellationToken.IsCancellationRequested &&
+            IsProviderCancellationException(ex))
         {
-            throw new OperationCanceledException(cancellationToken);
+            throw CreateCallerCancellationException(ex, cancellationToken);
         }
         catch (OperationCanceledException)
         {

--- a/DbaClientX.SQLite/SQLite.Transactions.cs
+++ b/DbaClientX.SQLite/SQLite.Transactions.cs
@@ -98,7 +98,9 @@ public partial class SQLite
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
 
             connection = new SqliteConnection(connectionString);
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => connection.OpenAsync(cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             await ApplyBusyTimeoutAsync(connection, busyTimeoutMs: null, cancellationToken).ConfigureAwait(false);
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
             transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
@@ -477,7 +479,9 @@ public partial class SQLite
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
 
             connection = new SqliteConnection(connectionString);
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => connection.OpenAsync(cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             await ApplyBusyTimeoutAsync(connection, busyTimeoutMs: null, cancellationToken).ConfigureAwait(false);
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
             transaction = (SqliteTransaction)await connection.BeginTransactionAsync(isolationLevel, cancellationToken).ConfigureAwait(false);

--- a/DbaClientX.SqlServer/SqlServer.AsyncCommandExecution.cs
+++ b/DbaClientX.SqlServer/SqlServer.AsyncCommandExecution.cs
@@ -56,7 +56,7 @@ public partial class SqlServer
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute non-query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -90,7 +90,7 @@ public partial class SqlServer
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -145,7 +145,7 @@ public partial class SqlServer
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute scalar query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -239,7 +239,7 @@ public partial class SqlServer
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute mapped query.", query, ex, cancellationToken);
         }
         finally
         {
@@ -277,7 +277,7 @@ public partial class SqlServer
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute scalar query.", query, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.SqlServer/SqlServer.AsyncCommandExecution.cs
+++ b/DbaClientX.SqlServer/SqlServer.AsyncCommandExecution.cs
@@ -54,7 +54,7 @@ public partial class SqlServer
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await base.ExecuteNonQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute non-query.", query, ex);
         }
@@ -88,7 +88,7 @@ public partial class SqlServer
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteQueryAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute query.", query, ex);
         }
@@ -143,7 +143,7 @@ public partial class SqlServer
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteScalarAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
         }
@@ -237,7 +237,7 @@ public partial class SqlServer
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteMappedQueryAsync(connection, transaction, query, map, initialize, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute mapped query.", query, ex);
         }
@@ -275,7 +275,7 @@ public partial class SqlServer
             var dbTypes = ConvertParameterTypes(parameterTypes);
             return await ExecuteScalarAsync(connection, transaction, query, parameters, cancellationToken, dbTypes, parameterDirections).ConfigureAwait(false);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute scalar query.", query, ex);
         }

--- a/DbaClientX.SqlServer/SqlServer.BulkDataReader.cs
+++ b/DbaClientX.SqlServer/SqlServer.BulkDataReader.cs
@@ -177,7 +177,7 @@ public partial class SqlServer
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute bulk insert.", destinationTable, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.SqlServer/SqlServer.BulkDataReader.cs
+++ b/DbaClientX.SqlServer/SqlServer.BulkDataReader.cs
@@ -175,7 +175,7 @@ public partial class SqlServer
         {
             throw;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
         }

--- a/DbaClientX.SqlServer/SqlServer.BulkOperations.cs
+++ b/DbaClientX.SqlServer/SqlServer.BulkOperations.cs
@@ -177,7 +177,7 @@ public partial class SqlServer
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute bulk insert.", destinationTable, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.SqlServer/SqlServer.BulkOperations.cs
+++ b/DbaClientX.SqlServer/SqlServer.BulkOperations.cs
@@ -175,7 +175,7 @@ public partial class SqlServer
         {
             throw;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute bulk insert.", destinationTable, ex);
         }

--- a/DbaClientX.SqlServer/SqlServer.Cancellation.cs
+++ b/DbaClientX.SqlServer/SqlServer.Cancellation.cs
@@ -18,7 +18,7 @@ public partial class SqlServer
             if (sqlException.Number != 0 ||
                 sqlException.Class != 11 ||
                 sqlException.State != 0 ||
-                sqlException.Errors.Count < 2)
+                sqlException.Errors.Count == 0)
             {
                 return false;
             }

--- a/DbaClientX.SqlServer/SqlServer.Cancellation.cs
+++ b/DbaClientX.SqlServer/SqlServer.Cancellation.cs
@@ -1,0 +1,39 @@
+using System;
+using Microsoft.Data.SqlClient;
+
+namespace DBAClientX;
+
+public partial class SqlServer
+{
+    /// <inheritdoc />
+    protected override bool IsProviderCancellationException(Exception exception)
+    {
+        if (base.IsProviderCancellationException(exception))
+        {
+            return true;
+        }
+
+        return ExceptionChainContains<SqlException>(exception, static sqlException =>
+        {
+            if (sqlException.Number != 0 ||
+                sqlException.Class != 11 ||
+                sqlException.State != 0 ||
+                sqlException.Errors.Count < 2)
+            {
+                return false;
+            }
+
+            var hasOnlyCancellationErrors = true;
+            foreach (SqlError error in sqlException.Errors)
+            {
+                if (error.Number != 0 || error.Class != 11 || error.State != 0)
+                {
+                    hasOnlyCancellationErrors = false;
+                    break;
+                }
+            }
+
+            return hasOnlyCancellationErrors;
+        });
+    }
+}

--- a/DbaClientX.SqlServer/SqlServer.DataReader.cs
+++ b/DbaClientX.SqlServer/SqlServer.DataReader.cs
@@ -150,6 +150,11 @@ public partial class SqlServer
                 await DisposeOwnedResourceAsync(connection, ownsResource: true, DisposeConnectionAsync).ConfigureAwait(false);
             }
 
+            if (IsCallerCancellation(ex, cancellationToken))
+            {
+                throw;
+            }
+
             throw new DbaQueryExecutionException("Failed to open query reader.", query, ex);
         }
     }

--- a/DbaClientX.SqlServer/SqlServer.DataReader.cs
+++ b/DbaClientX.SqlServer/SqlServer.DataReader.cs
@@ -155,7 +155,7 @@ public partial class SqlServer
                 throw;
             }
 
-            throw new DbaQueryExecutionException("Failed to open query reader.", query, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to open query reader.", query, ex, cancellationToken);
         }
     }
 

--- a/DbaClientX.SqlServer/SqlServer.DataReader.cs
+++ b/DbaClientX.SqlServer/SqlServer.DataReader.cs
@@ -212,7 +212,9 @@ public partial class SqlServer
         {
             try
             {
-                return await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
+                return await AwaitWithCallerCancellationAsync(
+                    () => command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex) when (IsTransient(ex) && ++attempt < maxAttempts)
             {

--- a/DbaClientX.SqlServer/SqlServer.Monitoring.cs
+++ b/DbaClientX.SqlServer/SqlServer.Monitoring.cs
@@ -122,7 +122,9 @@ public partial class SqlServer
         {
             throw;
         }
-        catch (SqlException ex) when (cancellationToken.IsCancellationRequested)
+        catch (SqlException ex) when (
+            cancellationToken.IsCancellationRequested &&
+            IsProviderCancellationException(ex))
         {
             throw CreateCallerCancellationException(ex, cancellationToken);
         }
@@ -230,7 +232,9 @@ public partial class SqlServer
             {
                 throw;
             }
-            catch (SqlException ex) when (cancellationToken.IsCancellationRequested)
+            catch (SqlException ex) when (
+                cancellationToken.IsCancellationRequested &&
+                IsProviderCancellationException(ex))
             {
                 throw CreateCallerCancellationException(ex, cancellationToken);
             }

--- a/DbaClientX.SqlServer/SqlServer.Monitoring.cs
+++ b/DbaClientX.SqlServer/SqlServer.Monitoring.cs
@@ -122,6 +122,10 @@ public partial class SqlServer
         {
             throw;
         }
+        catch (SqlException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            throw CreateCallerCancellationException(ex, cancellationToken);
+        }
         catch (SqlException ex)
         {
             diagnostic.ErrorCategory = ClassifySqlMonitoringError(ex);
@@ -196,7 +200,9 @@ public partial class SqlServer
         var connectionString = BuildMonitoringConnectionString(target);
 
         using SqlConnection connection = CreateConnection(connectionString);
-        await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+        await AwaitWithCallerCancellationAsync(
+            () => OpenConnectionAsync(connection, cancellationToken),
+            cancellationToken).ConfigureAwait(false);
 
         foreach (SqlServerDatabaseState database in databases)
         {
@@ -223,6 +229,10 @@ public partial class SqlServer
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
+            }
+            catch (SqlException ex) when (cancellationToken.IsCancellationRequested)
+            {
+                throw CreateCallerCancellationException(ex, cancellationToken);
             }
             catch (SqlException ex)
             {
@@ -291,7 +301,9 @@ public partial class SqlServer
         var connectionString = BuildMonitoringConnectionString(target);
         var rows = new List<T>();
         using SqlConnection connection = CreateConnection(connectionString);
-        await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+        await AwaitWithCallerCancellationAsync(
+            () => OpenConnectionAsync(connection, cancellationToken),
+            cancellationToken).ConfigureAwait(false);
         using SqlCommand command = connection.CreateCommand();
         command.CommandText = query;
         command.CommandType = CommandType.Text;
@@ -304,8 +316,12 @@ public partial class SqlServer
         }
         command.Parameters.AddWithValue("@includeFilteredRows", includeFilteredRows ? 1 : 0);
 
-        using SqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        using SqlDataReader reader = await AwaitWithCallerCancellationAsync(
+            () => command.ExecuteReaderAsync(cancellationToken),
+            cancellationToken).ConfigureAwait(false);
+        while (await AwaitWithCallerCancellationAsync(
+            () => reader.ReadAsync(cancellationToken),
+            cancellationToken).ConfigureAwait(false))
         {
             rows.Add(map(reader));
         }

--- a/DbaClientX.SqlServer/SqlServer.Monitoring.cs
+++ b/DbaClientX.SqlServer/SqlServer.Monitoring.cs
@@ -100,7 +100,9 @@ public partial class SqlServer
         {
             connection = CreateConnection(connectionString);
             var connect = Stopwatch.StartNew();
-            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => OpenConnectionAsync(connection, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             connect.Stop();
             diagnostic.Connected = true;
             diagnostic.ConnectDuration = connect.Elapsed;
@@ -109,8 +111,12 @@ public partial class SqlServer
             using SqlCommand command = connection.CreateCommand();
             command.CommandText = ConnectionDiagnosticsQuery;
             command.CommandType = CommandType.Text;
-            using SqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            using SqlDataReader reader = await AwaitWithCallerCancellationAsync(
+                () => command.ExecuteReaderAsync(cancellationToken),
+                cancellationToken).ConfigureAwait(false);
+            if (await AwaitWithCallerCancellationAsync(
+                () => reader.ReadAsync(cancellationToken),
+                cancellationToken).ConfigureAwait(false))
             {
                 SqlServerMonitoringMappers.PopulateConnectionDiagnostics(reader, diagnostic);
             }
@@ -218,8 +224,12 @@ public partial class SqlServer
             {
                 using SqlCommand command = connection.CreateCommand();
                 command.CommandText = $"DBCC DBINFO({QuoteSqlIdentifier(database.DatabaseName)}) WITH TABLERESULTS";
-                using SqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-                while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+                using SqlDataReader reader = await AwaitWithCallerCancellationAsync(
+                    () => command.ExecuteReaderAsync(cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
+                while (await AwaitWithCallerCancellationAsync(
+                    () => reader.ReadAsync(cancellationToken),
+                    cancellationToken).ConfigureAwait(false))
                 {
                     string? field = SqlServerMonitoringMappers.GetString(reader, "Field");
                     if (string.Equals(field, "dbi_dbccLastKnownGood", StringComparison.OrdinalIgnoreCase))

--- a/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
+++ b/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
@@ -136,16 +136,7 @@ public partial class SqlServer
                 command.CommandTimeout = commandTimeout;
             }
 
-            var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
-            var tableIndex = 0;
-            do
-            {
-                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
-                dataSet.Tables.Add(table);
-                tableIndex++;
-            }
-            while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+            var dataSet = await ReadStoredProcedureResultsAsync(command, cancellationToken).ConfigureAwait(false);
 
             return BuildResult(dataSet);
         }

--- a/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
+++ b/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
@@ -153,6 +153,10 @@ public partial class SqlServer
         {
             throw;
         }
+        catch (SqlException ex) when (cancellationToken.IsCancellationRequested)
+        {
+            throw CreateCallerCancellationException(ex, cancellationToken);
+        }
         catch (SqlException ex)
         {
             throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);

--- a/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
+++ b/DbaClientX.SqlServer/SqlServer.StoredProcedures.DbParameters.cs
@@ -153,7 +153,9 @@ public partial class SqlServer
         {
             throw;
         }
-        catch (SqlException ex) when (cancellationToken.IsCancellationRequested)
+        catch (SqlException ex) when (
+            cancellationToken.IsCancellationRequested &&
+            IsProviderCancellationException(ex))
         {
             throw CreateCallerCancellationException(ex, cancellationToken);
         }

--- a/DbaClientX.SqlServer/SqlServer.StoredProcedures.cs
+++ b/DbaClientX.SqlServer/SqlServer.StoredProcedures.cs
@@ -137,7 +137,7 @@ public partial class SqlServer
             UpdateOutputParameters(command, parameters);
             return result;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
             throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
         }

--- a/DbaClientX.SqlServer/SqlServer.StoredProcedures.cs
+++ b/DbaClientX.SqlServer/SqlServer.StoredProcedures.cs
@@ -139,7 +139,7 @@ public partial class SqlServer
         }
         catch (Exception ex) when (!IsCallerCancellation(ex, cancellationToken))
         {
-            throw new DbaQueryExecutionException("Failed to execute stored procedure.", procedure, ex);
+            throw CreateQueryExecutionOrCancellationException("Failed to execute stored procedure.", procedure, ex, cancellationToken);
         }
         finally
         {

--- a/DbaClientX.SqlServer/SqlServer.StoredProcedures.cs
+++ b/DbaClientX.SqlServer/SqlServer.StoredProcedures.cs
@@ -122,16 +122,7 @@ public partial class SqlServer
                 command.CommandTimeout = commandTimeout;
             }
 
-            var dataSet = new DataSet();
-            using var reader = await command.ExecuteReaderAsync(CommandBehavior.SequentialAccess, cancellationToken).ConfigureAwait(false);
-            var tableIndex = 0;
-            do
-            {
-                var table = await ReadDataTableAsync(reader, $"Table{tableIndex}", cancellationToken).ConfigureAwait(false);
-                dataSet.Tables.Add(table);
-                tableIndex++;
-            }
-            while (!reader.IsClosed && await reader.NextResultAsync(cancellationToken).ConfigureAwait(false));
+            var dataSet = await ReadStoredProcedureResultsAsync(command, cancellationToken).ConfigureAwait(false);
 
             var result = BuildResult(dataSet);
             UpdateOutputParameters(command, parameters);

--- a/DbaClientX.SqlServer/SqlServer.Transactions.cs
+++ b/DbaClientX.SqlServer/SqlServer.Transactions.cs
@@ -150,7 +150,9 @@ public partial class SqlServer
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
 
             connection = CreateConnection(connectionString);
-            await OpenConnectionAsync(connection, cancellationToken).ConfigureAwait(false);
+            await AwaitWithCallerCancellationAsync(
+                () => OpenConnectionAsync(connection, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
             transaction = await BeginDbTransactionAsync(connection, isolationLevel, cancellationToken).ConfigureAwait(false);
 
             lock (_syncRoot)

--- a/DbaClientX.SqlServer/SqlServer.cs
+++ b/DbaClientX.SqlServer/SqlServer.cs
@@ -300,7 +300,9 @@ public partial class SqlServer : DatabaseClientBase
             var candidate = CreateConnection(connectionString);
             try
             {
-                await OpenConnectionAsync(candidate, cancellationToken).ConfigureAwait(false);
+                await AwaitWithCallerCancellationAsync(
+                    () => OpenConnectionAsync(candidate, cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
                 return candidate;
             }
             catch

--- a/DbaClientX.Tests/OracleBulkInsertTests.cs
+++ b/DbaClientX.Tests/OracleBulkInsertTests.cs
@@ -166,10 +166,9 @@ public class OracleBulkInsertTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        var ex = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(() =>
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
             oracle.BulkInsertAsync("h", "svc", "u", "p", table, "Dest", cancellationToken: cts.Token));
 
-        Assert.IsType<OperationCanceledException>(ex.InnerException);
         Assert.False(oracle.WriteCalled);
     }
 

--- a/DbaClientX.Tests/ProviderMappedQueryParityTests.cs
+++ b/DbaClientX.Tests/ProviderMappedQueryParityTests.cs
@@ -160,6 +160,20 @@ public class ProviderMappedQueryParityTests
             => Task.FromCanceled(cancellationToken);
     }
 
+    private sealed class TokenlessOpenCancellationSqlServer : DBAClientX.SqlServer
+    {
+        private readonly CancellationTokenSource _cancellationSource;
+
+        public TokenlessOpenCancellationSqlServer(CancellationTokenSource cancellationSource)
+            => _cancellationSource = cancellationSource;
+
+        protected override Task OpenConnectionAsync(SqlConnection connection, CancellationToken cancellationToken)
+        {
+            _cancellationSource.Cancel();
+            return Task.FromException(new OperationCanceledException());
+        }
+    }
+
     [Fact]
     public async Task SqlServerQueryAsListAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
     {
@@ -296,6 +310,22 @@ public class ProviderMappedQueryParityTests
             ":memory:",
             "SELECT 1",
             cancellationToken: cancellation.Token));
+    }
+
+    [Fact]
+    public async Task SqlServerQueryAsync_WhenConnectionOpenThrowsTokenlessCancellation_NormalizesCallerCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var sqlServer = new TokenlessOpenCancellationSqlServer(cancellation);
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(() => sqlServer.QueryAsync(
+            "Server=.;Database=app;Integrated Security=True;Encrypt=True;TrustServerCertificate=True",
+            "SELECT 1",
+            cancellationToken: cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        var providerException = Assert.IsType<OperationCanceledException>(exception.InnerException);
+        Assert.Equal(default, providerException.CancellationToken);
     }
 
     [Fact]

--- a/DbaClientX.Tests/ProviderMappedQueryParityTests.cs
+++ b/DbaClientX.Tests/ProviderMappedQueryParityTests.cs
@@ -136,6 +136,30 @@ public class ProviderMappedQueryParityTests
         }
     }
 
+    private sealed class CancellationSqlServer : DBAClientX.SqlServer
+    {
+        protected override Task OpenConnectionAsync(SqlConnection connection, CancellationToken cancellationToken)
+            => Task.FromCanceled(cancellationToken);
+    }
+
+    private sealed class CancellationMySql : DBAClientX.MySql
+    {
+        protected override Task OpenConnectionAsync(MySqlConnection connection, CancellationToken cancellationToken)
+            => Task.FromCanceled(cancellationToken);
+    }
+
+    private sealed class CancellationPostgreSql : DBAClientX.PostgreSql
+    {
+        protected override Task OpenConnectionAsync(NpgsqlConnection connection, CancellationToken cancellationToken)
+            => Task.FromCanceled(cancellationToken);
+    }
+
+    private sealed class CancellationOracle : DBAClientX.Oracle
+    {
+        protected override Task OpenConnectionAsync(OracleConnection connection, CancellationToken cancellationToken)
+            => Task.FromCanceled(cancellationToken);
+    }
+
     [Fact]
     public async Task SqlServerQueryAsListAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
     {
@@ -168,6 +192,20 @@ public class ProviderMappedQueryParityTests
             oracle.QueryAsListAsync<int>(connectionString, "SELECT 1 FROM dual", null!));
 
         Assert.Equal(0, oracle.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task PostgreSqlQueryAsListAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
+    {
+        using var postgreSql = new OpenFailurePostgreSql();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            postgreSql.QueryAsListAsync<int>(
+                "Host=dbhost;Database=app;Username=user;Password=password;SslMode=Require",
+                "SELECT 1",
+                null!));
+
+        Assert.Equal(0, postgreSql.AsyncDisposeCalls);
     }
 
     [Fact]
@@ -211,6 +249,135 @@ public class ProviderMappedQueryParityTests
             oracle.QueryStreamAsync<int>(connectionString, "SELECT 1 FROM dual", null!));
 
         Assert.Equal(0, oracle.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public void PostgreSqlQueryStreamAsync_WithNullMapper_ThrowsBeforeOpeningConnection()
+    {
+        using var postgreSql = new OpenFailurePostgreSql();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            postgreSql.QueryStreamAsync<int>(
+                "Host=dbhost;Database=app;Username=user;Password=password;SslMode=Require",
+                "SELECT 1",
+                null!));
+
+        Assert.Equal(0, postgreSql.AsyncDisposeCalls);
+    }
+
+    [Fact]
+    public async Task ProviderQueryAsync_PropagatesCallerCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        using var sqlServer = new CancellationSqlServer();
+        using var mySql = new CancellationMySql();
+        using var postgreSql = new CancellationPostgreSql();
+        using var oracle = new CancellationOracle();
+        using var sqlite = new DBAClientX.SQLite();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sqlServer.QueryAsync(
+            "Server=.;Database=app;Integrated Security=True;Encrypt=True;TrustServerCertificate=True",
+            "SELECT 1",
+            cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => mySql.QueryAsync(
+            "Server=dbhost;Database=app;User ID=user;Password=password;SslMode=Required",
+            "SELECT 1",
+            cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => postgreSql.QueryAsync(
+            "Host=dbhost;Database=app;Username=user;Password=password;SslMode=Require",
+            "SELECT 1",
+            cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => oracle.QueryAsync(
+            DBAClientX.Oracle.BuildConnectionString("dbhost", "svc", "user", "password"),
+            "SELECT 1 FROM dual",
+            cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sqlite.QueryAsync(
+            ":memory:",
+            "SELECT 1",
+            cancellationToken: cancellation.Token));
+    }
+
+    [Fact]
+    public async Task ProviderStoredProcedureAsync_PropagatesCallerCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        using var sqlServer = new CancellationSqlServer();
+        using var mySql = new CancellationMySql();
+        using var postgreSql = new CancellationPostgreSql();
+        using var oracle = new CancellationOracle();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sqlServer.ExecuteStoredProcedureAsync(
+            "Server=.;Database=app;Integrated Security=True;Encrypt=True;TrustServerCertificate=True",
+            "sp_test",
+            cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => mySql.ExecuteStoredProcedureAsync(
+            "Server=dbhost;Database=app;User ID=user;Password=password;SslMode=Required",
+            "sp_test",
+            cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => postgreSql.ExecuteStoredProcedureAsync(
+            "Host=dbhost;Database=app;Username=user;Password=password;SslMode=Require",
+            "sp_test",
+            cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => oracle.ExecuteStoredProcedureAsync(
+            DBAClientX.Oracle.BuildConnectionString("dbhost", "svc", "user", "password"),
+            "sp_test",
+            cancellationToken: cancellation.Token));
+    }
+
+    [Fact]
+    public async Task ProviderBulkInsertAsync_PropagatesCallerCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        using var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Rows.Add(1);
+        using var sqlServer = new CancellationSqlServer();
+        using var mySql = new CancellationMySql();
+        using var postgreSql = new CancellationPostgreSql();
+        using var oracle = new CancellationOracle();
+        using var sqlite = new DBAClientX.SQLite();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sqlServer.BulkInsertAsync(
+            "Server=.;Database=app;Integrated Security=True;Encrypt=True;TrustServerCertificate=True",
+            table,
+            "dbo.Items",
+            cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => mySql.BulkInsertAsync(
+            "Server=dbhost;Database=app;User ID=user;Password=password;SslMode=Required",
+            table,
+            "Items",
+            cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => postgreSql.BulkInsertAsync(
+            "Host=dbhost;Database=app;Username=user;Password=password;SslMode=Require",
+            table,
+            "Items",
+            cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => oracle.BulkInsertAsync(
+            DBAClientX.Oracle.BuildConnectionString("dbhost", "svc", "user", "password"),
+            table,
+            "Items",
+            cancellationToken: cancellation.Token));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sqlite.BulkInsertAsync(
+            ":memory:",
+            table,
+            "Items",
+            cancellationToken: cancellation.Token));
+    }
+
+    [Fact]
+    public async Task SqlServerQueryReaderAsync_PropagatesCallerCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        using var sqlServer = new CancellationSqlServer();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sqlServer.QueryReaderAsync(
+            "Server=.;Database=app;Integrated Security=True;Encrypt=True;TrustServerCertificate=True",
+            "SELECT 1",
+            cancellationToken: cancellation.Token));
     }
 
     [Fact]

--- a/DbaClientX.Tests/ProviderRetryTests.cs
+++ b/DbaClientX.Tests/ProviderRetryTests.cs
@@ -190,7 +190,8 @@ public class ProviderRetryTests
         Assert.False(sqlServer.IsCancellation(CreateSqlException(0, errorClass: 10, state: 0, errorCount: 1)));
         Assert.True(sqlite.IsCancellation(new SqliteException("interrupted", 9)));
         Assert.False(sqlite.IsCancellation(new SqliteException("busy", 5)));
-        Assert.True(postgreSql.IsCancellation(new PostgresException("cancelled", "ERROR", "ERROR", PostgresErrorCodes.QueryCanceled)));
+        Assert.True(postgreSql.IsCancellation(new PostgresException("canceling statement due to user request", "ERROR", "ERROR", PostgresErrorCodes.QueryCanceled)));
+        Assert.False(postgreSql.IsCancellation(new PostgresException("canceling statement due to statement timeout", "ERROR", "ERROR", PostgresErrorCodes.QueryCanceled)));
         Assert.False(postgreSql.IsCancellation(new PostgresException("serialization", "ERROR", "ERROR", PostgresErrorCodes.SerializationFailure)));
         Assert.True(mySql.IsCancellation(CreateMySqlException(MySqlErrorCode.QueryInterrupted)));
         Assert.False(mySql.IsCancellation(CreateMySqlException(MySqlErrorCode.LockDeadlock)));

--- a/DbaClientX.Tests/ProviderRetryTests.cs
+++ b/DbaClientX.Tests/ProviderRetryTests.cs
@@ -195,7 +195,7 @@ public class ProviderRetryTests
         Assert.False(postgreSql.IsCancellation(new PostgresException("serialization", "ERROR", "ERROR", PostgresErrorCodes.SerializationFailure)));
         Assert.True(mySql.IsCancellation(CreateMySqlException(MySqlErrorCode.QueryInterrupted)));
         Assert.False(mySql.IsCancellation(CreateMySqlException(MySqlErrorCode.LockDeadlock)));
-        Assert.True(oracle.IsCancellation(CreateOracleException(1013)));
+        Assert.False(oracle.IsCancellation(CreateOracleException(1013)));
         Assert.False(oracle.IsCancellation(CreateOracleException(12541)));
     }
 

--- a/DbaClientX.Tests/ProviderRetryTests.cs
+++ b/DbaClientX.Tests/ProviderRetryTests.cs
@@ -14,6 +14,7 @@ public class ProviderRetryTests
     private class MySqlRetryClient : DBAClientX.MySql
     {
         public T Run<T>(Func<T> operation) => ExecuteWithRetry(operation);
+        public bool IsCancellation(Exception exception) => IsProviderCancellationException(exception);
     }
 
     private static MySqlException CreateMySqlException(MySqlErrorCode code)
@@ -44,6 +45,7 @@ public class ProviderRetryTests
     private class PostgreSqlRetryClient : DBAClientX.PostgreSql
     {
         public T Run<T>(Func<T> operation) => ExecuteWithRetry(operation);
+        public bool IsCancellation(Exception exception) => IsProviderCancellationException(exception);
     }
 
     [Fact]
@@ -69,20 +71,24 @@ public class ProviderRetryTests
         public T Run<T>(Func<T> operation) => ExecuteWithRetry(operation);
         public bool IsConnectionOpenRetryable(Exception exception) => IsConnectionOpenTransient(exception);
         public bool IsCommandRetryable(Exception exception) => IsTransient(exception);
+        public bool IsCancellation(Exception exception) => IsProviderCancellationException(exception);
     }
 
-    private static SqlException CreateSqlException(int number)
+    private static SqlException CreateSqlException(int number, byte errorClass = 0, byte state = 0, int errorCount = 1)
     {
         var errorCtor = typeof(SqlError).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)
             .First(c => c.GetParameters().Length == 8);
-        var error = errorCtor.Invoke(new object?[]
-        {
-            number, (byte)0, (byte)0, string.Empty, string.Empty, string.Empty, 1, null
-        });
         var collection = (SqlErrorCollection)typeof(SqlErrorCollection).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0]
             .Invoke(null);
-        typeof(SqlErrorCollection).GetMethod("Add", BindingFlags.NonPublic | BindingFlags.Instance)!
-            .Invoke(collection, new[] { error });
+        for (var index = 0; index < errorCount; index++)
+        {
+            var error = errorCtor.Invoke(new object?[]
+            {
+                number, state, errorClass, string.Empty, string.Empty, string.Empty, 1, null
+            });
+            typeof(SqlErrorCollection).GetMethod("Add", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(collection, new[] { error });
+        }
         var ctor = typeof(SqlException).GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)
             .First(c => c.GetParameters().Length == 4);
         return (SqlException)ctor.Invoke(new object?[] { "msg", collection, null, Guid.NewGuid() });
@@ -118,6 +124,7 @@ public class ProviderRetryTests
     private class SqliteRetryClient : DBAClientX.SQLite
     {
         public T Run<T>(Func<T> operation) => ExecuteWithRetry(operation);
+        public bool IsCancellation(Exception exception) => IsProviderCancellationException(exception);
     }
 
     [Fact]
@@ -141,6 +148,7 @@ public class ProviderRetryTests
     private class OracleRetryClient : DBAClientX.Oracle
     {
         public T Run<T>(Func<T> operation) => ExecuteWithRetry(operation);
+        public bool IsCancellation(Exception exception) => IsProviderCancellationException(exception);
     }
 
     private static OracleException CreateOracleException(int number)
@@ -166,6 +174,27 @@ public class ProviderRetryTests
         });
         Assert.Equal(1, result);
         Assert.Equal(3, attempts);
+    }
+
+    [Fact]
+    public void ProviderCancellationClassifiers_RecognizeOnlyProviderCancellationCodes()
+    {
+        using var sqlServer = new SqlServerRetryClient();
+        using var sqlite = new SqliteRetryClient();
+        using var postgreSql = new PostgreSqlRetryClient();
+        using var mySql = new MySqlRetryClient();
+        using var oracle = new OracleRetryClient();
+
+        Assert.True(sqlServer.IsCancellation(CreateSqlException(0, errorClass: 11, state: 0, errorCount: 2)));
+        Assert.False(sqlServer.IsCancellation(CreateSqlException(0, errorClass: 11, state: 0, errorCount: 1)));
+        Assert.True(sqlite.IsCancellation(new SqliteException("interrupted", 9)));
+        Assert.False(sqlite.IsCancellation(new SqliteException("busy", 5)));
+        Assert.True(postgreSql.IsCancellation(new PostgresException("cancelled", "ERROR", "ERROR", PostgresErrorCodes.QueryCanceled)));
+        Assert.False(postgreSql.IsCancellation(new PostgresException("serialization", "ERROR", "ERROR", PostgresErrorCodes.SerializationFailure)));
+        Assert.True(mySql.IsCancellation(CreateMySqlException(MySqlErrorCode.QueryInterrupted)));
+        Assert.False(mySql.IsCancellation(CreateMySqlException(MySqlErrorCode.LockDeadlock)));
+        Assert.True(oracle.IsCancellation(CreateOracleException(1013)));
+        Assert.False(oracle.IsCancellation(CreateOracleException(12541)));
     }
 
     [Fact]

--- a/DbaClientX.Tests/ProviderRetryTests.cs
+++ b/DbaClientX.Tests/ProviderRetryTests.cs
@@ -185,8 +185,9 @@ public class ProviderRetryTests
         using var mySql = new MySqlRetryClient();
         using var oracle = new OracleRetryClient();
 
+        Assert.True(sqlServer.IsCancellation(CreateSqlException(0, errorClass: 11, state: 0, errorCount: 1)));
         Assert.True(sqlServer.IsCancellation(CreateSqlException(0, errorClass: 11, state: 0, errorCount: 2)));
-        Assert.False(sqlServer.IsCancellation(CreateSqlException(0, errorClass: 11, state: 0, errorCount: 1)));
+        Assert.False(sqlServer.IsCancellation(CreateSqlException(0, errorClass: 10, state: 0, errorCount: 1)));
         Assert.True(sqlite.IsCancellation(new SqliteException("interrupted", 9)));
         Assert.False(sqlite.IsCancellation(new SqliteException("busy", 5)));
         Assert.True(postgreSql.IsCancellation(new PostgresException("cancelled", "ERROR", "ERROR", PostgresErrorCodes.QueryCanceled)));

--- a/DbaClientX.Tests/RetryTests.cs
+++ b/DbaClientX.Tests/RetryTests.cs
@@ -113,6 +113,8 @@ public class RetryTests
         public object? Run(DbConnection connection) => ExecuteScalar(connection, null, "q");
         public Task<object?> RunAsync(DbConnection connection, CancellationToken token = default) => ExecuteScalarAsync(connection, null, "q", cancellationToken: token);
         public Task<T> RunOperationAsync<T>(Func<Task<T>> operation, CancellationToken token = default) => ExecuteWithRetryAsync(operation, token);
+        public Exception CreatePublicExecutionException(Exception exception, CancellationToken token)
+            => CreateQueryExecutionOrCancellationException("failed", "q", exception, token);
     }
 
     private class RetryNonQueryClient : DBAClientX.DatabaseClientBase
@@ -244,5 +246,32 @@ public class RetryTests
             }, cts.Token));
 
         Assert.Equal(1, attempts);
+    }
+
+    [Fact]
+    public void CreatePublicExecutionException_WhenProviderReportsCancelledCommand_NormalizesCallerCancellation()
+    {
+        using var client = new RetryClient();
+        using var cancellation = new CancellationTokenSource();
+        var providerException = new InvalidOperationException("provider-specific cancellation");
+        cancellation.Cancel();
+
+        var exception = Assert.IsType<OperationCanceledException>(
+            client.CreatePublicExecutionException(providerException, cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        Assert.Same(providerException, exception.InnerException);
+    }
+
+    [Fact]
+    public void CreatePublicExecutionException_WhenCallerDidNotCancel_PreservesQueryFailureContract()
+    {
+        using var client = new RetryClient();
+        var providerException = new InvalidOperationException("database failure");
+
+        var exception = Assert.IsType<DBAClientX.DbaQueryExecutionException>(
+            client.CreatePublicExecutionException(providerException, CancellationToken.None));
+
+        Assert.Same(providerException, exception.InnerException);
     }
 }

--- a/DbaClientX.Tests/RetryTests.cs
+++ b/DbaClientX.Tests/RetryTests.cs
@@ -12,6 +12,7 @@ namespace DbaClientX.Tests;
 public class RetryTests
 {
     private class TransientTestException : Exception { }
+    private class ProviderCancellationTestException : Exception { }
 
     private class TransientConnection : DbConnection
     {
@@ -113,6 +114,13 @@ public class RetryTests
         public object? Run(DbConnection connection) => ExecuteScalar(connection, null, "q");
         public Task<object?> RunAsync(DbConnection connection, CancellationToken token = default) => ExecuteScalarAsync(connection, null, "q", cancellationToken: token);
         public Task<T> RunOperationAsync<T>(Func<Task<T>> operation, CancellationToken token = default) => ExecuteWithRetryAsync(operation, token);
+    }
+
+    private sealed class CancellationNormalizationClient : DBAClientX.DatabaseClientBase
+    {
+        protected override bool IsProviderCancellationException(Exception exception)
+            => exception is ProviderCancellationTestException || base.IsProviderCancellationException(exception);
+
         public Exception CreatePublicExecutionException(Exception exception, CancellationToken token)
             => CreateQueryExecutionOrCancellationException("failed", "q", exception, token);
     }
@@ -251,9 +259,9 @@ public class RetryTests
     [Fact]
     public void CreatePublicExecutionException_WhenProviderReportsCancelledCommand_NormalizesCallerCancellation()
     {
-        using var client = new RetryClient();
+        using var client = new CancellationNormalizationClient();
         using var cancellation = new CancellationTokenSource();
-        var providerException = new InvalidOperationException("provider-specific cancellation");
+        var providerException = new ProviderCancellationTestException();
         cancellation.Cancel();
 
         var exception = Assert.IsType<OperationCanceledException>(
@@ -264,13 +272,15 @@ public class RetryTests
     }
 
     [Fact]
-    public void CreatePublicExecutionException_WhenCallerDidNotCancel_PreservesQueryFailureContract()
+    public void CreatePublicExecutionException_WhenUnrelatedFailureRacesCancellation_PreservesQueryFailureContract()
     {
-        using var client = new RetryClient();
+        using var client = new CancellationNormalizationClient();
+        using var cancellation = new CancellationTokenSource();
         var providerException = new InvalidOperationException("database failure");
+        cancellation.Cancel();
 
         var exception = Assert.IsType<DBAClientX.DbaQueryExecutionException>(
-            client.CreatePublicExecutionException(providerException, CancellationToken.None));
+            client.CreatePublicExecutionException(providerException, cancellation.Token));
 
         Assert.Same(providerException, exception.InnerException);
     }

--- a/DbaClientX.Tests/RetryTests.cs
+++ b/DbaClientX.Tests/RetryTests.cs
@@ -71,7 +71,7 @@ public class RetryTests
             public override Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken) => Task.FromResult(ExecuteScalar());
         }
 
-        private class FakeParameterCollection : DbParameterCollection
+        internal class FakeParameterCollection : DbParameterCollection
         {
             public override int Count => 0;
             public override object SyncRoot { get; } = new();
@@ -94,7 +94,7 @@ public class RetryTests
             protected override void SetParameter(string parameterName, DbParameter value) { }
         }
 
-        private class FakeParameter : DbParameter
+        internal class FakeParameter : DbParameter
         {
             public override DbType DbType { get; set; }
             public override ParameterDirection Direction { get; set; }
@@ -123,6 +123,63 @@ public class RetryTests
 
         public Exception CreatePublicExecutionException(Exception exception, CancellationToken token)
             => CreateQueryExecutionOrCancellationException("failed", "q", exception, token);
+    }
+
+    private sealed class TokenlessCancellationQueryClient : DBAClientX.DatabaseClientBase
+    {
+        public Task<object?> RunQueryAsync(DbConnection connection, CancellationToken token)
+            => ExecuteQueryAsync(connection, null, "q", cancellationToken: token);
+    }
+
+    private sealed class TokenlessCancellationConnection : DbConnection
+    {
+        private readonly CancellationTokenSource _cancellationSource;
+
+        public TokenlessCancellationConnection(CancellationTokenSource cancellationSource)
+            => _cancellationSource = cancellationSource;
+
+        public override string ConnectionString { get; set; } = string.Empty;
+        public override string Database => string.Empty;
+        public override string DataSource => string.Empty;
+        public override string ServerVersion => string.Empty;
+        public override ConnectionState State => ConnectionState.Open;
+        public override void ChangeDatabase(string databaseName) { }
+        public override void Close() { }
+        public override void Open() { }
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel) => throw new NotSupportedException();
+        protected override DbCommand CreateDbCommand() => new TokenlessCancellationCommand(this, _cancellationSource);
+    }
+
+    private sealed class TokenlessCancellationCommand : DbCommand
+    {
+        private readonly DbConnection _connection;
+        private readonly CancellationTokenSource _cancellationSource;
+
+        public TokenlessCancellationCommand(DbConnection connection, CancellationTokenSource cancellationSource)
+        {
+            _connection = connection;
+            _cancellationSource = cancellationSource;
+        }
+
+        public override string CommandText { get; set; } = string.Empty;
+        public override int CommandTimeout { get; set; }
+        public override CommandType CommandType { get; set; }
+        public override bool DesignTimeVisible { get; set; }
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+        protected override DbConnection DbConnection { get => _connection; set { } }
+        protected override DbParameterCollection DbParameterCollection { get; } = new TransientConnection.FakeParameterCollection();
+        protected override DbTransaction DbTransaction { get; set; } = null!;
+        public override void Cancel() { }
+        public override int ExecuteNonQuery() => throw new NotSupportedException();
+        public override object? ExecuteScalar() => throw new NotSupportedException();
+        public override void Prepare() { }
+        protected override DbParameter CreateDbParameter() => new TransientConnection.FakeParameter();
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => throw new NotSupportedException();
+        protected override Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+        {
+            _cancellationSource.Cancel();
+            return Task.FromException<DbDataReader>(new OperationCanceledException());
+        }
     }
 
     private class RetryNonQueryClient : DBAClientX.DatabaseClientBase
@@ -283,5 +340,20 @@ public class RetryTests
             client.CreatePublicExecutionException(providerException, cancellation.Token));
 
         Assert.Same(providerException, exception.InnerException);
+    }
+
+    [Fact]
+    public async Task ExecuteQueryAsync_WhenProviderThrowsTokenlessCancellation_NormalizesCallerCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var client = new TokenlessCancellationQueryClient();
+        using var connection = new TokenlessCancellationConnection(cancellation);
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            client.RunQueryAsync(connection, cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        var providerException = Assert.IsType<OperationCanceledException>(exception.InnerException);
+        Assert.Equal(default, providerException.CancellationToken);
     }
 }

--- a/DbaClientX.Tests/RetryTests.cs
+++ b/DbaClientX.Tests/RetryTests.cs
@@ -123,6 +123,12 @@ public class RetryTests
 
         public Exception CreatePublicExecutionException(Exception exception, CancellationToken token)
             => CreateQueryExecutionOrCancellationException("failed", "q", exception, token);
+
+        public bool IsCallerCancellationException(Exception exception, CancellationToken token)
+            => IsCallerCancellation(exception, token);
+
+        public Task<DataSet> ReadStoredProcedureAsync(DbCommand command, CancellationToken token)
+            => ReadStoredProcedureResultsAsync(command, token);
     }
 
     private sealed class TokenlessCancellationQueryClient : DBAClientX.DatabaseClientBase
@@ -340,6 +346,35 @@ public class RetryTests
             client.CreatePublicExecutionException(providerException, cancellation.Token));
 
         Assert.Same(providerException, exception.InnerException);
+    }
+
+    [Fact]
+    public void IsCallerCancellation_WhenFailureOnlyWrapsCallerCancellation_ReturnsFalse()
+    {
+        using var client = new CancellationNormalizationClient();
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var exception = new InvalidOperationException(
+            "mapper failed",
+            new OperationCanceledException(cancellation.Token));
+
+        Assert.False(client.IsCallerCancellationException(exception, cancellation.Token));
+    }
+
+    [Fact]
+    public async Task ReadStoredProcedureResultsAsync_WhenProviderThrowsTokenlessCancellation_NormalizesCallerCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var client = new CancellationNormalizationClient();
+        using var connection = new TokenlessCancellationConnection(cancellation);
+        using var command = new TokenlessCancellationCommand(connection, cancellation);
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            client.ReadStoredProcedureAsync(command, cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        var providerException = Assert.IsType<OperationCanceledException>(exception.InnerException);
+        Assert.Equal(default, providerException.CancellationToken);
     }
 
     [Fact]

--- a/DbaClientX.Tests/SQLiteBulkInsertTests.cs
+++ b/DbaClientX.Tests/SQLiteBulkInsertTests.cs
@@ -128,10 +128,9 @@ public class SQLiteBulkInsertTests
             using var cts = new CancellationTokenSource();
             sqlite.CancellationSource = cts;
 
-            var ex = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(() =>
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
                 sqlite.BulkInsertAsync(path, table, "Dest", batchSize: 1, cancellationToken: cts.Token));
 
-            Assert.IsAssignableFrom<OperationCanceledException>(ex.InnerException);
             Assert.True(sqlite.RollbackCalled);
             Assert.False(sqlite.RollbackCancellationToken.CanBeCanceled);
 

--- a/DbaClientX.Tests/SQLiteBulkInsertTests.cs
+++ b/DbaClientX.Tests/SQLiteBulkInsertTests.cs
@@ -12,13 +12,14 @@ public class SQLiteBulkInsertTests
     private sealed class CancellingBulkInsertSqlite : DBAClientX.SQLite
     {
         public CancellationTokenSource? CancellationSource { get; set; }
+        public Exception? Failure { get; set; }
         public bool RollbackCalled { get; private set; }
         public CancellationToken RollbackCancellationToken { get; private set; }
 
         protected override Task ExecuteBulkInsertCommandAsync(Microsoft.Data.Sqlite.SqliteCommand command, CancellationToken cancellationToken)
         {
             CancellationSource?.Cancel();
-            return Task.FromException(new OperationCanceledException(CancellationSource?.Token ?? cancellationToken));
+            return Task.FromException(Failure ?? new OperationCanceledException(CancellationSource?.Token ?? cancellationToken));
         }
 
         protected override async Task RollbackOwnedBulkInsertTransactionAsync(Microsoft.Data.Sqlite.SqliteTransaction transaction, CancellationToken cancellationToken)
@@ -131,6 +132,38 @@ public class SQLiteBulkInsertTests
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
                 sqlite.BulkInsertAsync(path, table, "Dest", batchSize: 1, cancellationToken: cts.Token));
 
+            Assert.True(sqlite.RollbackCalled);
+            Assert.False(sqlite.RollbackCancellationToken.CanBeCanceled);
+
+            var count = await sqlite.ExecuteScalarAsync(path, "SELECT COUNT(*) FROM Dest;");
+            Assert.Equal(0L, count);
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    [Fact]
+    public async Task BulkInsertAsync_WhenProviderReportsInterrupt_NormalizesCancellationAfterRollback()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            using var sqlite = new CancellingBulkInsertSqlite();
+            await sqlite.ExecuteNonQueryAsync(path, "CREATE TABLE Dest(Id INTEGER, Name TEXT);");
+
+            var table = CreateTable(2);
+            using var cancellation = new CancellationTokenSource();
+            var providerException = new Microsoft.Data.Sqlite.SqliteException("interrupted", 9);
+            sqlite.CancellationSource = cancellation;
+            sqlite.Failure = providerException;
+
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                sqlite.BulkInsertAsync(path, table, "Dest", batchSize: 1, cancellationToken: cancellation.Token));
+
+            Assert.Equal(cancellation.Token, exception.CancellationToken);
+            Assert.Same(providerException, exception.InnerException);
             Assert.True(sqlite.RollbackCalled);
             Assert.False(sqlite.RollbackCancellationToken.CanBeCanceled);
 

--- a/DbaClientX.Tests/SQLiteCancellationNormalizationTests.cs
+++ b/DbaClientX.Tests/SQLiteCancellationNormalizationTests.cs
@@ -81,4 +81,36 @@ public class SQLiteCancellationNormalizationTests
             File.Delete(path);
         }
     }
+
+    [Fact]
+    public async Task QueryAsListAsync_WhenMapperThrowsUnrelatedCancellation_PreservesQueryFailure()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            using var sqlite = new DBAClientX.SQLite();
+            using var callerCancellation = new CancellationTokenSource();
+            using var mapperCancellation = new CancellationTokenSource();
+            mapperCancellation.Cancel();
+            var mapperException = new OperationCanceledException(mapperCancellation.Token);
+
+            var exception = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(() =>
+                sqlite.QueryAsListAsync<int>(
+                    path,
+                    "SELECT 1",
+                    _ =>
+                    {
+                        callerCancellation.Cancel();
+                        throw mapperException;
+                    },
+                    cancellationToken: callerCancellation.Token));
+
+            Assert.Same(mapperException, exception.InnerException);
+            Assert.Equal(mapperCancellation.Token, mapperException.CancellationToken);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }

--- a/DbaClientX.Tests/SQLiteCancellationNormalizationTests.cs
+++ b/DbaClientX.Tests/SQLiteCancellationNormalizationTests.cs
@@ -1,0 +1,84 @@
+using System.Data;
+using Microsoft.Data.Sqlite;
+
+namespace DbaClientX.Tests;
+
+public class SQLiteCancellationNormalizationTests
+{
+    private sealed class ProviderFailureSQLite : DBAClientX.SQLite
+    {
+        public required CancellationTokenSource CancellationSource { get; init; }
+        public required Exception Failure { get; init; }
+
+        protected override Task<object?> ExecuteResolvedQueryAsync(
+            SqliteConnection connection,
+            SqliteTransaction? transaction,
+            string query,
+            IDictionary<string, object?>? parameters,
+            CancellationToken cancellationToken,
+            IDictionary<string, DbType>? parameterTypes,
+            IDictionary<string, ParameterDirection>? parameterDirections)
+        {
+            CancellationSource.Cancel();
+            return Task.FromException<object?>(Failure);
+        }
+    }
+
+    [Fact]
+    public async Task QueryWithConnectionStringAsync_WhenProviderReportsInterrupt_NormalizesCallerCancellation()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            using var cancellation = new CancellationTokenSource();
+            var providerException = new SqliteException("interrupted", 9);
+            using var sqlite = new ProviderFailureSQLite
+            {
+                CancellationSource = cancellation,
+                Failure = providerException
+            };
+
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                sqlite.QueryWithConnectionStringAsync(
+                    $"Data Source={path};Pooling=False",
+                    "SELECT 1",
+                    cancellationToken: cancellation.Token));
+
+            Assert.Equal(cancellation.Token, exception.CancellationToken);
+            Assert.Same(providerException, exception.InnerException);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task QueryAsListAsync_WhenMapperFailsAfterCancellation_PreservesQueryFailure()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            using var sqlite = new DBAClientX.SQLite();
+            using var cancellation = new CancellationTokenSource();
+            var mapperException = new InvalidOperationException("mapper failed");
+
+            var exception = await Assert.ThrowsAsync<DBAClientX.DbaQueryExecutionException>(() =>
+                sqlite.QueryAsListAsync<int>(
+                    path,
+                    "SELECT 1",
+                    _ =>
+                    {
+                        cancellation.Cancel();
+                        throw mapperException;
+                    },
+                    cancellationToken: cancellation.Token));
+
+            Assert.Same(mapperException, exception.InnerException);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/DbaClientX.Tests/SqlServerMonitoringTests.cs
+++ b/DbaClientX.Tests/SqlServerMonitoringTests.cs
@@ -7,6 +7,20 @@ namespace DbaClientX.Tests;
 
 public class SqlServerMonitoringTests
 {
+    private sealed class TokenlessCancellationSqlServer : SqlServer
+    {
+        private readonly CancellationTokenSource _cancellationSource;
+
+        public TokenlessCancellationSqlServer(CancellationTokenSource cancellationSource)
+            => _cancellationSource = cancellationSource;
+
+        protected override Task OpenConnectionAsync(SqlConnection connection, CancellationToken cancellationToken)
+        {
+            _cancellationSource.Cancel();
+            return Task.FromException(new OperationCanceledException());
+        }
+    }
+
     [Fact]
     public void BuildConnectionString_WithMonitoringOptions_KeepsEncryptionAndAppliesDiagnosticsSettings()
     {
@@ -116,5 +130,24 @@ public class SqlServerMonitoringTests
         Assert.True(target.IntegratedSecurity);
         Assert.Equal("master", target.Database);
         Assert.Equal("DbaClientX.Monitoring", target.ApplicationName);
+    }
+
+    [Fact]
+    public async Task GetConnectionDiagnosticsAsync_WhenProviderThrowsTokenlessCancellation_NormalizesCallerCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var sqlServer = new TokenlessCancellationSqlServer(cancellation);
+        var target = new SqlServerMonitoringTarget
+        {
+            ServerOrInstance = "sql01",
+            TrustServerCertificate = true
+        };
+
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            sqlServer.GetConnectionDiagnosticsAsync(target, cancellation.Token));
+
+        Assert.Equal(cancellation.Token, exception.CancellationToken);
+        var providerException = Assert.IsType<OperationCanceledException>(exception.InnerException);
+        Assert.Equal(default, providerException.CancellationToken);
     }
 }

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Use it when you need:
 
 - one codebase for SQL Server, PostgreSQL, MySQL, SQLite, and Oracle
 - sync and async query execution
+- consistent caller cancellation across query, scalar, non-query, reader, streaming, stored procedure, and bulk APIs; provider-specific cancellation failures are normalized to `OperationCanceledException` with the caller's token
 - parameterized commands and provider-specific parameter type preservation
 - transaction helpers that commit on success and roll back on failure
 - provider-native bulk insert paths for staging tables and direct table writes


### PR DESCRIPTION
## Summary

- preserve caller-requested cancellation across asynchronous query, scalar, non-query, mapped-query, reader, streaming, stored-procedure, monitoring, maintenance, transaction, and bulk-insert APIs
- normalize tokenless provider cancellation only at narrow awaited provider boundaries, including connection opens, SQLite reader/setup/diagnostic operations, and SQL Server bulk-copy writes
- classify SQL Server, SQLite, PostgreSQL, and MySQL cancellation by provider-specific error signatures without misclassifying PostgreSQL statement timeouts, MySQL command-timeout wrappers, or Oracle ORA-01013 command timeouts
- compose cancellation normalization with the shared `TransientRetry` engine for streaming-reader startup instead of maintaining a second retry loop
- share one cancellation-aware Core helper for stored-procedure result loops while mapper, initializer, callback, argument, timeout, and unrelated provider failures retain the query-failure contract
- keep provider cleanup and SQLite rollback behavior intact before cancellation is rethrown, and asynchronously dispose owned PostgreSQL and Oracle connections in stored-procedure async overloads

## Consumer impact

Cancellation requested through the supplied token now consistently surfaces as `OperationCanceledException`, including provider-specific and tokenless provider cancellation shapes. The original provider exception remains available as diagnostic context. Unrelated mapper, data, argument, timeout, and provider failures remain wrapped in `DbaQueryExecutionException` even when cancellation races with the failure.

## Validation

- integrated Release solution build succeeded with zero warnings and errors across `net472`, `net8.0`, and `net10.0`
- full integrated tests passed: 1,149 on `net8.0` and 1,149 on `net10.0`
- focused cancellation, retry, connection-open, SQLite diagnostics/maintenance, streaming, bulk-insert, and SQL Server monitoring tests passed: 116
- disposable SQL Server LocalDB validation covered parameterized non-query, scalar, mapped query, owned reader, streaming, stored procedure, bulk insert, cancellation, and post-cancellation connection reuse
- Core and all five provider packages were inspected for expected target-framework assemblies, XML documentation, README content, and dependency groups