### PR TITLE
Optimize bulk reader setup and harden SQL performance comparisons

### DIFF
--- a/DbaClientX.SqlServer/SqlServer.BulkAutoCreate.cs
+++ b/DbaClientX.SqlServer/SqlServer.BulkAutoCreate.cs
@@ -43,7 +43,7 @@ public partial class SqlServer
     private void EnsureAutoCreatedDestinationTable(
         SqlConnection connection,
         SqlTransaction? transaction,
-        IDataReader reader,
+        IReadOnlyList<SqlServerBulkSourceColumn> columns,
         string destinationTable,
         SqlServerBulkInsertOptions? options)
     {
@@ -65,7 +65,7 @@ public partial class SqlServer
         ExecuteBulkInsertSetupCommand(
             connection,
             transaction,
-            BuildCreateTableCommand(reader, destination, options.ColumnMappings),
+            BuildCreateTableCommand(columns, destination),
             new Dictionary<string, object?> { ["@objectName"] = destination.QuotedFullName });
     }
 
@@ -106,7 +106,7 @@ public partial class SqlServer
     private async Task EnsureAutoCreatedDestinationTableAsync(
         SqlConnection connection,
         SqlTransaction? transaction,
-        IDataReader reader,
+        IReadOnlyList<SqlServerBulkSourceColumn> columns,
         string destinationTable,
         SqlServerBulkInsertOptions? options,
         CancellationToken cancellationToken)
@@ -131,7 +131,7 @@ public partial class SqlServer
         await ExecuteBulkInsertSetupCommandAsync(
                 connection,
                 transaction,
-                BuildCreateTableCommand(reader, destination, options.ColumnMappings),
+                BuildCreateTableCommand(columns, destination),
                 new Dictionary<string, object?> { ["@objectName"] = destination.QuotedFullName },
                 cancellationToken)
             .ConfigureAwait(false);
@@ -229,11 +229,9 @@ public partial class SqlServer
     }
 
     private static string BuildCreateTableCommand(
-        IDataReader reader,
-        SqlServerDestinationTable destination,
-        IDictionary<string, string>? columnMappings)
+        IReadOnlyList<SqlServerBulkSourceColumn> columns,
+        SqlServerDestinationTable destination)
     {
-        var columns = GetReaderColumns(reader, columnMappings);
         var builder = new StringBuilder();
         builder.AppendLine("IF OBJECT_ID(@objectName, N'U') IS NULL");
         builder.AppendLine("BEGIN");

--- a/DbaClientX.SqlServer/SqlServer.BulkDataReader.cs
+++ b/DbaClientX.SqlServer/SqlServer.BulkDataReader.cs
@@ -25,8 +25,6 @@ public partial class SqlServer
         string? username = null,
         string? password = null)
     {
-        ValidateBulkInsertInputs(reader, destinationTable, batchSize, bulkCopyTimeout, options);
-
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
         BulkInsert(connectionString, reader, destinationTable, options, useTransaction, batchSize, bulkCopyTimeout);
     }
@@ -60,7 +58,7 @@ public partial class SqlServer
         int? bulkCopyTimeout = null)
     {
         ValidateConnectionString(connectionString);
-        ValidateBulkInsertInputs(reader, destinationTable, batchSize, bulkCopyTimeout, options);
+        var columns = ValidateBulkInsertInputs(reader, destinationTable, batchSize, bulkCopyTimeout, options);
 
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;
@@ -69,9 +67,9 @@ public partial class SqlServer
         try
         {
             (connection, transaction, dispose) = ResolveConnection(connectionString, useTransaction);
-            EnsureAutoCreatedDestinationTable(connection!, transaction, reader, destinationTable, options);
+            EnsureAutoCreatedDestinationTable(connection!, transaction, columns, destinationTable, options);
             using var bulkCopy = CreateBulkCopy(connection!, transaction, options);
-            ConfigureBulkCopy(bulkCopy, reader, destinationTable, batchSize, bulkCopyTimeout, options);
+            ConfigureBulkCopy(bulkCopy, columns, destinationTable, batchSize, bulkCopyTimeout, options);
             WriteToServer(bulkCopy, reader);
         }
         catch (DbaTransactionException)
@@ -120,8 +118,6 @@ public partial class SqlServer
         string? username = null,
         string? password = null)
     {
-        ValidateBulkInsertInputs(reader, destinationTable, batchSize, bulkCopyTimeout, options);
-
         var connectionString = BuildConnectionString(serverOrInstance, database, integratedSecurity, username, password);
         await BulkInsertAsync(connectionString, reader, destinationTable, options, useTransaction, batchSize, bulkCopyTimeout, cancellationToken).ConfigureAwait(false);
     }
