### PR TITLE
Publish portable symbols for DbaClientX packages

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -32,7 +32,7 @@ jobs:
             - name: Setup PowerShell modules
               shell: pwsh
               run: |
-                  Install-Module PSPublishModule -MinimumVersion 3.0.51 -Force -Scope CurrentUser -AllowClobber
+                  Install-Module PSPublishModule -MinimumVersion 3.0.55 -Force -Scope CurrentUser -AllowClobber
 
             - name: Refresh module manifest
               shell: pwsh
@@ -149,7 +149,7 @@ jobs:
                       Register-PSRepository -Default
                   }
                   Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-                  Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.51 -Force -SkipPublisherCheck -AllowClobber
+                  Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.55 -Force -SkipPublisherCheck -AllowClobber
                   Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
                   Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
 

--- a/Build/Build-Project.ps1
+++ b/Build/Build-Project.ps1
@@ -8,7 +8,7 @@ param(
     [string] $PlanPath
 )
 
-Import-Module PSPublishModule -Force -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.55 -Force -ErrorAction Stop
 
 $publishingNuget = $PublishNuget -eq $true
 $publishingGitHub = $PublishGitHub -eq $true

--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -26,6 +26,7 @@
   "PlanOutputPath": "../Artefacts/ProjectBuild/project.build.plan.json",
   "UpdateVersions": true,
   "Build": true,
+  "IncludeSymbols": true,
   "PublishNuget": false,
   "PublishGitHub": false,
   "CreateReleaseZip": true,

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -10,7 +10,7 @@
     [string] $GitHubApiKeyPath = 'C:\Support\Important\GitHubAPI.txt'
 )
 
-Import-Module PSPublishModule -Force -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.55 -Force -ErrorAction Stop
 
 Build-Module -ModuleName 'DbaClientX' -NoInteractive {
     # Usual defaults as per standard module


### PR DESCRIPTION
## Summary

- enable portable symbol packages for all six DbaClientX NuGet packages through the shared PowerForge `IncludeSymbols` setting
- require the public PSPublishModule 3.0.55 release in both build entry points and the PowerShell CI lanes
- keep package discovery, signing, publish ordering, and release staging in PowerForge rather than adding DbaClientX-specific packaging logic

## Release requirement

PSPublishModule 3.0.55 is public on PSGallery and contains the required symbol-package support. DbaClientX now uses that three-part public version without a private build, compatibility probe, or consumer-side fallback.

## Validation

A package-only build using the published PSPublishModule 3.0.55 release produced all six primary packages and all six matching symbol packages. Every `.nupkg` and `.snupkg` was signed, and each symbol package contained portable PDBs for `net472`, `net8.0`, and `net10.0`.