### PR TITLE
Modernize test platform and CI runtime coverage

### DIFF
--- a/.github/workflows/test-dotnet.yml
+++ b/.github/workflows/test-dotnet.yml
@@ -6,8 +6,7 @@ on:
       - master
     paths-ignore:
       - '*.md'
-      - 'Docs/**'
-      - 'Examples/**'
+      - 'docs/**'
       - '.gitignore'
   pull_request:
     branches:
@@ -18,25 +17,27 @@ permissions:
   contents: read
 
 env:
-  DOTNET_VERSION: '8.x'
   BUILD_CONFIGURATION: 'Release'
 
 jobs:
   test:
-    name: ${{ matrix.os }}
+    name: ${{ matrix.os }} (${{ matrix.framework }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
+        framework: [net8.0, net10.0]
     timeout-minutes: 10
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            8.x
+            10.x
 
       - name: Restore dependencies
         run: dotnet restore DbaClientX.sln
@@ -45,26 +46,26 @@ jobs:
         run: dotnet build DbaClientX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
       - name: Run tests
-        run: dotnet test DbaClientX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+        run: dotnet test DbaClientX.sln --configuration ${{ env.BUILD_CONFIGURATION }} --framework ${{ matrix.framework }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
         env:
           DNSCLIENTX_DEBUG_SYSTEMDNS: '1'
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: test-results-${{ matrix.os }}
+          name: test-results-${{ matrix.os }}-${{ matrix.framework }}
           path: '**/*.trx'
 
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
-          name: coverage-reports-${{ matrix.os }}
+          name: coverage-reports-${{ matrix.os }}-${{ matrix.framework }}
           path: '**/coverage.cobertura.xml'
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         continue-on-error: true
         with:
           files: '**/coverage.cobertura.xml'

--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -6,8 +6,7 @@ on:
             - master
         paths-ignore:
             - '*.md'
-            - 'Docs/**'
-            - 'Examples/**'
+            - 'docs/**'
             - '.gitignore'
     pull_request:
         branches:
@@ -28,7 +27,7 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Setup PowerShell modules
               shell: pwsh
@@ -41,7 +40,7 @@ jobs:
                   ./Module/Build/Build-Module.ps1 -RunMode Manifest
 
             - name: Upload refreshed module entry files
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: module-entry
                   path: |
@@ -56,16 +55,16 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Download refreshed module entry files
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: module-entry
                   path: Module
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                   dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -96,16 +95,16 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Download refreshed module entry files
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: module-entry
                   path: Module
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                   dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -135,10 +134,10 @@ jobs:
         timeout-minutes: 15
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                   dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -173,16 +172,16 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Download refreshed module entry files
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: module-entry
                   path: Module
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                   dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -220,16 +219,16 @@ jobs:
         timeout-minutes: 10
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Download refreshed module entry files
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: module-entry
                   path: Module
 
             - name: Setup .NET
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                   dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/DbaClientX.Tests/DbaClientX.Tests.csproj
+++ b/DbaClientX.Tests/DbaClientX.Tests.csproj
@@ -2,18 +2,21 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- Provider contract tests deliberately control cancellation timing and token identity. -->
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.Management.Infrastructure" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.PowerShell.SDK" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
@@ -20,9 +20,9 @@
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.9" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.3" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.5" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.5" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.9" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.9" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
@@ -31,6 +31,6 @@
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.14" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.6.3" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageVersion Include="Npgsql" Version="8.0.9" Condition="'$(TargetFramework)' == 'net472'" />
-    <PackageVersion Include="Npgsql" Version="10.0.2" Condition="'$(TargetFramework)' != 'net472'" />
+    <PackageVersion Include="Npgsql" Version="10.0.3" Condition="'$(TargetFramework)' != 'net472'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- migrate the test project from deprecated xUnit v2 to xUnit v3.2.2 and keep VSTest/coverage integration
- run the .NET suite for both advertised runtimes (`net8.0` and `net10.0`) on Windows, Linux, and macOS
- update enabled workflow actions to their current major releases
- apply current compatible patch releases for shared BCL JSON/ASN.1 packages and modern Npgsql targets

The test project remains explicit about cancellation-token ownership: provider contract tests deliberately use pre-cancelled and operation-specific tokens, so only xUnit analyzer rule `xUnit1051` is suppressed. Other analyzer warnings remain enabled.

Migration reference: https://xunit.net/docs/getting-started/v3/migration

## Validation

- Release solution build: zero warnings and zero errors
- `net8.0`: 1,058 tests passed with TRX and Cobertura collection
- `net10.0`: 1,058 tests passed with TRX and Cobertura collection
- both enabled workflow files parse as YAML
- live NuGet audit reports no deprecated or vulnerable packages