@@ -157,7 +153,7 @@ public partial class SqlServer
         CancellationToken cancellationToken = default)
     {
         ValidateConnectionString(connectionString);
-        ValidateBulkInsertInputs(reader, destinationTable, batchSize, bulkCopyTimeout, options);
+        var columns = ValidateBulkInsertInputs(reader, destinationTable, batchSize, bulkCopyTimeout, options);
 
         SqlConnection? connection = null;
         SqlTransaction? transaction = null;
@@ -166,9 +162,9 @@ public partial class SqlServer
         try
         {
             (connection, transaction, dispose) = await ResolveConnectionAsync(connectionString, useTransaction, cancellationToken).ConfigureAwait(false);
-            await EnsureAutoCreatedDestinationTableAsync(connection!, transaction, reader, destinationTable, options, cancellationToken).ConfigureAwait(false);
+            await EnsureAutoCreatedDestinationTableAsync(connection!, transaction, columns, destinationTable, options, cancellationToken).ConfigureAwait(false);
             using var bulkCopy = CreateBulkCopy(connection!, transaction, options);
-            ConfigureBulkCopy(bulkCopy, reader, destinationTable, batchSize, bulkCopyTimeout, options);
+            ConfigureBulkCopy(bulkCopy, columns, destinationTable, batchSize, bulkCopyTimeout, options);
             await AwaitWithCallerCancellationAsync(
                 () => WriteToServerAsync(bulkCopy, reader, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
@@ -200,7 +196,7 @@ public partial class SqlServer
         CancellationToken cancellationToken = default)
         => BulkInsertAsync(connectionString, reader, destinationTable, options: null, useTransaction, batchSize, bulkCopyTimeout, cancellationToken);
 
-    private static void ConfigureBulkCopy(SqlBulkCopy bulkCopy, IDataReader reader, string destinationTable, int? batchSize, int? bulkCopyTimeout, SqlServerBulkInsertOptions? options)
+    private static void ConfigureBulkCopy(SqlBulkCopy bulkCopy, IReadOnlyList<SqlServerBulkSourceColumn> columns, string destinationTable, int? batchSize, int? bulkCopyTimeout, SqlServerBulkInsertOptions? options)
     {
         bulkCopy.DestinationTableName = ResolveBulkCopyDestinationTableName(destinationTable, options);
         bulkCopy.EnableStreaming = true;
@@ -226,13 +222,13 @@ public partial class SqlServer
             bulkCopy.NotifyAfter = notifyAfter.Value;
         }
 
-        foreach (var column in GetReaderColumns(reader, options?.ColumnMappings))
+        foreach (var column in columns)
         {
             bulkCopy.ColumnMappings.Add(column.Ordinal, column.DestinationName);
         }
     }
 
-    private static void ValidateBulkInsertInputs(IDataReader reader, string destinationTable, int? batchSize, int? bulkCopyTimeout, SqlServerBulkInsertOptions? options = null)
+    private static IReadOnlyList<SqlServerBulkSourceColumn> ValidateBulkInsertInputs(IDataReader reader, string destinationTable, int? batchSize, int? bulkCopyTimeout, SqlServerBulkInsertOptions? options = null)
     {
         if (reader == null)
         {
@@ -264,10 +260,10 @@ public partial class SqlServer
             throw new ArgumentOutOfRangeException(nameof(SqlServerBulkInsertOptions.NotifyAfter), "NotifyAfter must be greater than zero.");
         }
 
-        ValidateColumnMappings(reader, options?.ColumnMappings);
+        return GetValidatedReaderColumns(reader, options?.ColumnMappings);
     }
 
-    private static void ValidateColumnMappings(IDataReader reader, IDictionary<string, string>? columnMappings)
+    private static IReadOnlyList<SqlServerBulkSourceColumn> GetValidatedReaderColumns(IDataReader reader, IDictionary<string, string>? columnMappings)
     {
         if (columnMappings != null)
         {
@@ -283,7 +279,22 @@ public partial class SqlServer
                     throw new ArgumentException("Column mapping destination cannot be null or whitespace.", nameof(columnMappings));
                 }
 
-                if (!ContainsColumn(reader, mapping.Key, columnMappings))
+            }
+        }
+
+        var columns = GetReaderColumns(reader, columnMappings);
+        if (columnMappings != null)
+        {
+            var comparer = GetComparer(columnMappings);
+            var sourceColumns = new HashSet<string>(comparer);
+            foreach (var column in columns)
+            {
+                sourceColumns.Add(column.SourceName);
+            }
+
+            foreach (var mapping in columnMappings)
+            {
+                if (!sourceColumns.Contains(mapping.Key))
                 {
                     throw new ArgumentException($"Column mapping source '{mapping.Key}' does not exist in the source reader.", nameof(columnMappings));
                 }
@@ -291,27 +302,15 @@ public partial class SqlServer
         }
 
         var destinationColumns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var column in GetReaderColumns(reader, columnMappings))
+        foreach (var column in columns)
         {
             if (!destinationColumns.Add(column.DestinationName))
             {
                 throw new ArgumentException($"Column mappings produce duplicate destination column '{column.DestinationName}'.", nameof(columnMappings));
             }
         }
-    }
 
-    private static bool ContainsColumn(IDataReader reader, string columnName, IDictionary<string, string> columnMappings)
-    {
-        var comparer = GetComparer(columnMappings);
-        foreach (var sourceName in GetReaderSourceNames(reader, columnMappings))
-        {
-            if (comparer.Equals(sourceName, columnName))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return columns;
     }
 
     private static IReadOnlyList<SqlServerBulkSourceColumn> GetReaderColumns(IDataReader reader, IDictionary<string, string>? columnMappings)
@@ -370,13 +369,13 @@ public partial class SqlServer
 
     private static Dictionary<int, DataRow> GetReaderSchemaRows(IDataReader reader)
     {
-        var rows = new Dictionary<int, DataRow>();
         var schema = reader.GetSchemaTable();
         if (schema == null)
         {
-            return rows;
+            return new Dictionary<int, DataRow>();
         }
 
+        var rows = new Dictionary<int, DataRow>(schema.Rows.Count);
         foreach (DataRow row in schema.Rows)
         {
             if (TryGetSchemaValue<int>(row, "ColumnOrdinal", out var ordinal))

--- a/DbaClientX.Tests/SqlServerBulkInsertTests.cs
+++ b/DbaClientX.Tests/SqlServerBulkInsertTests.cs
@@ -177,6 +177,8 @@ public class SqlServerBulkInsertTests
 
         public int FieldCount => _names.Length;
 
+        public int SchemaTableCallCount { get; private set; }
+
         public void Close() => IsClosed = true;
 
         public void Dispose() => Close();
@@ -219,6 +221,7 @@ public class SqlServerBulkInsertTests
 
         public DataTable GetSchemaTable()
         {
+            SchemaTableCallCount++;
             var schema = new DataTable();
             schema.Columns.Add("ColumnName", typeof(string));
             schema.Columns.Add("ColumnOrdinal", typeof(int));
@@ -736,6 +739,7 @@ public class SqlServerBulkInsertTests
 
         sqlServer.BulkInsert("s", "db", true, reader, "dbo.Dest", options);
 
+        Assert.Equal(1, reader.SchemaTableCallCount);
         Assert.Contains(sqlServer.Mappings, mapping => mapping.Source == "0" && mapping.Destination == "Id");
     }
 
@@ -755,6 +759,7 @@ public class SqlServerBulkInsertTests
 
         sqlServer.BulkInsert("s", "db", true, reader, "dbo.Dest", options);
 
+        Assert.Equal(1, reader.SchemaTableCallCount);
         Assert.Contains(sqlServer.Mappings, mapping => mapping.Source == "0" && mapping.Destination == "GeneratedId");
         Assert.Contains(sqlServer.Mappings, mapping => mapping.Source == "1" && mapping.Destination == "ExistingColumn");
     }

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -113,7 +113,9 @@ $settings = {
     $rowCounts = $RowCount
     $fileKinds = $FileKind
     $columnShapes = $ColumnShape
-    $selectedEngines = if ($Engine) { $Engine } else { @('DbaClientX') }
+    $selectedEngines = @(
+        if ($Engine) { $Engine } else { 'DbaClientX' }
+    )
     $benchmarkWarmupCount = $WarmupCount
     $benchmarkIterationCount = $Iterations
 

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -629,7 +629,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
         }
 
         if ($selectedEngines.Count -gt 1) {
-            comparison Engine -Baseline $engineComparisonBaseline -Metric MedianMs -TieTolerance 0.05
+            comparison Engine -Baseline $engineComparisonBaseline -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
             if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
                 readme $readmePath -Block 'office-file-roundtrip-benchmark' -Renderer ComparisonTable
             }

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -90,7 +90,7 @@ if ($Engine -contains 'dbatools') {
     }
 }
 
-Import-Module PSPublishModule -MinimumVersion 3.0.44 -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.64 -ErrorAction Stop
 
 $benchmarkScriptRoot = $PSScriptRoot
 $benchmarkRunToken = [guid]::NewGuid().ToString('N').Substring(0, 8)

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -576,10 +576,6 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 & $assertTypedSchema -FileKind $case.FileKind -TableName $run.DestinationTable -Columns @($schema)
             }
 
-            if ($null -ne $run.RowsWritten -and $run.RowsWritten -ne [int] $case.RowCount) {
-                throw "$($case.FileKind) round trip wrote $($run.RowsWritten) of $($case.RowCount) expected row(s)."
-            }
-
             $run.RowsProcessed = $actual.Rows
             $run.IdSum = $actual.IdSum
             $run.ScoreSum = $actual.ScoreSum

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -24,6 +24,9 @@ param(
     [switch] $KeepArtifacts
 )
 
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
 function Convert-DbaClientXBenchmarkList {
     param([object[]] $Value)
 
@@ -77,6 +80,14 @@ if ($Iterations -lt 1) {
 }
 if ($WarmupCount -lt 0) {
     throw 'WarmupCount cannot be negative.'
+}
+
+if ($Engine -contains 'dbatools') {
+    $requiredCommands = @('Connect-DbaInstance', 'Export-DbaCsv', 'Import-DbaCsv')
+    $missingCommands = @($requiredCommands | Where-Object { -not (Get-Command $_ -ErrorAction SilentlyContinue) })
+    if ($missingCommands.Count -gt 0) {
+        throw "The explicitly requested dbatools benchmark engine is unavailable. Missing command(s): $($missingCommands -join ', ')."
+    }
 }
 
 Import-Module PSPublishModule -MinimumVersion 3.0.44 -ErrorAction Stop
@@ -247,6 +258,8 @@ FROM numbers;
             $run.Server = $server
             $run.Database = $database
             $run.KeepArtifacts = $keepArtifacts
+            $run.ExportMs = 0.0
+            $run.LoadMs = 0.0
             $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
             $laneToken = '{0}_{1}_{2}_{3}_{4}' -f $benchmarkRunToken, $case.Engine, $case.FileKind, $case.ColumnShape, $case.RowCount
             $run.SourceTable = 'DbaClientXBench_FileSource_{0}' -f $laneToken
@@ -326,6 +339,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 }
 
                 if ($case.FileKind -in @('Csv', 'CsvGZip', 'CsvTyped', 'CsvGZipTyped')) {
+                    $exportTimer = [System.Diagnostics.Stopwatch]::StartNew()
                     $csvExportParameters = @{
                         Path = $run.FilePath
                         ErrorAction = 'Stop'
@@ -371,9 +385,13 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
 
                         $client.Dispose()
                     }
+                    $exportTimer.Stop()
+                    $run.ExportMs = $exportTimer.Elapsed.TotalMilliseconds
 
+                    $loadTimer = [System.Diagnostics.Stopwatch]::StartNew()
                     $imported = Import-OfficeCsv @csvImportParameters
                 } elseif ($case.FileKind -in @('ExcelReader', 'ExcelReaderMapped')) {
+                    $exportTimer = [System.Diagnostics.Stopwatch]::StartNew()
                     $connectionString = [DBAClientX.SqlServer]::BuildConnectionString(
                         $run.Server,
                         $run.Database,
@@ -399,7 +417,10 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
 
                         $client.Dispose()
                     }
+                    $exportTimer.Stop()
+                    $run.ExportMs = $exportTimer.Elapsed.TotalMilliseconds
 
+                    $loadTimer = [System.Diagnostics.Stopwatch]::StartNew()
                     $excelImportParameters = @{
                         Path = $run.FilePath
                         WorksheetName = 'Data'
@@ -410,6 +431,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
 
                     $imported = Import-OfficeExcel @excelImportParameters
                 } else {
+                    $exportTimer = [System.Diagnostics.Stopwatch]::StartNew()
                     $data = Invoke-DbaXQuery `
                         -Server $run.Server `
                         -Database $run.Database `
@@ -420,6 +442,10 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                         -ErrorAction Stop
 
                     $data | Export-OfficeExcel -Path $run.FilePath -WorksheetName Data -TableName Data -ErrorAction Stop
+                    $exportTimer.Stop()
+                    $run.ExportMs = $exportTimer.Elapsed.TotalMilliseconds
+
+                    $loadTimer = [System.Diagnostics.Stopwatch]::StartNew()
                     $imported = Import-OfficeExcel -Path $run.FilePath -WorksheetName Data -AsDataTable -ErrorAction Stop
                 }
 
@@ -454,6 +480,8 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                         $imported.Dispose()
                     }
                 }
+                $loadTimer.Stop()
+                $run.LoadMs = $loadTimer.Elapsed.TotalMilliseconds
             }
         }
 
@@ -463,6 +491,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
 
+                $exportTimer = [System.Diagnostics.Stopwatch]::StartNew()
                 $exportParameters = @{
                     SqlInstance = $run.DbatoolsInstance
                     Database = $run.Database
@@ -478,7 +507,10 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 }
 
                 Export-DbaCsv @exportParameters | Out-Null
+                $exportTimer.Stop()
+                $run.ExportMs = $exportTimer.Elapsed.TotalMilliseconds
 
+                $loadTimer = [System.Diagnostics.Stopwatch]::StartNew()
                 $importParameters = @{
                     Path = $run.FilePath
                     SqlInstance = $run.DbatoolsInstance
@@ -504,6 +536,8 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 }
 
                 Import-DbaCsv @importParameters | Out-Null
+                $loadTimer.Stop()
+                $run.LoadMs = $loadTimer.Elapsed.TotalMilliseconds
             }
         }
 
@@ -564,6 +598,18 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             $run.RowsProcessed
         }
 
+        metric ExportMs {
+            param($case, $run)
+
+            $run.ExportMs
+        }
+
+        metric LoadMs {
+            param($case, $run)
+
+            $run.LoadMs
+        }
+
         metric IdSum {
             param($case, $run)
 
@@ -587,7 +633,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
         }
 
         if ($selectedEngines.Count -gt 1) {
-            comparison Engine -Baseline $engineComparisonBaseline -Metric MedianMs
+            comparison Engine -Baseline $engineComparisonBaseline -Metric MedianMs -TieTolerance 0.05
             if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
                 readme $readmePath -Block 'office-file-roundtrip-benchmark' -Renderer ComparisonTable
             }

--- a/Module/Examples/Benchmark.SqlServerCsvExport.ps1
+++ b/Module/Examples/Benchmark.SqlServerCsvExport.ps1
@@ -112,7 +112,7 @@ if ($Engine -contains 'DbaClientXPartitionedReader' -and -not (Get-Command Start
     throw 'The explicitly requested DbaClientXPartitionedReader benchmark engine is unavailable. Missing command: Start-ThreadJob.'
 }
 
-Import-Module PSPublishModule -MinimumVersion 3.0.44 -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.64 -ErrorAction Stop
 
 $benchmarkScriptRoot = $PSScriptRoot
 $settings = {

--- a/Module/Examples/Benchmark.SqlServerCsvExport.ps1
+++ b/Module/Examples/Benchmark.SqlServerCsvExport.ps1
@@ -672,7 +672,7 @@ ORDER BY Id;
             [double] $case.RowCount / ($run.DurationMs / 1000)
         }
 
-        comparison Engine -Baseline DbaClientXReader -Metric MedianMs -TieTolerance 0.05
+        comparison Engine -Baseline DbaClientXReader -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
         if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
             readme $readmePath -Block 'sqlserver-csv-export-benchmark' -Renderer ComparisonTable
         }

--- a/Module/Examples/Benchmark.SqlServerCsvExport.ps1
+++ b/Module/Examples/Benchmark.SqlServerCsvExport.ps1
@@ -3,7 +3,7 @@ param(
     [string] $Server = $(if ($env:DBACLIENTX_SQLSERVER) { $env:DBACLIENTX_SQLSERVER } else { 'localhost' }),
     [string] $Database = $(if ($env:DBACLIENTX_SQLDATABASE) { $env:DBACLIENTX_SQLDATABASE } else { 'tempdb' }),
     [int[]] $RowCount = @(100000),
-    [string[]] $Engine,
+    [string[]] $Engine = @('DbaClientXReader'),
     [int] $Iterations = 3,
     [int] $WarmupCount = 1,
     [string] $ModulePath = $(
@@ -26,6 +26,9 @@ param(
     [switch] $UpdateReadme,
     [switch] $KeepArtifacts
 )
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
 function Convert-DbaClientXBenchmarkList {
     param([object[]] $Value)
@@ -59,11 +62,19 @@ function Assert-DbaClientXBenchmarkValue {
     }
 }
 
-$Engine = Convert-DbaClientXBenchmarkList -Value $Engine
+$Engine = @(
+    Convert-DbaClientXBenchmarkList -Value $Engine | ForEach-Object {
+        switch ($_) {
+            'DbaClientX' { 'DbaClientXDataTable' }
+            'DbaClientXStream' { 'DbaClientXPowerShellStream' }
+            default { $_ }
+        }
+    }
+)
 if ($RowCount.Count -eq 0 -or @($RowCount | Where-Object { $_ -lt 1 }).Count -gt 0) {
     throw 'RowCount values must be greater than zero.'
 }
-Assert-DbaClientXBenchmarkValue -Name Engine -Value $Engine -ValidValue @('DbaClientX', 'DbaClientXStream', 'DbaClientXReader', 'DbaClientXPartitionedReader', 'dbatools', 'bcp', 'FastBCP')
+Assert-DbaClientXBenchmarkValue -Name Engine -Value $Engine -ValidValue @('DbaClientXDataTable', 'DbaClientXPowerShellStream', 'DbaClientXReader', 'DbaClientXPartitionedReader', 'dbatools', 'bcp', 'FastBCP')
 if ($Iterations -lt 1) {
     throw 'Iterations must be greater than zero.'
 }
@@ -72,6 +83,33 @@ if ($WarmupCount -lt 0) {
 }
 if ($DbaClientXPartitionDegree -lt 0) {
     throw 'DbaClientXPartitionDegree cannot be negative. Use 0 to default to the current processor count.'
+}
+
+if ($Engine -contains 'dbatools') {
+    $requiredCommands = @('Connect-DbaInstance', 'Export-DbaCsv')
+    $missingCommands = @($requiredCommands | Where-Object { -not (Get-Command $_ -ErrorAction SilentlyContinue) })
+    if ($missingCommands.Count -gt 0) {
+        throw "The explicitly requested dbatools benchmark engine is unavailable. Missing command(s): $($missingCommands -join ', ')."
+    }
+}
+if ($Engine -contains 'bcp' -and -not (Get-Command bcp -ErrorAction SilentlyContinue)) {
+    throw 'The explicitly requested bcp benchmark engine is unavailable. Missing command: bcp.'
+}
+if ($Engine -contains 'FastBCP') {
+    $resolvedFastBcpCommand = Get-Command $FastBcpPath -ErrorAction SilentlyContinue
+    $fastBcpCommand = if (Test-Path -LiteralPath $FastBcpPath) {
+        (Resolve-Path -LiteralPath $FastBcpPath).Path
+    } elseif ($resolvedFastBcpCommand) {
+        $resolvedFastBcpCommand.Source
+    } else {
+        $null
+    }
+    if ([string]::IsNullOrWhiteSpace($fastBcpCommand)) {
+        throw "The explicitly requested FastBCP benchmark engine is unavailable. '$FastBcpPath' could not be resolved."
+    }
+}
+if ($Engine -contains 'DbaClientXPartitionedReader' -and -not (Get-Command Start-ThreadJob -ErrorAction SilentlyContinue)) {
+    throw 'The explicitly requested DbaClientXPartitionedReader benchmark engine is unavailable. Missing command: Start-ThreadJob.'
 }
 
 Import-Module PSPublishModule -MinimumVersion 3.0.44 -ErrorAction Stop
@@ -290,7 +328,7 @@ ORDER BY Id;
 
             New-Item -ItemType Directory -Force -Path $outputRootBase | Out-Null
             Import-Module $modulePath -Global -Force -ErrorAction Stop
-            if ($case.Engine -in @('DbaClientX', 'DbaClientXStream', 'DbaClientXReader', 'DbaClientXPartitionedReader')) {
+            if ($case.Engine -in @('DbaClientXDataTable', 'DbaClientXPowerShellStream', 'DbaClientXReader', 'DbaClientXPartitionedReader')) {
                 Import-Module $psWriteOfficeModulePath -Global -Force -ErrorAction Stop
             }
 
@@ -314,7 +352,7 @@ ORDER BY Id;
         skip {
             param($case)
 
-            if ($case.Engine -in @('DbaClientX', 'DbaClientXStream', 'DbaClientXReader', 'DbaClientXPartitionedReader')) {
+            if ($case.Engine -in @('DbaClientXDataTable', 'DbaClientXPowerShellStream', 'DbaClientXReader', 'DbaClientXPartitionedReader')) {
                 if ($case.Engine -eq 'DbaClientXPartitionedReader' -and -not (& $testThreadJobCommand)) {
                     return $true
                 }
@@ -337,7 +375,7 @@ ORDER BY Id;
             return $false
         }
 
-        engine DbaClientX {
+        engine DbaClientXDataTable {
             operation Export {
                 param($case, $run)
 
@@ -354,7 +392,7 @@ ORDER BY Id;
             }
         }
 
-        engine DbaClientXStream {
+        engine DbaClientXPowerShellStream {
             operation Export {
                 param($case, $run)
 
@@ -634,7 +672,7 @@ ORDER BY Id;
             [double] $case.RowCount / ($run.DurationMs / 1000)
         }
 
-        comparison Engine -Baseline DbaClientXReader -Metric MedianMs
+        comparison Engine -Baseline DbaClientXReader -Metric MedianMs -TieTolerance 0.05
         if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
             readme $readmePath -Block 'sqlserver-csv-export-benchmark' -Renderer ComparisonTable
         }

--- a/Module/Examples/Benchmark.SqlServerDataMovement.ps1
+++ b/Module/Examples/Benchmark.SqlServerDataMovement.ps1
@@ -584,7 +584,7 @@ CREATE TABLE dbo.$TableName
                 [double] $case.RowCount / ($run.DurationMs / 1000)
             }
 
-            comparison Engine -Baseline DbaClientX -Metric MedianMs -TieTolerance 0.05
+            comparison Engine -Baseline DbaClientX -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
             if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
                 readme $readmePath -Block 'sqlserver-data-movement-write-benchmark' -Renderer ComparisonTable
             }
@@ -778,7 +778,7 @@ CREATE TABLE dbo.$TableName
                 [double] $case.RowCount / ($run.DurationMs / 1000)
             }
 
-            comparison Engine -Baseline DbaClientX -Metric MedianMs -TieTolerance 0.05
+            comparison Engine -Baseline DbaClientX -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
             if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
                 readme $readmePath -Block 'sqlserver-data-movement-read-benchmark' -Renderer ComparisonTable
             }

--- a/Module/Examples/Benchmark.SqlServerDataMovement.ps1
+++ b/Module/Examples/Benchmark.SqlServerDataMovement.ps1
@@ -124,7 +124,7 @@ if ($Engine -contains 'SqlServer' -and (-not $Operation -or $Operation -contains
     }
 }
 
-Import-Module PSPublishModule -MinimumVersion 3.0.44 -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.64 -ErrorAction Stop
 
 $benchmarkScriptRoot = $PSScriptRoot
 $settings = {

--- a/Module/Examples/Benchmark.SqlServerDataMovement.ps1
+++ b/Module/Examples/Benchmark.SqlServerDataMovement.ps1
@@ -6,8 +6,8 @@ param(
     [object[]] $BatchSize = @(5000),
     [string[]] $InputKind = @('DataTable', 'DataReader', 'PSCustomObject', 'Class'),
     [string[]] $ReadShape = @('DataTableAll', 'PSObjectAll'),
-    [int] $Iterations = 3,
-    [int] $WarmupCount = 1,
+    [int] $Iterations = 20,
+    [int] $WarmupCount = 5,
     [string] $ModulePath = $(
         if ($env:DBACLIENTX_BENCHMARK_MODULE_PATH) {
             $env:DBACLIENTX_BENCHMARK_MODULE_PATH
@@ -22,8 +22,12 @@ param(
     [string[]] $Operation,
     [string] $OutputRoot,
     [switch] $Plan,
-    [switch] $KeepTables
+    [switch] $KeepTables,
+    [switch] $UpdateReadme
 )
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
 
 function Convert-DbaClientXBenchmarkList {
     param([object[]] $Value)
@@ -105,6 +109,21 @@ if ($WarmupCount -lt 0) {
     throw 'WarmupCount cannot be negative.'
 }
 
+if ($Engine -contains 'dbatools') {
+    $requiredCommands = @('Connect-DbaInstance')
+    if (-not $Operation -or $Operation -contains 'Write') { $requiredCommands += 'Write-DbaDbTableData' }
+    if (-not $Operation -or $Operation -contains 'Read') { $requiredCommands += 'Invoke-DbaQuery' }
+    $missingCommands = @($requiredCommands | Where-Object { -not (Get-Command $_ -ErrorAction SilentlyContinue) })
+    if ($missingCommands.Count -gt 0) {
+        throw "The explicitly requested dbatools benchmark engine is unavailable. Missing command(s): $($missingCommands -join ', ')."
+    }
+}
+if ($Engine -contains 'SqlServer' -and (-not $Operation -or $Operation -contains 'Write')) {
+    if (-not (Get-Command Write-SqlTableData -ErrorAction SilentlyContinue)) {
+        throw 'The explicitly requested SqlServer benchmark engine is unavailable. Missing command: Write-SqlTableData.'
+    }
+}
+
 Import-Module PSPublishModule -MinimumVersion 3.0.44 -ErrorAction Stop
 
 $benchmarkScriptRoot = $PSScriptRoot
@@ -124,6 +143,7 @@ $settings = {
     $database = $Database
     $modulePath = $ModulePath
     $keepTables = $KeepTables.IsPresent
+    $updateReadme = $UpdateReadme.IsPresent
     $rowCounts = $RowCount
     $batchSizes = $BatchSize
     $inputKinds = $InputKind
@@ -564,8 +584,8 @@ CREATE TABLE dbo.$TableName
                 [double] $case.RowCount / ($run.DurationMs / 1000)
             }
 
-            comparison Engine -Baseline DbaClientX -Metric MedianMs
-            if (Test-Path -LiteralPath $readmePath) {
+            comparison Engine -Baseline DbaClientX -Metric MedianMs -TieTolerance 0.05
+            if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
                 readme $readmePath -Block 'sqlserver-data-movement-write-benchmark' -Renderer ComparisonTable
             }
             artifacts Json, Csv, Markdown
@@ -758,8 +778,8 @@ CREATE TABLE dbo.$TableName
                 [double] $case.RowCount / ($run.DurationMs / 1000)
             }
 
-            comparison Engine -Baseline DbaClientX -Metric MedianMs
-            if (Test-Path -LiteralPath $readmePath) {
+            comparison Engine -Baseline DbaClientX -Metric MedianMs -TieTolerance 0.05
+            if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
                 readme $readmePath -Block 'sqlserver-data-movement-read-benchmark' -Renderer ComparisonTable
             }
             artifacts Json, Csv, Markdown
@@ -788,9 +808,9 @@ if ($Plan) {
             Engine = $_.Engine
             Operation = $_.Operation
             RowCount = $_.Values.RowCount
-            BatchSize = $_.Values.BatchSize
-            InputKind = $_.Values.InputKind
-            ReadShape = $_.Values.ReadShape
+            BatchSize = if ($_.Values.Keys -contains 'BatchSize') { $_.Values.BatchSize } else { $null }
+            InputKind = if ($_.Values.Keys -contains 'InputKind') { $_.Values.InputKind } else { $null }
+            ReadShape = if ($_.Values.Keys -contains 'ReadShape') { $_.Values.ReadShape } else { $null }
             Skipped = [bool] $_.IsSkipped
         }
     } | Sort-Object Operation, Scenario, Engine | Format-Table -AutoSize

--- a/Module/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Module/Tests/AssemblyLoadContext.Tests.ps1
@@ -144,11 +144,13 @@ Import-Module DbaClientX -Force
 
         $result.DefaultConflictAssembly | Should -Be $conflictAssemblyPath
         $result.DefaultConflictALCIsDefault | Should -BeTrue
-        $result.InvokeDbaXQueryAssembly | Should -BeLike '*\Module\Artefacts\Unpacked\DbaClientX\Lib\Core\DBAClientX.PowerShell.dll'
+        $expectedCommandAssembly = [IO.Path]::GetFullPath((Join-Path $packagedModuleRoot 'DbaClientX/Lib/Core/DBAClientX.PowerShell.dll'))
+        $result.InvokeDbaXQueryAssembly | Should -Be $expectedCommandAssembly
         $result.InvokeDbaXQueryALC | Should -Be 'DbaClientX'
         $result.InvokeDbaXQueryALCIsDefault | Should -BeFalse
         if ($IsWindows) {
-            $result.ModuleSqlClientAssembly | Should -BeLike '*\Module\Artefacts\Unpacked\DbaClientX\Lib\Core\runtimes\win\lib\net8.0\Microsoft.Data.SqlClient.dll'
+            $expectedSqlClientAssembly = [IO.Path]::GetFullPath((Join-Path $packagedModuleRoot 'DbaClientX/Lib/Core/runtimes/win/lib/net8.0/Microsoft.Data.SqlClient.dll'))
+            $result.ModuleSqlClientAssembly | Should -Be $expectedSqlClientAssembly
         }
 
         $loadedAssemblies = @($result.LoadedAssemblies)

--- a/README.md
+++ b/README.md
@@ -336,47 +336,29 @@ and artifact details are in [SQL Server benchmark notes](docs/sqlserver-benchmar
 ### Write Benchmark
 
 <!-- sqlserver-data-movement-write-benchmark:start -->
-| Scenario | Variables | Host | Operation | DbaClientX | dbatools | SqlServer | Result |
-| --- | --- | --- | --- | ---: | ---: | ---: | --- |
-| 1000 rows / batch 5000 / Class | BatchSize=5000, InputKind=Class, RowCount=1000 | Core-7.6.3 | Write | 1.00x (25ms) | 6.39x (161ms) | Skipped | DbaClientX fastest |
-| 1000 rows / batch 5000 / DataReader | BatchSize=5000, InputKind=DataReader, RowCount=1000 | Core-7.6.3 | Write | 1.00x (21ms) | Skipped | Skipped | DbaClientX only successful |
-| 1000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=1000 | Core-7.6.3 | Write | 1.00x (20ms) | 2.02x (41ms) | Skipped | DbaClientX fastest |
-| 1000 rows / batch 5000 / PSCustomObject | BatchSize=5000, InputKind=PSCustomObject, RowCount=1000 | Core-7.6.3 | Write | 1.00x (27ms) | 4.15x (111ms) | Skipped | DbaClientX fastest |
-| 100000 rows / batch 5000 / Class | BatchSize=5000, InputKind=Class, RowCount=100000 | Core-7.6.3 | Write | 1.00x (3.07s) | 4.34x (13.30s) | Skipped | DbaClientX fastest |
-| 100000 rows / batch 5000 / DataReader | BatchSize=5000, InputKind=DataReader, RowCount=100000 | Core-7.6.3 | Write | 1.00x (112ms) | Skipped | Skipped | DbaClientX only successful |
-| 100000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=100000 | Core-7.6.3 | Write | 1.00x (134ms) | 1.31x (175ms) | Skipped | DbaClientX fastest |
-| 100000 rows / batch 5000 / PSCustomObject | BatchSize=5000, InputKind=PSCustomObject, RowCount=100000 | Core-7.6.3 | Write | 1.00x (2.82s) | 4.30x (12.16s) | Skipped | DbaClientX fastest |
-| 20000 rows / batch 5000 / Class | BatchSize=5000, InputKind=Class, RowCount=20000 | Core-7.6.3 | Write | 1.00x (311ms) | 6.50x (2.02s) | Skipped | DbaClientX fastest |
-| 20000 rows / batch 5000 / DataReader | BatchSize=5000, InputKind=DataReader, RowCount=20000 | Core-7.6.3 | Write | 1.00x (36ms) | Skipped | Skipped | DbaClientX only successful |
-| 20000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=20000 | Core-7.6.3 | Write | 1.00x (37ms) | 1.48x (54ms) | Skipped | DbaClientX fastest |
-| 20000 rows / batch 5000 / PSCustomObject | BatchSize=5000, InputKind=PSCustomObject, RowCount=20000 | Core-7.6.3 | Write | 1.00x (423ms) | 5.00x (2.11s) | Skipped | DbaClientX fastest |
-| 5000 rows / batch 5000 / Class | BatchSize=5000, InputKind=Class, RowCount=5000 | Core-7.6.3 | Write | 1.00x (169ms) | 3.93x (665ms) | Skipped | DbaClientX fastest |
-| 5000 rows / batch 5000 / DataReader | BatchSize=5000, InputKind=DataReader, RowCount=5000 | Core-7.6.3 | Write | 1.00x (22ms) | Skipped | Skipped | DbaClientX only successful |
-| 5000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=5000 | Core-7.6.3 | Write | 1.00x (25ms) | 1.78x (44ms) | Skipped | DbaClientX fastest |
-| 5000 rows / batch 5000 / PSCustomObject | BatchSize=5000, InputKind=PSCustomObject, RowCount=5000 | Core-7.6.3 | Write | 1.00x (114ms) | 4.30x (492ms) | Skipped | DbaClientX fastest |
+| Scenario | Variables | Host | Operation | DbaClientX | dbatools | Result |
+| --- | --- | --- | --- | ---: | ---: | --- |
+| 25000 rows / batch 5000 / Class | BatchSize=5000, InputKind=Class, RowCount=25000 | Core-7.6.3 | Write | 1.00x (373ms) | 5.70x (2.13s) | DbaClientX fastest |
+| 25000 rows / batch 5000 / DataReader | BatchSize=5000, InputKind=DataReader, RowCount=25000 | Core-7.6.3 | Write | 1.00x (70ms) | Skipped | DbaClientX only successful |
+| 25000 rows / batch 5000 / DataTable | BatchSize=5000, InputKind=DataTable, RowCount=25000 | Core-7.6.3 | Write | 1.00x (40ms) | 1.51x (60ms) | DbaClientX fastest |
+| 25000 rows / batch 5000 / PSCustomObject | BatchSize=5000, InputKind=PSCustomObject, RowCount=25000 | Core-7.6.3 | Write | 1.00x (423ms) | 5.12x (2.17s) | DbaClientX fastest |
 <!-- sqlserver-data-movement-write-benchmark:end -->
 
 ### Read Benchmark
 
 <!-- sqlserver-data-movement-read-benchmark:start -->
-| Scenario | Variables | Host | Operation | DbaClientX | dbatools | SqlServer | Result |
-| --- | --- | --- | --- | ---: | ---: | ---: | --- |
-| 1000 rows / DataTableAll | ReadShape=DataTableAll, RowCount=1000 | Core-7.6.3 | Read | 1.00x (8ms) | 3.45x (26ms) | Skipped | DbaClientX fastest |
-| 1000 rows / PSObjectAll | ReadShape=PSObjectAll, RowCount=1000 | Core-7.6.3 | Read | 1.00x (11ms) | 2.19x (23ms) | Skipped | DbaClientX fastest |
-| 100000 rows / DataTableAll | ReadShape=DataTableAll, RowCount=100000 | Core-7.6.3 | Read | 1.00x (71ms) | 1.13x (80ms) | Skipped | DbaClientX fastest |
-| 100000 rows / PSObjectAll | ReadShape=PSObjectAll, RowCount=100000 | Core-7.6.3 | Read | 1.00x (898ms) | 1.68x (1.51s) | Skipped | DbaClientX fastest |
-| 20000 rows / DataTableAll | ReadShape=DataTableAll, RowCount=20000 | Core-7.6.3 | Read | 1.00x (21ms) | 1.70x (36ms) | Skipped | DbaClientX fastest |
-| 20000 rows / PSObjectAll | ReadShape=PSObjectAll, RowCount=20000 | Core-7.6.3 | Read | 1.00x (105ms) | 1.79x (187ms) | Skipped | DbaClientX fastest |
-| 5000 rows / DataTableAll | ReadShape=DataTableAll, RowCount=5000 | Core-7.6.3 | Read | 1.00x (10ms) | 1.86x (19ms) | Skipped | DbaClientX fastest |
-| 5000 rows / PSObjectAll | ReadShape=PSObjectAll, RowCount=5000 | Core-7.6.3 | Read | 1.00x (17ms) | 2.90x (51ms) | Skipped | DbaClientX fastest |
+| Scenario | Variables | Host | Operation | DbaClientX | dbatools | Result |
+| --- | --- | --- | --- | ---: | ---: | --- |
+| 25000 rows / DataTableAll | ReadShape=DataTableAll, RowCount=25000 | Core-7.6.3 | Read | 1.00x (32ms) | 1.33x (43ms) | DbaClientX fastest |
+| 25000 rows / PSObjectAll | ReadShape=PSObjectAll, RowCount=25000 | Core-7.6.3 | Read | 1.00x (151ms) | 2.03x (308ms) | DbaClientX fastest |
 <!-- sqlserver-data-movement-read-benchmark:end -->
 
 ## SQL Server CSV Export
 
 <!-- sqlserver-csv-export-benchmark:start -->
-| Scenario | Variables | Host | Operation | DbaClientXReader | bcp | DbaClientX | DbaClientXStream | dbatools | FastBCP | Result |
-| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
-| 100000 rows / CSV export | RowCount=100000 | Core-7.6.3 | Export | 1.00x (65ms) | 4.17x (273ms) | 6.69x (437ms) | 5.25x (343ms) | 1.58x (103ms) | Skipped | DbaClientXReader fastest |
+| Scenario | Variables | Host | Operation | DbaClientXReader | bcp | DbaClientXDataTable | DbaClientXPowerShellStream | dbatools | Result |
+| --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| 100000 rows / CSV export | RowCount=100000 | Core-7.6.3 | Export | 1.00x (60ms) | 2.36x (142ms) | 6.28x (378ms) | 5.53x (333ms) | 1.44x (87ms) | DbaClientXReader fastest |
 <!-- sqlserver-csv-export-benchmark:end -->
 
 ## Office File Round Trip

--- a/docs/data-movement.md
+++ b/docs/data-movement.md
@@ -446,7 +446,7 @@ Copy-DbaXTableData `
 Use the benchmark example for repeatable local SQL Server import evidence. The example is a thin wrapper over the PSPublishModule benchmark suite.
 
 ```powershell
-Install-Module PSPublishModule -MinimumVersion 3.0.44 -Scope CurrentUser
+Install-Module PSPublishModule -MinimumVersion 3.0.64 -Scope CurrentUser
 
 .\Module\Examples\Benchmark.SqlServerDataMovement.ps1 `
     -Server localhost `

--- a/docs/sqlserver-benchmark-notes.md
+++ b/docs/sqlserver-benchmark-notes.md
@@ -11,7 +11,8 @@ Run the benchmark:
     -RowCount 1000, 5000, 20000, 100000 `
     -BatchSize 5000 `
     -InputKind DataTable, DataReader, PSCustomObject, Class `
-    -Iterations 3
+    -WarmupCount 5 `
+    -Iterations 20
 ```
 
 Run only one side of the suite when you want a smaller pass:
@@ -29,7 +30,7 @@ Use `-Plan` to inspect the matrix without touching SQL Server:
 
 The write suite benchmarks DbaClientX `Write-DbaXTableData` across `DataTable`, `DataReader`, `PSCustomObject`, and typed class input shapes. It compares DbaClientX with dbatools `Write-DbaDbTableData` and SqlServer `Write-SqlTableData` on their supported client-side input shapes. The `DataReader` lane is DbaClientX-only because it measures the public streaming path into SQL Server bulk copy. The dbatools `DataTable` lane passes a direct value to `-InputObject`, matching dbatools' documented SqlBulkCopy fast path and avoiding the slower piped `DataRow` path. `Copy-DbaDbTableData` is intentionally not part of this matrix because it measures SQL table-to-table streaming rather than client-side object/DataTable import.
 
-The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery` with dbatools `Invoke-DbaQuery`. By default it reads every row as full-result `DataTable` and PowerShell-object output; pass `-ReadShape DataSetAll` to include a `DataSet` materialization lane for local diagnosis. Successful lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) and then drop their isolated table. Failed lanes keep their table so the failing state can be inspected.
+The read suite seeds an isolated SQL Server table outside the measured operation, then compares DbaClientX `Invoke-DbaXQuery` with dbatools `Invoke-DbaQuery`. By default it reads every row as full-result `DataTable` and PowerShell-object output; pass `-ReadShape DataSetAll` to include a `DataSet` materialization lane for local diagnosis. Successful lanes verify row count plus simple data integrity (`Id` min/max/sum and `Score` sum) and then drop their isolated table. Failed lanes keep their table so the failing state can be inspected. Full `DataTable` materialization is allocation-heavy and can form GC timing clusters, so the default five warmups and twenty measurements are intentional; do not reduce them for a release comparison.
 
 ## CSV export and office round trips
 
@@ -90,8 +91,11 @@ Run the Excel round-trip lanes:
     -Iterations 5
 ```
 
-The benchmark commands expect matching DbaClientX, PSWriteOffice, and OfficeIMO
-packages. Use module-path parameters only when validating a local source build.
+For unreleased work, build PSWriteOffice with `OfficeIMORoot` pointing at the
+current OfficeIMO checkout and pass `-ModulePath` / `-PSWriteOfficeModulePath`
+to these scripts. That keeps DbaClientX, PSWriteOffice, and OfficeIMO on the
+exact source under test. Published-package measurements belong to a later
+release audit, after matching packages exist.
 
 Artifacts are written under `Ignore\Benchmarks\SqlServerDataMovement\Write` and `Ignore\Benchmarks\SqlServerDataMovement\Read`:
 


### PR DESCRIPTION
## Summary

- snapshot `IDataReader` schema and column metadata once, then reuse it for validation, destination creation, and bulk-copy mappings
- fail explicitly requested dbatools, bcp, FastBCP, and partitioned-reader lanes when their tools are unavailable
- label DataTable and PowerShell-stream CSV paths honestly and default the export comparison to the direct reader
- stabilize allocation-heavy read comparisons with five warmups and twenty measurements
- require DbaClientX to remain fastest or within the five-percent practical tie tolerance in each comparable lane
- preserve a single requested Office round-trip engine as a one-item array, keeping comparison selection and plan generation correct
- make packaged assembly-path assertions cross-platform

## Performance

For 100,000-row SQL-to-CSV export, the direct DbaClientX reader completes in about 60 ms versus dbatools at 87 ms and bcp at 142 ms. At 25,000 rows, DbaClientX leads dbatools by 1.33x for DataTable reads, 2.03x for PowerShell-object reads, and 1.51x to 5.70x across equivalent write shapes.

## Validation

Windows and WSL .NET/Pester suites, live SQL correctness checks, typed Office round trips, package creation, packaged assembly-load isolation, and source-binary provenance pass. The SQL data-movement, direct CSV-export, and Office round-trip specs produce non-empty plans through the source-built PowerForge gate surface; the single-engine Office plan also passes under PowerShell 7 and Windows PowerShell 5.1.

## Dependency order

The fastest-baseline assertion first ships in PSPublishModule `3.0.64` through EvotecIT/PSPublishModule#551. Until that release exists, use the source-built module for development; merge and release the shared PowerForge change before treating the updated benchmark specs as independently consumable. No package publication is part of this PR.