### PR TITLE
Add Azure Tables provider and PowerShell cmdlets

### DIFF
--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -4,6 +4,7 @@
   "ExpectedVersion": null,
   "ExpectedVersionMap": {
     "DbaClientX.Core": "0.X.0",
+    "DbaClientX.AzureTables": "0.X.0",
     "DbaClientX.SqlServer": "0.X.0",
     "DbaClientX.PostgreSql": "0.X.0",
     "DbaClientX.MySql": "0.X.0",
@@ -15,6 +16,8 @@
   "ExcludeProjects": [
     "DbaClientX.PowerShell",
     "DbaClientX.Tests",
+    "DbaClientX.AzureTables.Tests",
+    "DbaClientX.Benchmarks",
     "DbaClientX.Examples"
   ],
   "NugetSource": [],

--- a/DbaClientX.AzureTables.Tests/DbaAzureTablesContractTests.cs
+++ b/DbaClientX.AzureTables.Tests/DbaAzureTablesContractTests.cs
@@ -1,0 +1,191 @@
+using System.Data;
+using DBAClientX.DataMovement;
+
+namespace DBAClientX.AzureTables.Tests;
+
+public class DbaAzureTablesContractTests
+{
+    [Fact]
+    public async Task SourceAdapterPreservesOpaqueContinuationTokensAndKeys()
+    {
+        var store = new RecordingStore
+        {
+            QueryResult = new DbaAzureTablePage(
+                new[]
+                {
+                    new DbaAzureTableEntity(
+                        "p1",
+                        "r1",
+                        new Dictionary<string, object?> { ["DisplayName"] = "One" })
+                },
+                "opaque+token/2")
+        };
+        var source = (IDbaTableCopySource)new DbaAzureTablesAdapter(
+            store,
+            new DbaAzureTablesOptions { SelectColumns = new[] { "DisplayName" } });
+        var definition = new DbaTableCopyDefinition("SourceTable", "DestinationTable");
+
+        using var page = await source.ReadPageAsync(
+            new DbaTableCopyPageRequest(definition, "opaque+token/1", 37));
+
+        Assert.Equal("opaque+token/1", store.LastContinuationToken);
+        Assert.Equal(37, store.LastPageSize);
+        Assert.Contains("PartitionKey", store.LastSelect!);
+        Assert.Contains("RowKey", store.LastSelect!);
+        Assert.Equal("opaque+token/2", page.ContinuationToken);
+        Assert.Equal("p1", page.Data.Rows[0]["PartitionKey"]);
+        Assert.Equal("r1", page.Data.Rows[0]["RowKey"]);
+        Assert.Equal("One", page.Data.Rows[0]["DisplayName"]);
+    }
+
+    [Fact]
+    public async Task DestinationAdapterCreatesTableAndMapsDataRows()
+    {
+        var store = new RecordingStore();
+        var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(store);
+        var table = new DataTable();
+        table.Columns.Add("PartitionKey", typeof(string));
+        table.Columns.Add("RowKey", typeof(string));
+        table.Columns.Add("Enabled", typeof(bool));
+        table.Rows.Add("tenant-a", "item-1", true);
+
+        await destination.WritePageAsync(
+            new DbaTableCopyDefinition("SourceTable", "DestinationTable"),
+            table,
+            new DbaTableCopyOptions { BatchSize = 50 });
+
+        Assert.Equal("DestinationTable", store.CreatedTable);
+        Assert.Equal("DestinationTable", store.WrittenTable);
+        Assert.Equal(50, store.WrittenBatchSize);
+        var entity = Assert.Single(store.WrittenEntities!);
+        Assert.Equal("tenant-a", entity.PartitionKey);
+        Assert.Equal("item-1", entity.RowKey);
+        Assert.Equal(true, entity.Properties["Enabled"]);
+    }
+
+    [Fact]
+    public void BatchPlannerKeepsEachBatchInsideOnePartitionAndUnderLimit()
+    {
+        var entities = Enumerable.Range(0, 205)
+            .Select(index => new DbaAzureTableEntity("p1", index.ToString()))
+            .Concat(Enumerable.Range(0, 2).Select(index => new DbaAzureTableEntity("p2", index.ToString())))
+            .ToArray();
+
+        var batches = DbaAzureTableBatchPlanner.Plan(entities);
+
+        Assert.Equal(new[] { 100, 100, 5, 2 }, batches.Select(static batch => batch.Count));
+        Assert.All(batches, batch => Assert.Single(batch.Select(static entity => entity.PartitionKey).Distinct()));
+    }
+
+    [Fact]
+    public void BatchPlannerSplitsLargeSamePartitionPayloadsBeforeAzureLimit()
+    {
+        var payload = new string('x', 900_000);
+        var entities = Enumerable.Range(0, 4)
+            .Select(index => new DbaAzureTableEntity(
+                "p1",
+                index.ToString(),
+                new Dictionary<string, object?> { ["Payload"] = payload }))
+            .ToArray();
+
+        var batches = DbaAzureTableBatchPlanner.Plan(entities);
+
+        Assert.Equal(new[] { 3, 1 }, batches.Select(static batch => batch.Count));
+    }
+
+    [Fact]
+    public async Task ClearRequiresExplicitOptIn()
+    {
+        var store = new RecordingStore();
+        var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(store);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => destination.ClearAsync(
+            new DbaTableCopyDefinition("SourceTable", "DestinationTable")));
+
+        Assert.Contains("AllowClearDestination", exception.Message);
+        Assert.Null(store.ClearedTable);
+    }
+
+    [Fact]
+    public async Task RowCountingCanBeDisabledForLargeTables()
+    {
+        var store = new RecordingStore();
+        var adapter = new DbaAzureTablesAdapter(store, new DbaAzureTablesOptions { EnableRowCounts = false });
+        var definition = new DbaTableCopyDefinition("SourceTable", "DestinationTable");
+
+        var sourceCount = await ((IDbaTableCopySource)adapter).CountRowsAsync(definition);
+        var destinationCount = await ((IDbaTableCopyDestination)adapter).CountRowsAsync(definition);
+
+        Assert.Null(sourceCount);
+        Assert.Null(destinationCount);
+        Assert.Equal(0, store.CountCalls);
+    }
+
+    private sealed class RecordingStore : IDbaAzureTableStore
+    {
+        public DbaAzureTablePage QueryResult { get; init; } = new(Array.Empty<DbaAzureTableEntity>());
+
+        public string? LastContinuationToken { get; private set; }
+
+        public int LastPageSize { get; private set; }
+
+        public IReadOnlyList<string>? LastSelect { get; private set; }
+
+        public string? CreatedTable { get; private set; }
+
+        public string? WrittenTable { get; private set; }
+
+        public IReadOnlyList<DbaAzureTableEntity>? WrittenEntities { get; private set; }
+
+        public int WrittenBatchSize { get; private set; }
+
+        public string? ClearedTable { get; private set; }
+
+        public int CountCalls { get; private set; }
+
+        public Task<DbaAzureTablePage> QueryPageAsync(
+            string tableName,
+            string? filter,
+            IReadOnlyList<string>? select,
+            string? continuationToken,
+            int pageSize,
+            CancellationToken cancellationToken = default)
+        {
+            LastContinuationToken = continuationToken;
+            LastPageSize = pageSize;
+            LastSelect = select;
+            return Task.FromResult(QueryResult);
+        }
+
+        public Task<long> CountAsync(string tableName, string? filter = null, CancellationToken cancellationToken = default)
+        {
+            CountCalls++;
+            return Task.FromResult(0L);
+        }
+
+        public Task CreateTableIfNotExistsAsync(string tableName, CancellationToken cancellationToken = default)
+        {
+            CreatedTable = tableName;
+            return Task.CompletedTask;
+        }
+
+        public Task WriteAsync(
+            string tableName,
+            IReadOnlyList<DbaAzureTableEntity> entities,
+            DbaAzureTableWriteMode mode,
+            int batchSize,
+            CancellationToken cancellationToken = default)
+        {
+            WrittenTable = tableName;
+            WrittenEntities = entities;
+            WrittenBatchSize = batchSize;
+            return Task.CompletedTask;
+        }
+
+        public Task ClearAsync(string tableName, int batchSize, CancellationToken cancellationToken = default)
+        {
+            ClearedTable = tableName;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/DbaClientX.AzureTables.Tests/DbaAzureTablesContractTests.cs
+++ b/DbaClientX.AzureTables.Tests/DbaAzureTablesContractTests.cs
@@ -80,12 +80,16 @@ public class DbaAzureTablesContractTests
     [Fact]
     public void BatchPlannerSplitsLargeSamePartitionPayloadsBeforeAzureLimit()
     {
-        var payload = new string('x', 900_000);
+        var properties = Enumerable.Range(0, 30)
+            .ToDictionary(
+                static index => $"Payload{index}",
+                static _ => (object?)new string('x', 30_000),
+                StringComparer.Ordinal);
         var entities = Enumerable.Range(0, 4)
             .Select(index => new DbaAzureTableEntity(
                 "p1",
                 index.ToString(),
-                new Dictionary<string, object?> { ["Payload"] = payload }))
+                properties))
             .ToArray();
 
         var batches = DbaAzureTableBatchPlanner.Plan(entities);
@@ -155,6 +159,80 @@ public class DbaAzureTablesContractTests
         };
         var source = (IDbaTableCopySource)new DbaAzureTablesAdapter(store);
         var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(store, new DbaAzureTablesOptions { AllowClearDestination = true });
+
+        await Assert.ThrowsAsync<ArgumentException>(() => new DbaTableCopyEngine().CopyAsync(
+            source,
+            destination,
+            new[] { new DbaTableCopyDefinition("Source", "Destination") },
+            new DbaTableCopyOptions { ClearDestination = true }));
+
+        Assert.Null(store.ClearedTable);
+    }
+
+    [Fact]
+    public async Task InvalidKeysFailBeforeDestinationClear()
+    {
+        var store = new RecordingStore
+        {
+            QueryResult = new DbaAzureTablePage(new[] { new DbaAzureTableEntity("bad/key", "r1") })
+        };
+        var source = (IDbaTableCopySource)new DbaAzureTablesAdapter(store);
+        var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(
+            store,
+            new DbaAzureTablesOptions { AllowClearDestination = true });
+
+        await Assert.ThrowsAsync<ArgumentException>(() => new DbaTableCopyEngine().CopyAsync(
+            source,
+            destination,
+            new[] { new DbaTableCopyDefinition("Source", "Destination") },
+            new DbaTableCopyOptions { ClearDestination = true }));
+
+        Assert.Null(store.ClearedTable);
+    }
+
+    [Fact]
+    public async Task OversizedPropertiesFailBeforeDestinationClear()
+    {
+        var store = new RecordingStore
+        {
+            QueryResult = new DbaAzureTablePage(new[]
+            {
+                new DbaAzureTableEntity(
+                    "p1",
+                    "r1",
+                    new Dictionary<string, object?> { ["Payload"] = new string('x', 40_000) })
+            })
+        };
+        var source = (IDbaTableCopySource)new DbaAzureTablesAdapter(store);
+        var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(
+            store,
+            new DbaAzureTablesOptions { AllowClearDestination = true });
+
+        await Assert.ThrowsAsync<ArgumentException>(() => new DbaTableCopyEngine().CopyAsync(
+            source,
+            destination,
+            new[] { new DbaTableCopyDefinition("Source", "Destination") },
+            new DbaTableCopyOptions { ClearDestination = true }));
+
+        Assert.Null(store.ClearedTable);
+    }
+
+    [Fact]
+    public async Task OversizedEntitiesFailBeforeDestinationClear()
+    {
+        var properties = Enumerable.Range(0, 34)
+            .ToDictionary(
+                static index => $"Payload{index}",
+                static _ => (object?)new string('x', 30_000),
+                StringComparer.Ordinal);
+        var store = new RecordingStore
+        {
+            QueryResult = new DbaAzureTablePage(new[] { new DbaAzureTableEntity("p1", "r1", properties) })
+        };
+        var source = (IDbaTableCopySource)new DbaAzureTablesAdapter(store);
+        var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(
+            store,
+            new DbaAzureTablesOptions { AllowClearDestination = true });
 
         await Assert.ThrowsAsync<ArgumentException>(() => new DbaTableCopyEngine().CopyAsync(
             source,

--- a/DbaClientX.AzureTables.Tests/DbaAzureTablesContractTests.cs
+++ b/DbaClientX.AzureTables.Tests/DbaAzureTablesContractTests.cs
@@ -90,7 +90,145 @@ public class DbaAzureTablesContractTests
 
         var batches = DbaAzureTableBatchPlanner.Plan(entities);
 
-        Assert.Equal(new[] { 3, 1 }, batches.Select(static batch => batch.Count));
+        Assert.Equal(new[] { 1, 1, 1, 1 }, batches.Select(static batch => batch.Count));
+    }
+
+    [Fact]
+    public void BatchPlannerSeparatesDuplicateEntityKeysWithinOnePartition()
+    {
+        var entities = new[]
+        {
+            new DbaAzureTableEntity("p1", "same"),
+            new DbaAzureTableEntity("p1", "same")
+        };
+
+        var batches = DbaAzureTableBatchPlanner.Plan(entities);
+
+        Assert.Equal(new[] { 1, 1 }, batches.Select(static batch => batch.Count));
+    }
+
+    [Fact]
+    public async Task NativeEntitiesCanFlowDirectlyFromReadShapeToWriteShape()
+    {
+        var store = new RecordingStore();
+        var client = new DbaAzureTablesClient(store);
+        var entity = new DbaAzureTableEntity(
+            "p1",
+            "r1",
+            new Dictionary<string, object?> { ["DisplayName"] = "Ready" });
+
+        await client.WriteAsync("Reports", new[] { entity }, createTable: false);
+
+        DbaAzureTableEntity written = Assert.Single(store.WrittenEntities!);
+        Assert.Same(entity, written);
+        Assert.Equal("Ready", written.Properties["DisplayName"]);
+    }
+
+    [Fact]
+    public async Task CaseDistinctCustomPropertiesAreNotDiscardedAsSystemColumns()
+    {
+        var store = new RecordingStore();
+        var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(store);
+        var table = new DataTable { CaseSensitive = true };
+        table.Columns.Add("PartitionKey", typeof(string));
+        table.Columns.Add("RowKey", typeof(string));
+        table.Columns.Add("partitionkey", typeof(string));
+        table.Rows.Add("tenant-a", "item-1", "custom-value");
+
+        await destination.WritePageAsync(
+            new DbaTableCopyDefinition("Source", "Destination"),
+            table,
+            new DbaTableCopyOptions());
+
+        Assert.Equal("custom-value", Assert.Single(store.WrittenEntities!).Properties["partitionkey"]);
+    }
+
+    [Fact]
+    public async Task UnsupportedValuesFailBeforeDestinationClear()
+    {
+        var store = new RecordingStore
+        {
+            QueryResult = new DbaAzureTablePage(new[]
+            {
+                new DbaAzureTableEntity("p1", "r1", new Dictionary<string, object?> { ["Amount"] = 1.25m })
+            })
+        };
+        var source = (IDbaTableCopySource)new DbaAzureTablesAdapter(store);
+        var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(store, new DbaAzureTablesOptions { AllowClearDestination = true });
+
+        await Assert.ThrowsAsync<ArgumentException>(() => new DbaTableCopyEngine().CopyAsync(
+            source,
+            destination,
+            new[] { new DbaTableCopyDefinition("Source", "Destination") },
+            new DbaTableCopyOptions { ClearDestination = true }));
+
+        Assert.Null(store.ClearedTable);
+    }
+
+    [Fact]
+    public void TypedUnsupportedSchemaFailsEvenWhenItHasNoRows()
+    {
+        var store = new RecordingStore();
+        var destination = new DbaAzureTablesAdapter(store);
+        var table = new DataTable();
+        table.Columns.Add("PartitionKey", typeof(string));
+        table.Columns.Add("RowKey", typeof(string));
+        table.Columns.Add("Amount", typeof(decimal));
+
+        Assert.Throws<ArgumentException>(() => destination.ValidatePage(
+            new DbaTableCopyDefinition("Source", "Destination"), table));
+        Assert.Null(store.CreatedTable);
+    }
+
+    [Fact]
+    public void ClearSafetyRejectsSameServiceSourceOverlapAcrossDefinitions()
+    {
+        var store = new RecordingStore();
+        var source = (IDbaTableCopySource)new DbaAzureTablesAdapter(store);
+        var destination = (IDbaTableCopyClearSafetyValidator)new DbaAzureTablesAdapter(
+            store,
+            new DbaAzureTablesOptions { AllowClearDestination = true });
+        var definitions = new[]
+        {
+            new DbaTableCopyDefinition("Source", "Staging"),
+            new DbaTableCopyDefinition("Staging", "Final")
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => destination.ValidateClearOperation(source, definitions));
+
+        Assert.Contains("also used as source table", exception.Message);
+    }
+
+    [Fact]
+    public void ClearSafetyCanPreserveCaseDistinctCosmosTableNames()
+    {
+        var store = new RecordingStore();
+        var options = new DbaAzureTablesOptions {
+            AllowClearDestination = true,
+            TableNameComparison = DbaAzureTableNameComparison.Ordinal
+        };
+        var source = (IDbaTableCopySource)new DbaAzureTablesAdapter(store, options);
+        var destination = (IDbaTableCopyClearSafetyValidator)new DbaAzureTablesAdapter(store, options);
+
+        destination.ValidateClearOperation(
+            source,
+            new[] { new DbaTableCopyDefinition("Reports", "reports") });
+    }
+
+    [Fact]
+    public async Task DirectClientRejectsUnsupportedPropertiesBeforeCreatingTable()
+    {
+        var store = new RecordingStore();
+        var client = new DbaAzureTablesClient(store);
+        var entity = new DbaAzureTableEntity(
+            "p1",
+            "r1",
+            new Dictionary<string, object?> { ["Amount"] = 1.25m });
+
+        await Assert.ThrowsAsync<ArgumentException>(() => client.WriteAsync("Reports", new[] { entity }));
+
+        Assert.Null(store.CreatedTable);
+        Assert.Null(store.WrittenTable);
     }
 
     [Fact]
@@ -104,6 +242,20 @@ public class DbaAzureTablesContractTests
 
         Assert.Contains("AllowClearDestination", exception.Message);
         Assert.Null(store.ClearedTable);
+    }
+
+    [Fact]
+    public async Task ClearCreatesDestinationWhenAutoCreateIsEnabled()
+    {
+        var store = new RecordingStore();
+        var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(
+            store,
+            new DbaAzureTablesOptions { AllowClearDestination = true });
+
+        await destination.ClearAsync(new DbaTableCopyDefinition("SourceTable", "DestinationTable"));
+
+        Assert.Equal("DestinationTable", store.CreatedTable);
+        Assert.Equal("DestinationTable", store.ClearedTable);
     }
 
     [Fact]

--- a/DbaClientX.AzureTables.Tests/DbaAzureTablesContractTests.cs
+++ b/DbaClientX.AzureTables.Tests/DbaAzureTablesContractTests.cs
@@ -64,6 +64,25 @@ public class DbaAzureTablesContractTests
     }
 
     [Fact]
+    public async Task DestinationAdapterRejectsInvalidRowsBeforeCreatingTable()
+    {
+        var store = new RecordingStore();
+        var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(store);
+        var table = new DataTable();
+        table.Columns.Add("PartitionKey", typeof(string));
+        table.Columns.Add("RowKey", typeof(string));
+        table.Rows.Add("tenant-a", "bad/key");
+
+        await Assert.ThrowsAsync<ArgumentException>(() => destination.WritePageAsync(
+            new DbaTableCopyDefinition("SourceTable", "DestinationTable"),
+            table,
+            new DbaTableCopyOptions()));
+
+        Assert.Null(store.CreatedTable);
+        Assert.Null(store.WrittenTable);
+    }
+
+    [Fact]
     public void BatchPlannerKeepsEachBatchInsideOnePartitionAndUnderLimit()
     {
         var entities = Enumerable.Range(0, 205)

--- a/DbaClientX.AzureTables.Tests/DbaClientX.AzureTables.Tests.csproj
+++ b/DbaClientX.AzureTables.Tests/DbaClientX.AzureTables.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);xUnit1051</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DbaClientX.AzureTables\DbaClientX.AzureTables.csproj" />
+  </ItemGroup>
+</Project>

--- a/DbaClientX.AzureTables/AzureSdkTableStore.cs
+++ b/DbaClientX.AzureTables/AzureSdkTableStore.cs
@@ -1,0 +1,245 @@
+using Azure;
+using Azure.Data.Tables;
+
+namespace DBAClientX.AzureTables;
+
+/// <summary>Azure.Data.Tables implementation of the DbaClientX Azure Table boundary.</summary>
+public sealed class AzureSdkTableStore : IDbaAzureTableStore
+{
+    private const int AzureTransactionLimit = 100;
+    private readonly TableServiceClient _serviceClient;
+
+    /// <summary>Creates a store from an Azure Tables service client.</summary>
+    public AzureSdkTableStore(TableServiceClient serviceClient)
+        => _serviceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
+
+    /// <summary>Creates a store from an Azure Storage or Cosmos DB Table API connection string.</summary>
+    public AzureSdkTableStore(string connectionString)
+        : this(new TableServiceClient(connectionString))
+    {
+    }
+
+    /// <summary>Normalized service endpoint used by this store.</summary>
+    public Uri ServiceUri => _serviceClient.Uri;
+
+    /// <inheritdoc />
+    public async Task<DbaAzureTablePage> QueryPageAsync(
+        string tableName,
+        string? filter,
+        IReadOnlyList<string>? select,
+        string? continuationToken,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        ValidatePageSize(pageSize);
+        var client = GetTableClient(tableName);
+        await foreach (var page in client
+                           .QueryAsync<TableEntity>(filter, pageSize, select, cancellationToken)
+                           .AsPages(continuationToken, pageSize)
+                           .WithCancellation(cancellationToken)
+                           .ConfigureAwait(false))
+        {
+            return new DbaAzureTablePage(
+                page.Values.Select(ToDbaEntity).ToArray(),
+                page.ContinuationToken);
+        }
+
+        return new DbaAzureTablePage(Array.Empty<DbaAzureTableEntity>());
+    }
+
+    /// <inheritdoc />
+    public async Task<long> CountAsync(string tableName, string? filter = null, CancellationToken cancellationToken = default)
+    {
+        long count = 0;
+        var client = GetTableClient(tableName);
+        await foreach (var page in client
+                           .QueryAsync<TableEntity>(filter, maxPerPage: 1000, select: new[] { "PartitionKey", "RowKey" }, cancellationToken)
+                           .AsPages(pageSizeHint: 1000)
+                           .WithCancellation(cancellationToken)
+                           .ConfigureAwait(false))
+        {
+            count = checked(count + page.Values.Count);
+        }
+
+        return count;
+    }
+
+    /// <inheritdoc />
+    public async Task CreateTableIfNotExistsAsync(string tableName, CancellationToken cancellationToken = default)
+        => await GetTableClient(tableName).CreateIfNotExistsAsync(cancellationToken).ConfigureAwait(false);
+
+    /// <inheritdoc />
+    public async Task WriteAsync(
+        string tableName,
+        IReadOnlyList<DbaAzureTableEntity> entities,
+        DbaAzureTableWriteMode mode,
+        int batchSize,
+        CancellationToken cancellationToken = default)
+    {
+        if (entities == null)
+        {
+            throw new ArgumentNullException(nameof(entities));
+        }
+        ValidateBatchSize(batchSize);
+        var client = GetTableClient(tableName);
+
+        foreach (var batch in DbaAzureTableBatchPlanner.Plan(entities, batchSize))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var actions = batch
+                .Select(entity => new TableTransactionAction(ToActionType(mode), ToTableEntity(entity)))
+                .ToArray();
+            await client.SubmitTransactionAsync(actions, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task ClearAsync(string tableName, int batchSize, CancellationToken cancellationToken = default)
+    {
+        ValidateBatchSize(batchSize);
+        var client = GetTableClient(tableName);
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var page = await QueryFirstKeyPageAsync(client, cancellationToken).ConfigureAwait(false);
+            if (page.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var partition in page.GroupBy(static entity => entity.PartitionKey, StringComparer.Ordinal))
+            {
+                foreach (var batch in Batch(partition, batchSize))
+                {
+                    var actions = batch
+                        .Select(entity => new TableTransactionAction(TableTransactionActionType.Delete, entity, ETag.All))
+                        .ToArray();
+                    await client.SubmitTransactionAsync(actions, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+
+    private TableClient GetTableClient(string tableName)
+    {
+        if (string.IsNullOrWhiteSpace(tableName))
+        {
+            throw new ArgumentException("Table name cannot be null or whitespace.", nameof(tableName));
+        }
+
+        return _serviceClient.GetTableClient(tableName);
+    }
+
+    private static async Task<IReadOnlyList<TableEntity>> QueryFirstKeyPageAsync(
+        TableClient client,
+        CancellationToken cancellationToken)
+    {
+        await foreach (var page in client
+                           .QueryAsync<TableEntity>(maxPerPage: AzureTransactionLimit, select: new[] { "PartitionKey", "RowKey" }, cancellationToken: cancellationToken)
+                           .AsPages(pageSizeHint: AzureTransactionLimit)
+                           .WithCancellation(cancellationToken)
+                           .ConfigureAwait(false))
+        {
+            return page.Values;
+        }
+
+        return Array.Empty<TableEntity>();
+    }
+
+    private static DbaAzureTableEntity ToDbaEntity(TableEntity entity)
+    {
+        var properties = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var property in entity)
+        {
+            if (!IsSystemProperty(property.Key))
+            {
+                properties[property.Key] = property.Value;
+            }
+        }
+
+        return new DbaAzureTableEntity(
+            entity.PartitionKey,
+            entity.RowKey,
+            properties,
+            entity.Timestamp,
+            entity.ETag.ToString());
+    }
+
+    private static TableEntity ToTableEntity(DbaAzureTableEntity entity)
+    {
+        var tableEntity = new TableEntity(entity.PartitionKey, entity.RowKey);
+        foreach (var property in entity.Properties)
+        {
+            if (IsSystemProperty(property.Key))
+            {
+                continue;
+            }
+
+            tableEntity[property.Key] = NormalizePropertyValue(property.Key, property.Value);
+        }
+
+        return tableEntity;
+    }
+
+    private static object? NormalizePropertyValue(string propertyName, object? value)
+        => value switch
+        {
+            null => null,
+            DateTime dateTime => new DateTimeOffset(dateTime.ToUniversalTime(), TimeSpan.Zero),
+            string or byte[] or bool or double or Guid or int or long or DateTimeOffset => value,
+            _ => throw new ArgumentException(
+                $"Azure Table property '{propertyName}' has unsupported CLR type '{value.GetType().FullName}'. " +
+                "Supported values are string, byte[], bool, double, Guid, int, long, DateTime, DateTimeOffset, or null.")
+        };
+
+    private static bool IsSystemProperty(string name)
+        => string.Equals(name, "PartitionKey", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(name, "RowKey", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(name, "Timestamp", StringComparison.OrdinalIgnoreCase) ||
+           string.Equals(name, "ETag", StringComparison.OrdinalIgnoreCase);
+
+    private static TableTransactionActionType ToActionType(DbaAzureTableWriteMode mode)
+        => mode switch
+        {
+            DbaAzureTableWriteMode.Add => TableTransactionActionType.Add,
+            DbaAzureTableWriteMode.UpsertMerge => TableTransactionActionType.UpsertMerge,
+            DbaAzureTableWriteMode.UpsertReplace => TableTransactionActionType.UpsertReplace,
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported Azure Table write mode.")
+        };
+
+    private static IEnumerable<IReadOnlyList<T>> Batch<T>(IEnumerable<T> source, int batchSize)
+    {
+        var batch = new List<T>(batchSize);
+        foreach (var item in source)
+        {
+            batch.Add(item);
+            if (batch.Count == batchSize)
+            {
+                yield return batch;
+                batch = new List<T>(batchSize);
+            }
+        }
+
+        if (batch.Count > 0)
+        {
+            yield return batch;
+        }
+    }
+
+    private static void ValidatePageSize(int pageSize)
+    {
+        if (pageSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageSize), "Page size must be greater than zero.");
+        }
+    }
+
+    private static void ValidateBatchSize(int batchSize)
+    {
+        if (batchSize is < 1 or > AzureTransactionLimit)
+        {
+            throw new ArgumentOutOfRangeException(nameof(batchSize), "Azure Table transaction size must be between 1 and 100.");
+        }
+    }
+}

--- a/DbaClientX.AzureTables/AzureSdkTableStore.cs
+++ b/DbaClientX.AzureTables/AzureSdkTableStore.cs
@@ -81,9 +81,11 @@ public sealed class AzureSdkTableStore : IDbaAzureTableStore
             throw new ArgumentNullException(nameof(entities));
         }
         ValidateBatchSize(batchSize);
+        DbaAzureTableDataMapper.ValidateEntities(entities);
+        var batches = DbaAzureTableBatchPlanner.Plan(entities, batchSize);
         var client = GetTableClient(tableName);
 
-        foreach (var batch in DbaAzureTableBatchPlanner.Plan(entities, batchSize))
+        foreach (var batch in batches)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var actions = batch
@@ -171,33 +173,17 @@ public sealed class AzureSdkTableStore : IDbaAzureTableStore
         var tableEntity = new TableEntity(entity.PartitionKey, entity.RowKey);
         foreach (var property in entity.Properties)
         {
-            if (IsSystemProperty(property.Key))
-            {
-                continue;
-            }
-
-            tableEntity[property.Key] = NormalizePropertyValue(property.Key, property.Value);
+            tableEntity[property.Key] = DbaAzureTableDataMapper.NormalizePropertyValue(property.Key, property.Value);
         }
 
         return tableEntity;
     }
 
-    private static object? NormalizePropertyValue(string propertyName, object? value)
-        => value switch
-        {
-            null => null,
-            DateTime dateTime => new DateTimeOffset(dateTime.ToUniversalTime(), TimeSpan.Zero),
-            string or byte[] or bool or double or Guid or int or long or DateTimeOffset => value,
-            _ => throw new ArgumentException(
-                $"Azure Table property '{propertyName}' has unsupported CLR type '{value.GetType().FullName}'. " +
-                "Supported values are string, byte[], bool, double, Guid, int, long, DateTime, DateTimeOffset, or null.")
-        };
-
     private static bool IsSystemProperty(string name)
-        => string.Equals(name, "PartitionKey", StringComparison.OrdinalIgnoreCase) ||
-           string.Equals(name, "RowKey", StringComparison.OrdinalIgnoreCase) ||
-           string.Equals(name, "Timestamp", StringComparison.OrdinalIgnoreCase) ||
-           string.Equals(name, "ETag", StringComparison.OrdinalIgnoreCase);
+        => string.Equals(name, "PartitionKey", StringComparison.Ordinal) ||
+           string.Equals(name, "RowKey", StringComparison.Ordinal) ||
+           string.Equals(name, "Timestamp", StringComparison.Ordinal) ||
+           string.Equals(name, "ETag", StringComparison.Ordinal);
 
     private static TableTransactionActionType ToActionType(DbaAzureTableWriteMode mode)
         => mode switch

--- a/DbaClientX.AzureTables/DbaAzureTableBatchPlanner.cs
+++ b/DbaClientX.AzureTables/DbaAzureTableBatchPlanner.cs
@@ -1,8 +1,12 @@
+using System.Text;
+
 namespace DBAClientX.AzureTables;
 
 /// <summary>Plans transaction batches that stay inside one Azure Table partition.</summary>
 public static class DbaAzureTableBatchPlanner
 {
+    private const int MaximumKeyPayloadBytes = 1024;
+    private const int ConservativeEntityPayloadLimit = 1_000_000;
     private const int ConservativeTransactionPayloadLimit = 1_750_000;
 
     /// <summary>Groups entities by partition and splits each group into batches of at most 100 entities.</summary>
@@ -20,8 +24,19 @@ public static class DbaAzureTableBatchPlanner
             throw new ArgumentOutOfRangeException(nameof(batchSize), "Azure Table transaction size must be between 1 and 100.");
         }
 
+        var entityList = entities.ToArray();
+        foreach (DbaAzureTableEntity? entity in entityList)
+        {
+            if (entity == null)
+            {
+                throw new ArgumentException("Azure Table entity collections cannot contain null values.", nameof(entities));
+            }
+            ValidateKey(entity.PartitionKey, "PartitionKey", entity);
+            ValidateKey(entity.RowKey, "RowKey", entity);
+        }
+
         var batches = new List<IReadOnlyList<DbaAzureTableEntity>>();
-        foreach (var partition in entities.GroupBy(static entity => entity.PartitionKey, StringComparer.Ordinal))
+        foreach (var partition in entityList.GroupBy(static entity => entity.PartitionKey, StringComparer.Ordinal))
         {
             var batch = new List<DbaAzureTableEntity>(batchSize);
             var batchBytes = 0;
@@ -29,10 +44,10 @@ public static class DbaAzureTableBatchPlanner
             foreach (var entity in partition)
             {
                 var entityBytes = EstimatePayloadBytes(entity);
-                if (entityBytes > ConservativeTransactionPayloadLimit)
+                if (entityBytes > ConservativeEntityPayloadLimit)
                 {
                     throw new ArgumentException(
-                        $"Azure Table entity '{entity.PartitionKey}/{entity.RowKey}' is too large for a transaction payload.",
+                        $"Azure Table entity '{entity.PartitionKey}/{entity.RowKey}' exceeds the conservative 1 MB entity payload limit.",
                         nameof(entities));
                 }
 
@@ -57,6 +72,26 @@ public static class DbaAzureTableBatchPlanner
         }
 
         return batches;
+    }
+
+    private static void ValidateKey(string value, string keyName, DbaAzureTableEntity entity)
+    {
+        if (Encoding.UTF8.GetByteCount(value) > MaximumKeyPayloadBytes)
+        {
+            throw new ArgumentException(
+                $"Azure Table {keyName} for entity '{entity.PartitionKey}/{entity.RowKey}' exceeds the 1 KiB payload limit.",
+                nameof(entity));
+        }
+
+        foreach (char character in value)
+        {
+            if (character is '/' or '\\' or '#' or '?' || character <= '\u001f' || character is >= '\u007f' and <= '\u009f')
+            {
+                throw new ArgumentException(
+                    $"Azure Table {keyName} for entity '{entity.PartitionKey}/{entity.RowKey}' contains a forbidden character.",
+                    nameof(entity));
+            }
+        }
     }
 
     private static int EstimatePayloadBytes(DbaAzureTableEntity entity)

--- a/DbaClientX.AzureTables/DbaAzureTableBatchPlanner.cs
+++ b/DbaClientX.AzureTables/DbaAzureTableBatchPlanner.cs
@@ -1,0 +1,99 @@
+namespace DBAClientX.AzureTables;
+
+/// <summary>Plans transaction batches that stay inside one Azure Table partition.</summary>
+public static class DbaAzureTableBatchPlanner
+{
+    private const int ConservativeTransactionPayloadLimit = 3_500_000;
+
+    /// <summary>Groups entities by partition and splits each group into batches of at most 100 entities.</summary>
+    public static IReadOnlyList<IReadOnlyList<DbaAzureTableEntity>> Plan(
+        IEnumerable<DbaAzureTableEntity> entities,
+        int batchSize = 100)
+    {
+        if (entities == null)
+        {
+            throw new ArgumentNullException(nameof(entities));
+        }
+
+        if (batchSize is < 1 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(batchSize), "Azure Table transaction size must be between 1 and 100.");
+        }
+
+        var batches = new List<IReadOnlyList<DbaAzureTableEntity>>();
+        foreach (var partition in entities.GroupBy(static entity => entity.PartitionKey, StringComparer.Ordinal))
+        {
+            var batch = new List<DbaAzureTableEntity>(batchSize);
+            var batchBytes = 0;
+            foreach (var entity in partition)
+            {
+                var entityBytes = EstimatePayloadBytes(entity);
+                if (entityBytes > ConservativeTransactionPayloadLimit)
+                {
+                    throw new ArgumentException(
+                        $"Azure Table entity '{entity.PartitionKey}/{entity.RowKey}' is too large for a transaction payload.",
+                        nameof(entities));
+                }
+
+                if (batch.Count > 0 &&
+                    (batch.Count == batchSize || batchBytes + entityBytes > ConservativeTransactionPayloadLimit))
+                {
+                    batches.Add(batch);
+                    batch = new List<DbaAzureTableEntity>(batchSize);
+                    batchBytes = 0;
+                }
+
+                batch.Add(entity);
+                batchBytes += entityBytes;
+            }
+
+            if (batch.Count > 0)
+            {
+                batches.Add(batch);
+            }
+        }
+
+        return batches;
+    }
+
+    private static int EstimatePayloadBytes(DbaAzureTableEntity entity)
+    {
+        long size = 512L + EstimateJsonStringBytes(entity.PartitionKey) + EstimateJsonStringBytes(entity.RowKey);
+        foreach (var property in entity.Properties)
+        {
+            size += 32L + EstimateJsonStringBytes(property.Key) + EstimateValueBytes(property.Value);
+            if (size > int.MaxValue)
+            {
+                return int.MaxValue;
+            }
+        }
+
+        return (int)size;
+    }
+
+    private static long EstimateValueBytes(object? value)
+        => value switch
+        {
+            null => 8,
+            string text => EstimateJsonStringBytes(text),
+            byte[] bytes => 32L + ((bytes.LongLength + 2L) / 3L * 4L),
+            _ => 64
+        };
+
+    private static long EstimateJsonStringBytes(string value)
+    {
+        long size = 2;
+        foreach (var character in value)
+        {
+            size += character switch
+            {
+                '"' or '\\' => 2,
+                < ' ' => 6,
+                <= '\u007f' => 1,
+                _ => 6
+            };
+        }
+
+        return size;
+    }
+}

--- a/DbaClientX.AzureTables/DbaAzureTableBatchPlanner.cs
+++ b/DbaClientX.AzureTables/DbaAzureTableBatchPlanner.cs
@@ -3,7 +3,7 @@ namespace DBAClientX.AzureTables;
 /// <summary>Plans transaction batches that stay inside one Azure Table partition.</summary>
 public static class DbaAzureTableBatchPlanner
 {
-    private const int ConservativeTransactionPayloadLimit = 3_500_000;
+    private const int ConservativeTransactionPayloadLimit = 1_750_000;
 
     /// <summary>Groups entities by partition and splits each group into batches of at most 100 entities.</summary>
     public static IReadOnlyList<IReadOnlyList<DbaAzureTableEntity>> Plan(
@@ -25,6 +25,7 @@ public static class DbaAzureTableBatchPlanner
         {
             var batch = new List<DbaAzureTableEntity>(batchSize);
             var batchBytes = 0;
+            var rowKeys = new HashSet<string>(StringComparer.Ordinal);
             foreach (var entity in partition)
             {
                 var entityBytes = EstimatePayloadBytes(entity);
@@ -36,15 +37,17 @@ public static class DbaAzureTableBatchPlanner
                 }
 
                 if (batch.Count > 0 &&
-                    (batch.Count == batchSize || batchBytes + entityBytes > ConservativeTransactionPayloadLimit))
+                    (batch.Count == batchSize || batchBytes + entityBytes > ConservativeTransactionPayloadLimit || rowKeys.Contains(entity.RowKey)))
                 {
                     batches.Add(batch);
                     batch = new List<DbaAzureTableEntity>(batchSize);
                     batchBytes = 0;
+                    rowKeys.Clear();
                 }
 
                 batch.Add(entity);
                 batchBytes += entityBytes;
+                rowKeys.Add(entity.RowKey);
             }
 
             if (batch.Count > 0)

--- a/DbaClientX.AzureTables/DbaAzureTableDataMapper.cs
+++ b/DbaClientX.AzureTables/DbaAzureTableDataMapper.cs
@@ -1,0 +1,114 @@
+using System.Data;
+
+namespace DBAClientX.AzureTables;
+
+internal static class DbaAzureTableDataMapper
+{
+    private static readonly string[] SystemColumns = { "PartitionKey", "RowKey", "Timestamp", "ETag" };
+
+    public static DataTable ToDataTable(string tableName, IReadOnlyList<DbaAzureTableEntity> entities)
+    {
+        var table = new DataTable(tableName);
+        table.Columns.Add("PartitionKey", typeof(string));
+        table.Columns.Add("RowKey", typeof(string));
+        table.Columns.Add("Timestamp", typeof(DateTimeOffset));
+        table.Columns.Add("ETag", typeof(string));
+
+        foreach (var propertyName in entities
+                     .SelectMany(static entity => entity.Properties.Keys)
+                     .Where(static name => !IsSystemColumn(name))
+                     .Distinct(StringComparer.Ordinal))
+        {
+            table.Columns.Add(propertyName, typeof(object));
+        }
+
+        foreach (var entity in entities)
+        {
+            var row = table.NewRow();
+            row["PartitionKey"] = entity.PartitionKey;
+            row["RowKey"] = entity.RowKey;
+            row["Timestamp"] = entity.Timestamp.HasValue ? entity.Timestamp.Value : DBNull.Value;
+            row["ETag"] = entity.ETag ?? (object)DBNull.Value;
+            foreach (var property in entity.Properties)
+            {
+                if (table.Columns.Contains(property.Key) && !IsSystemColumn(property.Key))
+                {
+                    row[property.Key] = property.Value ?? DBNull.Value;
+                }
+            }
+
+            table.Rows.Add(row);
+        }
+
+        return table;
+    }
+
+    public static IReadOnlyList<DbaAzureTableEntity> ToEntities(DataTable table)
+    {
+        var partitionKeyColumn = FindRequiredColumn(table, "PartitionKey");
+        var rowKeyColumn = FindRequiredColumn(table, "RowKey");
+        var timestampColumn = FindColumn(table, "Timestamp");
+        var etagColumn = FindColumn(table, "ETag");
+        var entities = new List<DbaAzureTableEntity>(table.Rows.Count);
+
+        foreach (DataRow row in table.Rows)
+        {
+            if (row.IsNull(partitionKeyColumn) || row.IsNull(rowKeyColumn))
+            {
+                throw new InvalidOperationException("Every Azure Table row requires PartitionKey and RowKey values.");
+            }
+
+            var partitionKey = Convert.ToString(row[partitionKeyColumn], System.Globalization.CultureInfo.InvariantCulture)!;
+            var rowKey = Convert.ToString(row[rowKeyColumn], System.Globalization.CultureInfo.InvariantCulture)!;
+
+            var properties = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (DataColumn column in table.Columns)
+            {
+                if (!IsSystemColumn(column.ColumnName))
+                {
+                    properties[column.ColumnName] = row.IsNull(column) ? null : row[column];
+                }
+            }
+
+            entities.Add(new DbaAzureTableEntity(
+                partitionKey,
+                rowKey,
+                properties,
+                ToNullableDateTimeOffset(timestampColumn == null ? null : row[timestampColumn]),
+                etagColumn == null || row.IsNull(etagColumn) ? null : Convert.ToString(row[etagColumn], System.Globalization.CultureInfo.InvariantCulture)));
+        }
+
+        return entities;
+    }
+
+    public static IReadOnlyList<string>? IncludeKeys(IReadOnlyList<string>? select)
+    {
+        if (select == null || select.Count == 0)
+        {
+            return select;
+        }
+
+        return select
+            .Concat(new[] { "PartitionKey", "RowKey" })
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static DataColumn FindRequiredColumn(DataTable table, string name)
+        => FindColumn(table, name) ?? throw new InvalidOperationException($"Azure Table data requires a '{name}' column.");
+
+    private static DataColumn? FindColumn(DataTable table, string name)
+        => table.Columns.Cast<DataColumn>().SingleOrDefault(column => string.Equals(column.ColumnName, name, StringComparison.OrdinalIgnoreCase));
+
+    private static DateTimeOffset? ToNullableDateTimeOffset(object? value)
+        => value switch
+        {
+            null or DBNull => null,
+            DateTimeOffset dateTimeOffset => dateTimeOffset,
+            DateTime dateTime => new DateTimeOffset(dateTime),
+            _ => null
+        };
+
+    private static bool IsSystemColumn(string name)
+        => SystemColumns.Contains(name, StringComparer.OrdinalIgnoreCase);
+}

--- a/DbaClientX.AzureTables/DbaAzureTableDataMapper.cs
+++ b/DbaClientX.AzureTables/DbaAzureTableDataMapper.cs
@@ -1,9 +1,11 @@
 using System.Data;
+using System.Text;
 
 namespace DBAClientX.AzureTables;
 
 internal static class DbaAzureTableDataMapper
 {
+    private const int MaximumPropertyPayloadBytes = 64 * 1024;
     private static readonly string[] SystemColumns = { "PartitionKey", "RowKey", "Timestamp", "ETag" };
 
     public static DataTable ToDataTable(string tableName, IReadOnlyList<DbaAzureTableEntity> entities)
@@ -140,7 +142,13 @@ internal static class DbaAzureTableDataMapper
         {
             null => null,
             DateTime dateTime => new DateTimeOffset(dateTime.ToUniversalTime(), TimeSpan.Zero),
-            string or byte[] or bool or double or Guid or int or long or DateTimeOffset => value,
+            string text when Encoding.Unicode.GetByteCount(text) <= MaximumPropertyPayloadBytes => text,
+            string => throw new ArgumentException(
+                $"Azure Table string property '{propertyName}' exceeds the 64 KiB UTF-16 payload limit."),
+            byte[] bytes when bytes.Length <= MaximumPropertyPayloadBytes => bytes,
+            byte[] => throw new ArgumentException(
+                $"Azure Table binary property '{propertyName}' exceeds the 64 KiB payload limit."),
+            bool or double or Guid or int or long or DateTimeOffset => value,
             _ => throw new ArgumentException(
                 $"Azure Table property '{propertyName}' has unsupported CLR type '{value.GetType().FullName}'. " +
                 "Supported values are string, byte[], bool, double, Guid, int, long, DateTime, DateTimeOffset, or null.")

--- a/DbaClientX.AzureTables/DbaAzureTableDataMapper.cs
+++ b/DbaClientX.AzureTables/DbaAzureTableDataMapper.cs
@@ -31,9 +31,10 @@ internal static class DbaAzureTableDataMapper
             row["ETag"] = entity.ETag ?? (object)DBNull.Value;
             foreach (var property in entity.Properties)
             {
-                if (table.Columns.Contains(property.Key) && !IsSystemColumn(property.Key))
+                DataColumn? column = FindColumn(table, property.Key);
+                if (column != null && !IsSystemColumn(property.Key))
                 {
-                    row[property.Key] = property.Value ?? DBNull.Value;
+                    row[column] = property.Value ?? DBNull.Value;
                 }
             }
 
@@ -51,6 +52,14 @@ internal static class DbaAzureTableDataMapper
         var etagColumn = FindColumn(table, "ETag");
         var entities = new List<DbaAzureTableEntity>(table.Rows.Count);
 
+        foreach (DataColumn column in table.Columns)
+        {
+            if (!IsSystemColumn(column.ColumnName))
+            {
+                ValidateColumnType(column);
+            }
+        }
+
         foreach (DataRow row in table.Rows)
         {
             if (row.IsNull(partitionKeyColumn) || row.IsNull(rowKeyColumn))
@@ -66,7 +75,9 @@ internal static class DbaAzureTableDataMapper
             {
                 if (!IsSystemColumn(column.ColumnName))
                 {
-                    properties[column.ColumnName] = row.IsNull(column) ? null : row[column];
+                    properties[column.ColumnName] = row.IsNull(column)
+                        ? null
+                        : NormalizePropertyValue(column.ColumnName, row[column]);
                 }
             }
 
@@ -98,7 +109,55 @@ internal static class DbaAzureTableDataMapper
         => FindColumn(table, name) ?? throw new InvalidOperationException($"Azure Table data requires a '{name}' column.");
 
     private static DataColumn? FindColumn(DataTable table, string name)
-        => table.Columns.Cast<DataColumn>().SingleOrDefault(column => string.Equals(column.ColumnName, name, StringComparison.OrdinalIgnoreCase));
+        => table.Columns.Cast<DataColumn>().SingleOrDefault(column => string.Equals(column.ColumnName, name, StringComparison.Ordinal));
+
+    internal static void ValidateEntities(IEnumerable<DbaAzureTableEntity> entities)
+    {
+        if (entities == null)
+        {
+            throw new ArgumentNullException(nameof(entities));
+        }
+
+        foreach (DbaAzureTableEntity entity in entities)
+        {
+            if (entity == null)
+            {
+                throw new ArgumentException("Azure Table entity collections cannot contain null values.", nameof(entities));
+            }
+            foreach (var property in entity.Properties)
+            {
+                if (IsSystemColumn(property.Key))
+                {
+                    throw new ArgumentException($"Azure Table property '{property.Key}' is reserved for entity metadata.", nameof(entities));
+                }
+                _ = NormalizePropertyValue(property.Key, property.Value);
+            }
+        }
+    }
+
+    internal static object? NormalizePropertyValue(string propertyName, object? value)
+        => value switch
+        {
+            null => null,
+            DateTime dateTime => new DateTimeOffset(dateTime.ToUniversalTime(), TimeSpan.Zero),
+            string or byte[] or bool or double or Guid or int or long or DateTimeOffset => value,
+            _ => throw new ArgumentException(
+                $"Azure Table property '{propertyName}' has unsupported CLR type '{value.GetType().FullName}'. " +
+                "Supported values are string, byte[], bool, double, Guid, int, long, DateTime, DateTimeOffset, or null.")
+        };
+
+    private static void ValidateColumnType(DataColumn column)
+    {
+        Type type = column.DataType;
+        if (type != typeof(object) && type != typeof(string) && type != typeof(byte[]) && type != typeof(bool) &&
+            type != typeof(double) && type != typeof(Guid) && type != typeof(int) && type != typeof(long) &&
+            type != typeof(DateTime) && type != typeof(DateTimeOffset))
+        {
+            throw new ArgumentException(
+                $"Azure Table column '{column.ColumnName}' has unsupported CLR type '{type.FullName}'. " +
+                "Supported columns use string, byte[], bool, double, Guid, int, long, DateTime, DateTimeOffset, or object values.");
+        }
+    }
 
     private static DateTimeOffset? ToNullableDateTimeOffset(object? value)
         => value switch
@@ -110,5 +169,5 @@ internal static class DbaAzureTableDataMapper
         };
 
     private static bool IsSystemColumn(string name)
-        => SystemColumns.Contains(name, StringComparer.OrdinalIgnoreCase);
+        => SystemColumns.Contains(name, StringComparer.Ordinal);
 }

--- a/DbaClientX.AzureTables/DbaAzureTableEntity.cs
+++ b/DbaClientX.AzureTables/DbaAzureTableEntity.cs
@@ -1,0 +1,45 @@
+namespace DBAClientX.AzureTables;
+
+/// <summary>Provider-neutral representation of one Azure Table entity.</summary>
+public sealed class DbaAzureTableEntity
+{
+    /// <summary>Creates an entity from its required keys and optional properties.</summary>
+    public DbaAzureTableEntity(
+        string partitionKey,
+        string rowKey,
+        IReadOnlyDictionary<string, object?>? properties = null,
+        DateTimeOffset? timestamp = null,
+        string? etag = null)
+    {
+        if (partitionKey == null)
+        {
+            throw new ArgumentNullException(nameof(partitionKey));
+        }
+
+        if (rowKey == null)
+        {
+            throw new ArgumentNullException(nameof(rowKey));
+        }
+
+        PartitionKey = partitionKey;
+        RowKey = rowKey;
+        Properties = properties ?? new Dictionary<string, object?>(StringComparer.Ordinal);
+        Timestamp = timestamp;
+        ETag = etag;
+    }
+
+    /// <summary>Azure Table partition key.</summary>
+    public string PartitionKey { get; }
+
+    /// <summary>Azure Table row key.</summary>
+    public string RowKey { get; }
+
+    /// <summary>Entity properties excluding Azure system properties.</summary>
+    public IReadOnlyDictionary<string, object?> Properties { get; }
+
+    /// <summary>Server-maintained modification timestamp when returned by a query.</summary>
+    public DateTimeOffset? Timestamp { get; }
+
+    /// <summary>Entity tag used for optimistic concurrency when returned by a query.</summary>
+    public string? ETag { get; }
+}

--- a/DbaClientX.AzureTables/DbaAzureTablePage.cs
+++ b/DbaClientX.AzureTables/DbaAzureTablePage.cs
@@ -1,0 +1,23 @@
+namespace DBAClientX.AzureTables;
+
+/// <summary>A page of Azure Table entities and the opaque token for the following page.</summary>
+public sealed class DbaAzureTablePage
+{
+    /// <summary>Creates an Azure Table page.</summary>
+    public DbaAzureTablePage(IReadOnlyList<DbaAzureTableEntity> entities, string? continuationToken = null)
+    {
+        Entities = entities ?? throw new ArgumentNullException(nameof(entities));
+        if (continuationToken != null && continuationToken.Length == 0)
+        {
+            throw new ArgumentException("Continuation token cannot be empty.", nameof(continuationToken));
+        }
+
+        ContinuationToken = continuationToken;
+    }
+
+    /// <summary>Entities returned in this page.</summary>
+    public IReadOnlyList<DbaAzureTableEntity> Entities { get; }
+
+    /// <summary>Opaque Azure continuation token, or null when the query is complete.</summary>
+    public string? ContinuationToken { get; }
+}

--- a/DbaClientX.AzureTables/DbaAzureTableWriteMode.cs
+++ b/DbaClientX.AzureTables/DbaAzureTableWriteMode.cs
@@ -1,0 +1,14 @@
+namespace DBAClientX.AzureTables;
+
+/// <summary>Controls how Azure Table entities are written.</summary>
+public enum DbaAzureTableWriteMode
+{
+    /// <summary>Insert new entities and fail when an entity already exists.</summary>
+    Add,
+
+    /// <summary>Insert entities or merge the supplied properties into existing entities.</summary>
+    UpsertMerge,
+
+    /// <summary>Insert entities or replace existing entities.</summary>
+    UpsertReplace
+}

--- a/DbaClientX.AzureTables/DbaAzureTablesAdapter.cs
+++ b/DbaClientX.AzureTables/DbaAzureTablesAdapter.cs
@@ -110,7 +110,9 @@ public sealed class DbaAzureTablesAdapter :
         {
             throw new ArgumentNullException(nameof(page));
         }
-        _ = DbaAzureTableDataMapper.ToEntities(page);
+        IReadOnlyList<DbaAzureTableEntity> entities = DbaAzureTableDataMapper.ToEntities(page);
+        DbaAzureTableDataMapper.ValidateEntities(entities);
+        _ = DbaAzureTableBatchPlanner.Plan(entities, _options.BatchSize);
     }
 
     /// <inheritdoc />

--- a/DbaClientX.AzureTables/DbaAzureTablesAdapter.cs
+++ b/DbaClientX.AzureTables/DbaAzureTablesAdapter.cs
@@ -10,7 +10,8 @@ public sealed class DbaAzureTablesAdapter :
     IDbaTableCopyDestination,
     IDbaTableCopyPagePreflightDestination,
     IDbaTableCopyEmptyPageDestination,
-    IDbaTableCopyMissingTableClassifier
+    IDbaTableCopyMissingTableClassifier,
+    IDbaTableCopyClearSafetyValidator
 {
     private readonly IDbaAzureTableStore _store;
     private readonly DbaAzureTablesOptions _options;
@@ -58,6 +59,11 @@ public sealed class DbaAzureTablesAdapter :
         {
             throw new InvalidOperationException(
                 "Clearing an Azure Table requires DbaAzureTablesOptions.AllowClearDestination = true.");
+        }
+
+        if (_options.CreateDestinationTable)
+        {
+            await _store.CreateTableIfNotExistsAsync(definition.DestinationName, cancellationToken).ConfigureAwait(false);
         }
 
         await _store.ClearAsync(definition.DestinationName, _options.BatchSize, cancellationToken).ConfigureAwait(false);
@@ -114,4 +120,53 @@ public sealed class DbaAzureTablesAdapter :
     /// <inheritdoc />
     public bool IsMissingTableException(Exception exception)
         => exception is RequestFailedException { Status: 404 };
+
+    /// <inheritdoc />
+    public void ValidateClearOperation(IDbaTableCopySource source, IReadOnlyList<DbaTableCopyDefinition> definitions)
+    {
+        if (source is not DbaAzureTablesAdapter sourceAdapter || !TargetsSameService(sourceAdapter))
+        {
+            return;
+        }
+
+        var comparer = ResolveTableNameComparer(sourceAdapter);
+        foreach (var destinationDefinition in definitions)
+        {
+            foreach (var sourceDefinition in definitions)
+            {
+                if (comparer.Equals(destinationDefinition.DestinationName.Trim(), sourceDefinition.SourceName.Trim()))
+                {
+                    throw new InvalidOperationException(
+                        $"Refusing to clear destination Azure Table '{destinationDefinition.DestinationName}' because it is also used as source table '{sourceDefinition.SourceName}' on the same service.");
+                }
+            }
+        }
+    }
+
+    private bool TargetsSameService(DbaAzureTablesAdapter source)
+    {
+        if (ReferenceEquals(_store, source._store))
+        {
+            return true;
+        }
+
+        return ServiceUri != null && source.ServiceUri != null &&
+               Uri.Compare(ServiceUri, source.ServiceUri, UriComponents.SchemeAndServer | UriComponents.Path, UriFormat.SafeUnescaped, StringComparison.OrdinalIgnoreCase) == 0;
+    }
+
+    private StringComparer ResolveTableNameComparer(DbaAzureTablesAdapter source)
+    {
+        DbaAzureTableNameComparison mode = _options.TableNameComparison != DbaAzureTableNameComparison.Auto
+            ? _options.TableNameComparison
+            : source._options.TableNameComparison;
+        if (mode == DbaAzureTableNameComparison.Auto)
+        {
+            Uri? endpoint = ServiceUri ?? source.ServiceUri;
+            mode = endpoint != null && endpoint.Host.IndexOf(".table.cosmos.", StringComparison.OrdinalIgnoreCase) >= 0
+                ? DbaAzureTableNameComparison.Ordinal
+                : DbaAzureTableNameComparison.OrdinalIgnoreCase;
+        }
+
+        return mode == DbaAzureTableNameComparison.Ordinal ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+    }
 }

--- a/DbaClientX.AzureTables/DbaAzureTablesAdapter.cs
+++ b/DbaClientX.AzureTables/DbaAzureTablesAdapter.cs
@@ -1,0 +1,117 @@
+using System.Data;
+using Azure;
+using DBAClientX.DataMovement;
+
+namespace DBAClientX.AzureTables;
+
+/// <summary>Connects Azure Table data to the provider-neutral DbaClientX copy engine.</summary>
+public sealed class DbaAzureTablesAdapter :
+    IDbaTableCopySource,
+    IDbaTableCopyDestination,
+    IDbaTableCopyPagePreflightDestination,
+    IDbaTableCopyEmptyPageDestination,
+    IDbaTableCopyMissingTableClassifier
+{
+    private readonly IDbaAzureTableStore _store;
+    private readonly DbaAzureTablesOptions _options;
+
+    /// <summary>Creates an adapter over an Azure Tables store.</summary>
+    public DbaAzureTablesAdapter(IDbaAzureTableStore store, DbaAzureTablesOptions? options = null)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _options = options ?? new DbaAzureTablesOptions();
+        _options.Validate();
+    }
+
+    /// <summary>Creates an adapter from an Azure Storage or Cosmos DB Table API connection string.</summary>
+    public DbaAzureTablesAdapter(string connectionString, DbaAzureTablesOptions? options = null)
+        : this(new AzureSdkTableStore(connectionString), options)
+    {
+    }
+
+    /// <summary>Normalized Azure Tables service endpoint when the SDK-backed store is used.</summary>
+    public Uri? ServiceUri => (_store as AzureSdkTableStore)?.ServiceUri;
+
+    async Task<long?> IDbaTableCopySource.CountRowsAsync(DbaTableCopyDefinition definition, CancellationToken cancellationToken)
+        => _options.EnableRowCounts
+            ? await _store.CountAsync(definition.SourceName, _options.SourceFilter, cancellationToken).ConfigureAwait(false)
+            : null;
+
+    async Task<DbaTableCopyPage> IDbaTableCopySource.ReadPageAsync(DbaTableCopyPageRequest request, CancellationToken cancellationToken)
+    {
+        var page = await _store.QueryPageAsync(
+                request.Definition.SourceName,
+                _options.SourceFilter,
+                DbaAzureTableDataMapper.IncludeKeys(_options.SelectColumns),
+                request.ContinuationToken,
+                request.PageSize,
+                cancellationToken)
+            .ConfigureAwait(false);
+        return new DbaTableCopyPage(
+            DbaAzureTableDataMapper.ToDataTable(request.Definition.SourceName, page.Entities),
+            page.ContinuationToken);
+    }
+
+    async Task IDbaTableCopyDestination.ClearAsync(DbaTableCopyDefinition definition, CancellationToken cancellationToken)
+    {
+        if (!_options.AllowClearDestination)
+        {
+            throw new InvalidOperationException(
+                "Clearing an Azure Table requires DbaAzureTablesOptions.AllowClearDestination = true.");
+        }
+
+        await _store.ClearAsync(definition.DestinationName, _options.BatchSize, cancellationToken).ConfigureAwait(false);
+    }
+
+    async Task IDbaTableCopyDestination.WritePageAsync(
+        DbaTableCopyDefinition definition,
+        DataTable page,
+        DbaTableCopyOptions options,
+        CancellationToken cancellationToken)
+    {
+        var batchSize = options.BatchSize ?? _options.BatchSize;
+        if (batchSize is < 1 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(options), "Azure Table transaction size must be between 1 and 100.");
+        }
+
+        if (_options.CreateDestinationTable)
+        {
+            await _store.CreateTableIfNotExistsAsync(definition.DestinationName, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (page.Rows.Count > 0)
+        {
+            await _store.WriteAsync(
+                    definition.DestinationName,
+                    DbaAzureTableDataMapper.ToEntities(page),
+                    _options.WriteMode,
+                    batchSize,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    async Task<long?> IDbaTableCopyDestination.CountRowsAsync(DbaTableCopyDefinition definition, CancellationToken cancellationToken)
+        => _options.EnableRowCounts
+            ? await _store.CountAsync(definition.DestinationName, cancellationToken: cancellationToken).ConfigureAwait(false)
+            : null;
+
+    /// <inheritdoc />
+    public void ValidatePage(DbaTableCopyDefinition definition, DataTable page)
+    {
+        if (page == null)
+        {
+            throw new ArgumentNullException(nameof(page));
+        }
+        _ = DbaAzureTableDataMapper.ToEntities(page);
+    }
+
+    /// <inheritdoc />
+    public bool ShouldWriteEmptyPage(DbaTableCopyDefinition definition)
+        => _options.CreateDestinationTable;
+
+    /// <inheritdoc />
+    public bool IsMissingTableException(Exception exception)
+        => exception is RequestFailedException { Status: 404 };
+}

--- a/DbaClientX.AzureTables/DbaAzureTablesAdapter.cs
+++ b/DbaClientX.AzureTables/DbaAzureTablesAdapter.cs
@@ -81,16 +81,20 @@ public sealed class DbaAzureTablesAdapter :
             throw new ArgumentOutOfRangeException(nameof(options), "Azure Table transaction size must be between 1 and 100.");
         }
 
+        IReadOnlyList<DbaAzureTableEntity> entities = DbaAzureTableDataMapper.ToEntities(page);
+        DbaAzureTableDataMapper.ValidateEntities(entities);
+        _ = DbaAzureTableBatchPlanner.Plan(entities, batchSize);
+
         if (_options.CreateDestinationTable)
         {
             await _store.CreateTableIfNotExistsAsync(definition.DestinationName, cancellationToken).ConfigureAwait(false);
         }
 
-        if (page.Rows.Count > 0)
+        if (entities.Count > 0)
         {
             await _store.WriteAsync(
                     definition.DestinationName,
-                    DbaAzureTableDataMapper.ToEntities(page),
+                    entities,
                     _options.WriteMode,
                     batchSize,
                     cancellationToken)

--- a/DbaClientX.AzureTables/DbaAzureTablesClient.cs
+++ b/DbaClientX.AzureTables/DbaAzureTablesClient.cs
@@ -1,0 +1,56 @@
+namespace DBAClientX.AzureTables;
+
+/// <summary>Thin reusable client for querying and mutating Azure Table data.</summary>
+public sealed class DbaAzureTablesClient
+{
+    private readonly IDbaAzureTableStore _store;
+
+    /// <summary>Creates a client over a store implementation.</summary>
+    public DbaAzureTablesClient(IDbaAzureTableStore store)
+        => _store = store ?? throw new ArgumentNullException(nameof(store));
+
+    /// <summary>Creates a client from an Azure Storage or Cosmos DB Table API connection string.</summary>
+    public DbaAzureTablesClient(string connectionString)
+        : this(new AzureSdkTableStore(connectionString))
+    {
+    }
+
+    /// <summary>Reads one entity page while preserving the Azure continuation token.</summary>
+    public Task<DbaAzureTablePage> QueryPageAsync(
+        string tableName,
+        string? filter = null,
+        IReadOnlyList<string>? select = null,
+        string? continuationToken = null,
+        int pageSize = 1000,
+        CancellationToken cancellationToken = default)
+        => _store.QueryPageAsync(tableName, filter, select, continuationToken, pageSize, cancellationToken);
+
+    /// <summary>Counts entities matching an optional filter.</summary>
+    public Task<long> CountAsync(string tableName, string? filter = null, CancellationToken cancellationToken = default)
+        => _store.CountAsync(tableName, filter, cancellationToken);
+
+    /// <summary>Creates a table when it does not exist.</summary>
+    public Task CreateTableIfNotExistsAsync(string tableName, CancellationToken cancellationToken = default)
+        => _store.CreateTableIfNotExistsAsync(tableName, cancellationToken);
+
+    /// <summary>Writes entities in partition-safe transactions.</summary>
+    public async Task WriteAsync(
+        string tableName,
+        IReadOnlyList<DbaAzureTableEntity> entities,
+        DbaAzureTableWriteMode mode = DbaAzureTableWriteMode.UpsertReplace,
+        int batchSize = 100,
+        bool createTable = true,
+        CancellationToken cancellationToken = default)
+    {
+        if (createTable)
+        {
+            await _store.CreateTableIfNotExistsAsync(tableName, cancellationToken).ConfigureAwait(false);
+        }
+
+        await _store.WriteAsync(tableName, entities, mode, batchSize, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Deletes every entity while preserving the table resource.</summary>
+    public Task ClearAsync(string tableName, int batchSize = 100, CancellationToken cancellationToken = default)
+        => _store.ClearAsync(tableName, batchSize, cancellationToken);
+}

--- a/DbaClientX.AzureTables/DbaAzureTablesClient.cs
+++ b/DbaClientX.AzureTables/DbaAzureTablesClient.cs
@@ -42,6 +42,12 @@ public sealed class DbaAzureTablesClient
         bool createTable = true,
         CancellationToken cancellationToken = default)
     {
+        if (entities == null)
+        {
+            throw new ArgumentNullException(nameof(entities));
+        }
+        DbaAzureTableDataMapper.ValidateEntities(entities);
+        _ = DbaAzureTableBatchPlanner.Plan(entities, batchSize);
         if (createTable)
         {
             await _store.CreateTableIfNotExistsAsync(tableName, cancellationToken).ConfigureAwait(false);

--- a/DbaClientX.AzureTables/DbaAzureTablesOptions.cs
+++ b/DbaClientX.AzureTables/DbaAzureTablesOptions.cs
@@ -1,0 +1,36 @@
+namespace DBAClientX.AzureTables;
+
+/// <summary>Configures Azure Tables query and copy behavior.</summary>
+public sealed class DbaAzureTablesOptions
+{
+    /// <summary>Optional OData filter applied to source reads and source counts.</summary>
+    public string? SourceFilter { get; init; }
+
+    /// <summary>Optional source projection. PartitionKey and RowKey are always included.</summary>
+    public IReadOnlyList<string>? SelectColumns { get; init; }
+
+    /// <summary>Write behavior used for destination entities.</summary>
+    public DbaAzureTableWriteMode WriteMode { get; init; } = DbaAzureTableWriteMode.UpsertReplace;
+
+    /// <summary>Create a missing destination table before the first write.</summary>
+    public bool CreateDestinationTable { get; init; } = true;
+
+    /// <summary>Allow explicit ClearDestination operations.</summary>
+    public bool AllowClearDestination { get; init; }
+
+    /// <summary>
+    /// Enumerate entities for source and destination row-count verification. Disable for large tables when the extra scans are undesirable.
+    /// </summary>
+    public bool EnableRowCounts { get; init; } = true;
+
+    /// <summary>Default transaction size. Azure Table transactions are capped at 100 entities in one partition.</summary>
+    public int BatchSize { get; init; } = 100;
+
+    internal void Validate()
+    {
+        if (BatchSize is < 1 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(BatchSize), "Azure Table batch size must be between 1 and 100.");
+        }
+    }
+}

--- a/DbaClientX.AzureTables/DbaAzureTablesOptions.cs
+++ b/DbaClientX.AzureTables/DbaAzureTablesOptions.cs
@@ -1,5 +1,16 @@
 namespace DBAClientX.AzureTables;
 
+/// <summary>Controls how Azure Table names are compared for destructive copy-safety checks.</summary>
+public enum DbaAzureTableNameComparison
+{
+    /// <summary>Use case-sensitive comparison for Cosmos DB Table API and case-insensitive comparison for Azure Storage Tables.</summary>
+    Auto,
+    /// <summary>Compare table names case-sensitively.</summary>
+    Ordinal,
+    /// <summary>Compare table names case-insensitively.</summary>
+    OrdinalIgnoreCase
+}
+
 /// <summary>Configures Azure Tables query and copy behavior.</summary>
 public sealed class DbaAzureTablesOptions
 {
@@ -26,11 +37,18 @@ public sealed class DbaAzureTablesOptions
     /// <summary>Default transaction size. Azure Table transactions are capped at 100 entities in one partition.</summary>
     public int BatchSize { get; init; } = 100;
 
+    /// <summary>Table-name comparison used by destructive copy-safety checks.</summary>
+    public DbaAzureTableNameComparison TableNameComparison { get; init; } = DbaAzureTableNameComparison.Auto;
+
     internal void Validate()
     {
         if (BatchSize is < 1 or > 100)
         {
             throw new ArgumentOutOfRangeException(nameof(BatchSize), "Azure Table batch size must be between 1 and 100.");
+        }
+        if (!Enum.IsDefined(typeof(DbaAzureTableNameComparison), TableNameComparison))
+        {
+            throw new ArgumentOutOfRangeException(nameof(TableNameComparison), "Unsupported Azure Table name comparison mode.");
         }
     }
 }

--- a/DbaClientX.AzureTables/DbaClientX.AzureTables.csproj
+++ b/DbaClientX.AzureTables/DbaClientX.AzureTables.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Description>DbaClientX Azure Tables provider</Description>
+    <AssemblyName>DbaClientX.AzureTables</AssemblyName>
+    <AssemblyTitle>DbaClientX.AzureTables</AssemblyTitle>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageId>DbaClientX.AzureTables</PackageId>
+    <PackageProjectUrl>https://github.com/EvotecIT/DbaClientX</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/EvotecIT/DbaClientX</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <IsPublishable>true</IsPublishable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
+    <PackageReference Include="Azure.Data.Tables" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+</Project>

--- a/DbaClientX.AzureTables/IDbaAzureTableStore.cs
+++ b/DbaClientX.AzureTables/IDbaAzureTableStore.cs
@@ -1,0 +1,31 @@
+namespace DBAClientX.AzureTables;
+
+/// <summary>Narrow Azure Table boundary used by the reusable adapter and offline contract tests.</summary>
+public interface IDbaAzureTableStore
+{
+    /// <summary>Reads one page without interpreting the provider continuation token.</summary>
+    Task<DbaAzureTablePage> QueryPageAsync(
+        string tableName,
+        string? filter,
+        IReadOnlyList<string>? select,
+        string? continuationToken,
+        int pageSize,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Counts entities matching an optional filter.</summary>
+    Task<long> CountAsync(string tableName, string? filter = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Creates the table when it does not exist.</summary>
+    Task CreateTableIfNotExistsAsync(string tableName, CancellationToken cancellationToken = default);
+
+    /// <summary>Writes entities using partition-safe transactions.</summary>
+    Task WriteAsync(
+        string tableName,
+        IReadOnlyList<DbaAzureTableEntity> entities,
+        DbaAzureTableWriteMode mode,
+        int batchSize,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes all entities without deleting the table resource.</summary>
+    Task ClearAsync(string tableName, int batchSize, CancellationToken cancellationToken = default);
+}

--- a/DbaClientX.AzureTables/IsExternalInit.cs
+++ b/DbaClientX.AzureTables/IsExternalInit.cs
@@ -1,0 +1,7 @@
+#if NETFRAMEWORK
+namespace System.Runtime.CompilerServices;
+
+internal static class IsExternalInit
+{
+}
+#endif

--- a/DbaClientX.AzureTables/README.md
+++ b/DbaClientX.AzureTables/README.md
@@ -1,0 +1,23 @@
+# DbaClientX.AzureTables
+
+`DbaClientX.AzureTables` adds Azure Storage Tables and Azure Cosmos DB Table API data movement to the provider-neutral DbaClientX copy engine.
+
+The adapter preserves native continuation tokens, keeps writes within Azure's same-partition transaction boundary, caps batches at 100 entities, and requires an explicit option before clearing a table.
+
+```csharp
+var source = new DbaAzureTablesAdapter(sourceConnectionString);
+var destination = new DbaAzureTablesAdapter(
+    destinationConnectionString,
+    new DbaAzureTablesOptions
+    {
+        WriteMode = DbaAzureTableWriteMode.UpsertReplace,
+        CreateDestinationTable = true
+    });
+
+var result = await new DbaTableCopyEngine().CopyAsync(
+    source,
+    destination,
+    new[] { new DbaTableCopyDefinition("SourceTable", "ArchiveTable") });
+```
+
+Set `EnableRowCounts = false` to avoid the extra full-table scans used for verification on large tables. Clearing data is disabled by default; opt in with `AllowClearDestination = true` and set `DbaTableCopyOptions.ClearDestination` only when intentional.

--- a/DbaClientX.AzureTables/README.md
+++ b/DbaClientX.AzureTables/README.md
@@ -20,4 +20,6 @@ var result = await new DbaTableCopyEngine().CopyAsync(
     new[] { new DbaTableCopyDefinition("SourceTable", "ArchiveTable") });
 ```
 
-Set `EnableRowCounts = false` to avoid the extra full-table scans used for verification on large tables. Clearing data is disabled by default; opt in with `AllowClearDestination = true` and set `DbaTableCopyOptions.ClearDestination` only when intentional.
+Set `EnableRowCounts = false` to avoid the extra full-table scans used for verification on large tables. Clearing data is disabled by default; opt in with `AllowClearDestination = true` and set `DbaTableCopyOptions.ClearDestination` only when intentional. Before any clear, the adapter rejects a destination that is also a source anywhere in the same copy plan.
+
+`DbaAzureTableNameComparison.Auto` uses Azure Storage's case-insensitive table-name safety and Cosmos DB Table API's case-sensitive behavior. Set `Ordinal` or `OrdinalIgnoreCase` explicitly for custom endpoints. Entity property names remain case-sensitive, so a custom property such as `partitionkey` is not discarded as the reserved `PartitionKey` field.

--- a/DbaClientX.Benchmarks/DbaClientX.Benchmarks.csproj
+++ b/DbaClientX.Benchmarks/DbaClientX.Benchmarks.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DbaClientX.Benchmarks/Program.cs
+++ b/DbaClientX.Benchmarks/Program.cs
@@ -1,0 +1,3 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/DbaClientX.Benchmarks/README.md
+++ b/DbaClientX.Benchmarks/README.md
@@ -1,0 +1,9 @@
+# DbaClientX benchmarks
+
+The table-copy benchmark compares the cursor-driven engine with a frozen offset-loop baseline under the same in-memory paging workload.
+
+```powershell
+dotnet run --project DbaClientX.Benchmarks -c Release -- --filter '*TableCopyPagingBenchmarks*' --job Short --noOverwrite
+```
+
+Use `--job Dry` first after changing the benchmark or copy contracts. Treat ratios as same-run regression signals; absolute timings vary by machine.

--- a/DbaClientX.Benchmarks/TableCopyPagingBenchmarks.cs
+++ b/DbaClientX.Benchmarks/TableCopyPagingBenchmarks.cs
@@ -1,0 +1,143 @@
+using System.Data;
+using BenchmarkDotNet.Attributes;
+using DBAClientX.DataMovement;
+
+namespace DbaClientX.Benchmarks;
+
+/// <summary>Compares the cursor copy engine with the previous offset-loop behavior.</summary>
+[MemoryDiagnoser]
+public class TableCopyPagingBenchmarks
+{
+    private DataTable _rows = null!;
+    private DbaTableCopyDefinition _definition = null!;
+
+    [Params(10_000)]
+    public int RowCount { get; set; }
+
+    [Params(100, 1000)]
+    public int PageSize { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _rows = new DataTable("SourceRows");
+        _rows.Columns.Add("Id", typeof(int));
+        _rows.Columns.Add("DisplayName", typeof(string));
+        for (var index = 0; index < RowCount; index++)
+        {
+            _rows.Rows.Add(index, $"Row {index}");
+        }
+
+        _definition = new DbaTableCopyDefinition("SourceRows", "DestinationRows");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+        => _rows.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public async Task<long> LegacyOffsetLoop()
+    {
+        var destination = new CountingDestination();
+        long copied = 0;
+        long offset = 0;
+        while (copied < _rows.Rows.Count)
+        {
+            using var page = ReadOffsetPage(offset, PageSize);
+            if (page.Rows.Count == 0)
+            {
+                break;
+            }
+
+            await destination.WritePageAsync(
+                    _definition,
+                    page,
+                    new DbaTableCopyOptions { PageSize = PageSize },
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+            copied += page.Rows.Count;
+            offset += page.Rows.Count;
+            if (page.Rows.Count < PageSize)
+            {
+                break;
+            }
+        }
+
+        return copied;
+    }
+
+    [Benchmark]
+    public async Task<long> CursorCopyEngine()
+    {
+        var result = await new DbaTableCopyEngine().CopyAsync(
+                new CursorSource(_rows),
+                new CountingDestination(),
+                new[] { _definition },
+                new DbaTableCopyOptions { PageSize = PageSize })
+            .ConfigureAwait(false);
+        return result.CopiedRows;
+    }
+
+    private DataTable ReadOffsetPage(long offset, int pageSize)
+    {
+        var page = _rows.Clone();
+        foreach (var row in _rows.AsEnumerable().Skip((int)offset).Take(pageSize))
+        {
+            page.ImportRow(row);
+        }
+
+        return page;
+    }
+
+    private sealed class CursorSource : IDbaTableCopySource
+    {
+        private readonly DataTable _rows;
+
+        public CursorSource(DataTable rows)
+            => _rows = rows;
+
+        public Task<long?> CountRowsAsync(DbaTableCopyDefinition definition, CancellationToken cancellationToken = default)
+            => Task.FromResult<long?>(_rows.Rows.Count);
+
+        public Task<DbaTableCopyPage> ReadPageAsync(DbaTableCopyPageRequest request, CancellationToken cancellationToken = default)
+        {
+#pragma warning disable CS0618
+            var offset = request.Offset;
+#pragma warning restore CS0618
+            var page = _rows.Clone();
+            foreach (var row in _rows.AsEnumerable().Skip((int)offset).Take(request.PageSize))
+            {
+                page.ImportRow(row);
+            }
+
+            var nextOffset = offset + page.Rows.Count;
+            return Task.FromResult(DbaTableCopyPage.FromOffset(
+                page,
+                nextOffset < _rows.Rows.Count ? nextOffset : null));
+        }
+    }
+
+    private sealed class CountingDestination : IDbaTableCopyDestination
+    {
+        private long _rows;
+
+        public Task ClearAsync(DbaTableCopyDefinition definition, CancellationToken cancellationToken = default)
+        {
+            _rows = 0;
+            return Task.CompletedTask;
+        }
+
+        public Task WritePageAsync(
+            DbaTableCopyDefinition definition,
+            DataTable page,
+            DbaTableCopyOptions options,
+            CancellationToken cancellationToken = default)
+        {
+            _rows += page.Rows.Count;
+            return Task.CompletedTask;
+        }
+
+        public Task<long?> CountRowsAsync(DbaTableCopyDefinition definition, CancellationToken cancellationToken = default)
+            => Task.FromResult<long?>(_rows);
+    }
+}

--- a/DbaClientX.Core/DataMovement/DbaProviderTableCopyAdapterBase.cs
+++ b/DbaClientX.Core/DataMovement/DbaProviderTableCopyAdapterBase.cs
@@ -52,13 +52,14 @@ public abstract class DbaProviderTableCopyAdapterBase : IDbaTableCopySource, IDb
         => ExecuteCountAsync(definition.SourceName, definition.SourceOptions, treatMissingAsEmpty: true, cancellationToken);
 
     /// <inheritdoc />
-    public async Task<DataTable> ReadPageAsync(DbaTableCopyPageRequest request, CancellationToken cancellationToken = default)
+    public async Task<DbaTableCopyPage> ReadPageAsync(DbaTableCopyPageRequest request, CancellationToken cancellationToken = default)
     {
+        var offset = DbaOffsetContinuationToken.Decode(request.ContinuationToken);
         var query = BuildPageQuery(
             request.Definition.SourceName,
             request.Definition.OrderByColumns,
             request.Definition.SourceOptions,
-            request.Offset,
+            offset,
             request.PageSize);
         DataTable table;
         try
@@ -78,7 +79,10 @@ public abstract class DbaProviderTableCopyAdapterBase : IDbaTableCopySource, IDb
         }
 
         table.TableName = request.Definition.DestinationName;
-        return table;
+        var nextOffset = table.Rows.Count == request.PageSize
+            ? offset + table.Rows.Count
+            : (long?)null;
+        return DbaTableCopyPage.FromOffset(table, nextOffset);
     }
 
     /// <inheritdoc />

--- a/DbaClientX.Core/DataMovement/DbaTableCopyEngine.cs
+++ b/DbaClientX.Core/DataMovement/DbaTableCopyEngine.cs
@@ -52,33 +52,40 @@ public sealed class DbaTableCopyEngine
             ? await PreflightSourceAsync(source, destination, copyDefinitions, options, cancellationToken).ConfigureAwait(false)
             : null;
 
-        if (options.ClearDestination)
+        try
         {
-            await PreflightDestinationAsync(destination, copyDefinitions, preflight!, cancellationToken).ConfigureAwait(false);
+            if (options.ClearDestination)
+            {
+                await PreflightDestinationAsync(destination, copyDefinitions, preflight!, cancellationToken).ConfigureAwait(false);
 
-            for (var index = copyDefinitions.Length - 1; index >= 0; index--)
+                for (var index = copyDefinitions.Length - 1; index >= 0; index--)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await destination.ClearAsync(copyDefinitions[index], cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            var results = new List<DbaTableCopyTableResult>();
+            for (var index = 0; index < copyDefinitions.Length; index++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await destination.ClearAsync(copyDefinitions[index], cancellationToken).ConfigureAwait(false);
+                results.Add(await CopyTableAsync(
+                        source,
+                        destination,
+                        copyDefinitions[index],
+                        options,
+                        preflight?[index],
+                        cancellationToken)
+                    .ConfigureAwait(false));
             }
-        }
 
-        var results = new List<DbaTableCopyTableResult>();
-        for (var index = 0; index < copyDefinitions.Length; index++)
+            sw.Stop();
+            return new DbaTableCopyResult(results, sw.Elapsed);
+        }
+        finally
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            results.Add(await CopyTableAsync(
-                    source,
-                    destination,
-                    copyDefinitions[index],
-                    options,
-                    preflight?[index],
-                    cancellationToken)
-                .ConfigureAwait(false));
+            DisposePreflightPages(preflight);
         }
-
-        sw.Stop();
-        return new DbaTableCopyResult(results, sw.Elapsed);
     }
 
     private static async Task<DbaTableCopyPreflight?[]> PreflightSourceAsync(
@@ -90,31 +97,39 @@ public sealed class DbaTableCopyEngine
     {
         var results = new DbaTableCopyPreflight?[definitions.Count];
         var destinationPagePreflight = destination as IDbaTableCopyPagePreflightDestination;
-        for (var index = 0; index < definitions.Count; index++)
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var definition = definitions[index];
-            var sourceRows = await source.CountRowsAsync(definition, cancellationToken).ConfigureAwait(false);
-            DataTable? firstPage = null;
-            if (sourceRows != 0 || ShouldWriteEmptyPage(destination, definition))
+            for (var index = 0; index < definitions.Count; index++)
             {
-                var pageSize = sourceRows > 0
-                    ? GetReadPageSize(options.PageSize, sourceRows, copied: 0)
-                    : options.PageSize;
-                firstPage = await source.ReadPageAsync(
-                        new DbaTableCopyPageRequest(definition, 0, pageSize),
-                        cancellationToken)
-                    .ConfigureAwait(false);
-                if (firstPage.Columns.Count > 0)
+                cancellationToken.ThrowIfCancellationRequested();
+                var definition = definitions[index];
+                var sourceRows = await source.CountRowsAsync(definition, cancellationToken).ConfigureAwait(false);
+                DbaTableCopyPage? firstPage = null;
+                if (sourceRows != 0 || ShouldWriteEmptyPage(destination, definition))
                 {
-                    PreflightTransform(firstPage, definition, destinationPagePreflight);
+                    var pageSize = sourceRows > 0
+                        ? GetReadPageSize(options.PageSize, sourceRows, copied: 0)
+                        : options.PageSize;
+                    firstPage = await source.ReadPageAsync(
+                            new DbaTableCopyPageRequest(definition, continuationToken: null, pageSize: pageSize),
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    if (firstPage.Data.Columns.Count > 0)
+                    {
+                        PreflightTransform(firstPage.Data, definition, destinationPagePreflight);
+                    }
                 }
+
+                results[index] = new DbaTableCopyPreflight(sourceRows, firstPage);
             }
 
-            results[index] = new DbaTableCopyPreflight(sourceRows, firstPage);
+            return results;
         }
-
-        return results;
+        catch
+        {
+            DisposePreflightPages(results);
+            throw;
+        }
     }
 
     private static async Task PreflightDestinationAsync(
@@ -140,7 +155,7 @@ public sealed class DbaTableCopyEngine
     }
 
     private static bool HasNonEmptySource(DbaTableCopyPreflight? preflight)
-        => preflight?.SourceRows > 0 || preflight?.FirstPage?.Rows.Count > 0;
+        => preflight?.SourceRows > 0 || preflight?.FirstPage?.Data.Rows.Count > 0;
 
     private static async Task<long?> CountDestinationRowsBeforeClearAsync(
         IDbaTableCopyDestination destination,
@@ -192,25 +207,29 @@ public sealed class DbaTableCopyEngine
                 options,
                 cancellationToken)
             .ConfigureAwait(false);
-        var page = preflight?.FirstPage;
+        var page = preflight?.TakeFirstPage();
         if (sourceRows == 0)
         {
             if (page == null && ShouldWriteEmptyPage(destination, definition))
             {
                 page = await source.ReadPageAsync(
-                        new DbaTableCopyPageRequest(definition, 0, options.PageSize),
+                        new DbaTableCopyPageRequest(definition, continuationToken: null, pageSize: options.PageSize),
                         cancellationToken)
                     .ConfigureAwait(false);
             }
 
-            if (page is not { Columns.Count: > 0 })
+            if (page == null || page.Data.Columns.Count == 0)
             {
+                page?.Dispose();
                 return await CompleteCopyAsync(destination, definition, options, sourceRows, 0, initialDestinationRows, cancellationToken).ConfigureAwait(false);
             }
 
-            if (page.Rows.Count == 0)
+            if (page.Data.Rows.Count == 0)
             {
-                await CopyPageAsync(destination, definition, options, page, 0, sourceRows, cancellationToken).ConfigureAwait(false);
+                using (page)
+                {
+                    await CopyPageAsync(destination, definition, options, page.Data, 0, sourceRows, cancellationToken).ConfigureAwait(false);
+                }
                 return await CompleteCopyAsync(destination, definition, options, sourceRows, 0, initialDestinationRows, cancellationToken).ConfigureAwait(false);
             }
 
@@ -218,19 +237,30 @@ public sealed class DbaTableCopyEngine
         }
 
         long copied = 0;
-        long offset = 0;
+        string? continuationToken = null;
+        var observedTokens = new HashSet<string>(StringComparer.Ordinal);
         if (page != null)
         {
-            if (page.Rows.Count == 0)
+            continuationToken = page.ContinuationToken;
+            if (continuationToken != null)
+            {
+                observedTokens.Add(continuationToken);
+            }
+
+            using (page)
+            {
+                if (page.Data.Rows.Count > 0)
+                {
+                    copied += await CopyPageAsync(destination, definition, options, page.Data, copied, sourceRows, cancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            if (HasCopiedKnownSourceRows(sourceRows, copied))
             {
                 return await CompleteCopyAsync(destination, definition, options, sourceRows, copied, initialDestinationRows, cancellationToken).ConfigureAwait(false);
             }
 
-            var requestedPageSize = GetReadPageSize(options.PageSize, sourceRows, copied);
-            var pageRows = await CopyPageAsync(destination, definition, options, page, copied, sourceRows, cancellationToken).ConfigureAwait(false);
-            copied += pageRows;
-            offset += page.Rows.Count;
-            if (HasCopiedKnownSourceRows(sourceRows, copied) || page.Rows.Count < requestedPageSize)
+            if (continuationToken == null)
             {
                 return await CompleteCopyAsync(destination, definition, options, sourceRows, copied, initialDestinationRows, cancellationToken).ConfigureAwait(false);
             }
@@ -245,21 +275,26 @@ public sealed class DbaTableCopyEngine
                 break;
             }
 
-            page = await source.ReadPageAsync(
-                    new DbaTableCopyPageRequest(definition, offset, pageSize),
+            string? requestedToken = continuationToken;
+            using var nextPage = await source.ReadPageAsync(
+                    new DbaTableCopyPageRequest(definition, requestedToken, pageSize),
                     cancellationToken)
                 .ConfigureAwait(false);
 
-            if (page.Rows.Count == 0)
+            continuationToken = nextPage.ContinuationToken;
+            ValidateContinuationProgress(requestedToken, continuationToken, observedTokens, definition);
+
+            if (nextPage.Data.Rows.Count > 0)
+            {
+                copied += await CopyPageAsync(destination, definition, options, nextPage.Data, copied, sourceRows, cancellationToken).ConfigureAwait(false);
+            }
+
+            if (HasCopiedKnownSourceRows(sourceRows, copied))
             {
                 break;
             }
 
-            var pageRows = await CopyPageAsync(destination, definition, options, page, copied, sourceRows, cancellationToken).ConfigureAwait(false);
-            copied += pageRows;
-            offset += page.Rows.Count;
-
-            if (HasCopiedKnownSourceRows(sourceRows, copied) || page.Rows.Count < pageSize)
+            if (continuationToken == null)
             {
                 break;
             }
@@ -287,6 +322,24 @@ public sealed class DbaTableCopyEngine
     private static bool HasCopiedKnownSourceRows(long? sourceRows, long copied)
         => sourceRows.HasValue && copied >= sourceRows.Value;
 
+    private static void ValidateContinuationProgress(
+        string? requestedToken,
+        string? returnedToken,
+        ISet<string> observedTokens,
+        DbaTableCopyDefinition definition)
+    {
+        if (returnedToken == null)
+        {
+            return;
+        }
+
+        if (string.Equals(requestedToken, returnedToken, StringComparison.Ordinal) || !observedTokens.Add(returnedToken))
+        {
+            throw new InvalidOperationException(
+                $"Source page stream for '{definition.DisplayName}' returned a repeated continuation token and cannot make progress.");
+        }
+    }
+
     private static async Task<int> CopyPageAsync(
         IDbaTableCopyDestination destination,
         DbaTableCopyDefinition definition,
@@ -297,6 +350,7 @@ public sealed class DbaTableCopyEngine
         CancellationToken cancellationToken)
     {
         var destinationPage = DbaTableCopyPageTransformer.Transform(page, definition);
+        using var destinationPageToDispose = ReferenceEquals(destinationPage, page) ? null : destinationPage;
         await destination.WritePageAsync(definition, destinationPage, options, cancellationToken).ConfigureAwait(false);
         options.Progress?.Invoke(new DbaTableCopyProgress(definition.DisplayName, previousCopied + destinationPage.Rows.Count, sourceRows, destinationPage.Rows.Count));
         return destinationPage.Rows.Count;
@@ -418,5 +472,42 @@ public sealed class DbaTableCopyEngine
         return DbaIdentifierPath.UnquoteSegment(trimmed);
     }
 
-    private sealed record DbaTableCopyPreflight(long? SourceRows, DataTable? FirstPage);
+    private static void DisposePreflightPages(IEnumerable<DbaTableCopyPreflight?>? preflight)
+    {
+        if (preflight == null)
+        {
+            return;
+        }
+
+        foreach (var item in preflight)
+        {
+            item?.Dispose();
+        }
+    }
+
+    private sealed class DbaTableCopyPreflight : IDisposable
+    {
+        public DbaTableCopyPreflight(long? sourceRows, DbaTableCopyPage? firstPage)
+        {
+            SourceRows = sourceRows;
+            FirstPage = firstPage;
+        }
+
+        public long? SourceRows { get; }
+
+        public DbaTableCopyPage? FirstPage { get; private set; }
+
+        public DbaTableCopyPage? TakeFirstPage()
+        {
+            var page = FirstPage;
+            FirstPage = null;
+            return page;
+        }
+
+        public void Dispose()
+        {
+            FirstPage?.Dispose();
+            FirstPage = null;
+        }
+    }
 }

--- a/DbaClientX.Core/DataMovement/DbaTableCopyEngine.cs
+++ b/DbaClientX.Core/DataMovement/DbaTableCopyEngine.cs
@@ -45,6 +45,10 @@ public sealed class DbaTableCopyEngine
         if (options.ClearDestination)
         {
             ValidateUniqueClearDestinations(copyDefinitions);
+            if (destination is IDbaTableCopyClearSafetyValidator clearSafetyValidator)
+            {
+                clearSafetyValidator.ValidateClearOperation(source, copyDefinitions);
+            }
         }
 
         var sw = Stopwatch.StartNew();
@@ -112,15 +116,18 @@ public sealed class DbaTableCopyEngine
                         : options.PageSize;
                     firstPage = await source.ReadPageAsync(
                             new DbaTableCopyPageRequest(definition, continuationToken: null, pageSize: pageSize),
-                            cancellationToken)
+                        cancellationToken)
                         .ConfigureAwait(false);
+                    results[index] = new DbaTableCopyPreflight(sourceRows, firstPage);
                     if (firstPage.Data.Columns.Count > 0)
                     {
                         PreflightTransform(firstPage.Data, definition, destinationPagePreflight);
                     }
                 }
-
-                results[index] = new DbaTableCopyPreflight(sourceRows, firstPage);
+                else
+                {
+                    results[index] = new DbaTableCopyPreflight(sourceRows, firstPage);
+                }
             }
 
             return results;

--- a/DbaClientX.Core/DataMovement/DbaTableCopyPage.cs
+++ b/DbaClientX.Core/DataMovement/DbaTableCopyPage.cs
@@ -1,0 +1,32 @@
+using System.Data;
+
+namespace DBAClientX.DataMovement;
+
+/// <summary>A source page and the opaque provider token needed to request the following page.</summary>
+public sealed class DbaTableCopyPage : IDisposable
+{
+    /// <summary>Creates a page with an optional opaque token for the following page.</summary>
+    public DbaTableCopyPage(DataTable data, string? continuationToken = null)
+    {
+        Data = data ?? throw new ArgumentNullException(nameof(data));
+        if (continuationToken != null && continuationToken.Length == 0)
+        {
+            throw new ArgumentException("Continuation token cannot be empty.", nameof(continuationToken));
+        }
+
+        ContinuationToken = continuationToken;
+    }
+
+    /// <summary>Rows and schema returned by the source.</summary>
+    public DataTable Data { get; }
+
+    /// <summary>Opaque token for the next page, or null when the stream is complete.</summary>
+    public string? ContinuationToken { get; }
+
+    /// <summary>Creates a page for a legacy offset-backed provider.</summary>
+    public static DbaTableCopyPage FromOffset(DataTable data, long? nextOffset)
+        => new(data, nextOffset.HasValue ? DbaOffsetContinuationToken.Encode(nextOffset.Value) : null);
+
+    /// <inheritdoc />
+    public void Dispose() => Data.Dispose();
+}

--- a/DbaClientX.Core/DataMovement/DbaTableCopyPageRequest.cs
+++ b/DbaClientX.Core/DataMovement/DbaTableCopyPageRequest.cs
@@ -1,6 +1,69 @@
+using System.Globalization;
+
 namespace DBAClientX.DataMovement;
 
-/// <summary>
-/// Describes a source page request for a table copy.
-/// </summary>
-public sealed record DbaTableCopyPageRequest(DbaTableCopyDefinition Definition, long Offset, int PageSize);
+/// <summary>Describes a provider-owned continuation page request for a table copy.</summary>
+public sealed record DbaTableCopyPageRequest
+{
+    /// <summary>Creates a continuation-token page request. A null token requests the first page.</summary>
+    public DbaTableCopyPageRequest(DbaTableCopyDefinition definition, string? continuationToken, int pageSize)
+    {
+        Definition = definition ?? throw new ArgumentNullException(nameof(definition));
+        if (continuationToken != null && continuationToken.Length == 0)
+        {
+            throw new ArgumentException("Continuation token cannot be empty.", nameof(continuationToken));
+        }
+
+        if (pageSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(pageSize), "Page size must be greater than zero.");
+        }
+
+        ContinuationToken = continuationToken;
+        PageSize = pageSize;
+    }
+
+    /// <summary>Compatibility constructor for offset-based sources.</summary>
+    [Obsolete("Implement provider-owned continuation tokens. This offset constructor remains only for migration.")]
+    public DbaTableCopyPageRequest(DbaTableCopyDefinition definition, long offset, int pageSize)
+        : this(definition, DbaOffsetContinuationToken.Encode(offset), pageSize)
+    {
+    }
+
+    /// <summary>Copy definition describing the source to read.</summary>
+    public DbaTableCopyDefinition Definition { get; }
+
+    /// <summary>Opaque provider token returned by the preceding page, or null for the first page.</summary>
+    public string? ContinuationToken { get; }
+
+    /// <summary>Maximum number of rows requested for this page.</summary>
+    public int PageSize { get; }
+
+    /// <summary>Decoded offset for legacy offset-backed sources.</summary>
+    [Obsolete("ContinuationToken is the canonical paging contract.")]
+    public long Offset => DbaOffsetContinuationToken.Decode(ContinuationToken);
+}
+
+internal static class DbaOffsetContinuationToken
+{
+    private const string Prefix = "dbax-offset:";
+
+    internal static string? Encode(long offset)
+    {
+        if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
+        return offset == 0 ? null : Prefix + offset.ToString(CultureInfo.InvariantCulture);
+    }
+
+    internal static long Decode(string? continuationToken)
+    {
+        if (continuationToken == null) return 0;
+        if (!continuationToken.StartsWith(Prefix, StringComparison.Ordinal) ||
+            !long.TryParse(continuationToken.Substring(Prefix.Length), NumberStyles.None, CultureInfo.InvariantCulture, out long offset) ||
+            offset <= 0)
+        {
+            throw new ArgumentException("The continuation token was not issued by the DbaClientX offset paging adapter.", nameof(continuationToken));
+        }
+
+        return offset;
+    }
+}

--- a/DbaClientX.Core/DataMovement/IDbaTableCopyClearSafetyValidator.cs
+++ b/DbaClientX.Core/DataMovement/IDbaTableCopyClearSafetyValidator.cs
@@ -1,0 +1,8 @@
+namespace DBAClientX.DataMovement;
+
+/// <summary>Allows a destination adapter to reject destructive clear operations before source preflight begins.</summary>
+public interface IDbaTableCopyClearSafetyValidator
+{
+    /// <summary>Validates that clearing all destination definitions cannot remove data needed by the source.</summary>
+    void ValidateClearOperation(IDbaTableCopySource source, IReadOnlyList<DbaTableCopyDefinition> definitions);
+}

--- a/DbaClientX.Core/DataMovement/IDbaTableCopySource.cs
+++ b/DbaClientX.Core/DataMovement/IDbaTableCopySource.cs
@@ -10,6 +10,6 @@ public interface IDbaTableCopySource
     /// <summary>Counts effective source rows for a copy definition, or returns null when counting is unavailable.</summary>
     Task<long?> CountRowsAsync(DbaTableCopyDefinition definition, CancellationToken cancellationToken = default);
 
-    /// <summary>Reads one source page as a <see cref="DataTable"/>.</summary>
-    Task<DataTable> ReadPageAsync(DbaTableCopyPageRequest request, CancellationToken cancellationToken = default);
+    /// <summary>Reads one source page and returns the opaque token for the following page.</summary>
+    Task<DbaTableCopyPage> ReadPageAsync(DbaTableCopyPageRequest request, CancellationToken cancellationToken = default);
 }

--- a/DbaClientX.Core/DbaClientX.Core.csproj
+++ b/DbaClientX.Core/DbaClientX.Core.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX Core library</Description>
     <AssemblyName>DbaClientX.Core</AssemblyName>
     <AssemblyTitle>DbaClientX.Core</AssemblyTitle>
-    <VersionPrefix>0.13.0</VersionPrefix>
+    <VersionPrefix>0.14.0</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.MySql/DbaClientX.MySql.csproj
+++ b/DbaClientX.MySql/DbaClientX.MySql.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX MySql provider</Description>
     <AssemblyName>DbaClientX.MySql</AssemblyName>
     <AssemblyTitle>DbaClientX.MySql</AssemblyTitle>
-    <VersionPrefix>0.12.0</VersionPrefix>
+    <VersionPrefix>0.13.0</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.Oracle/DbaClientX.Oracle.csproj
+++ b/DbaClientX.Oracle/DbaClientX.Oracle.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX Oracle provider</Description>
     <AssemblyName>DbaClientX.Oracle</AssemblyName>
     <AssemblyTitle>DbaClientX.Oracle</AssemblyTitle>
-    <VersionPrefix>0.12.0</VersionPrefix>
+    <VersionPrefix>0.13.0</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
+++ b/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX PostgreSql provider</Description>
     <AssemblyName>DbaClientX.PostgreSql</AssemblyName>
     <AssemblyTitle>DbaClientX.PostgreSql</AssemblyTitle>
-    <VersionPrefix>0.11.0</VersionPrefix>
+    <VersionPrefix>0.12.0</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.PowerShell/CmdletCopyDbaXAzureTableData.cs
+++ b/DbaClientX.PowerShell/CmdletCopyDbaXAzureTableData.cs
@@ -1,0 +1,155 @@
+using DBAClientX.AzureTables;
+using DBAClientX.DataMovement;
+
+namespace DBAClientX.PowerShell;
+
+/// <summary>Copies Azure Table data between storage accounts or Table API endpoints.</summary>
+/// <example>
+/// <summary>Copy a filtered table into an archive account.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Copy-DbaXAzureTableData -SourceConnectionString $source -DestinationConnectionString $destination -SourceTable Reports -DestinationTable ReportsArchive -Filter "PartitionKey eq 'daily'" -PassThru</code>
+/// <para>Streams pages through the provider-neutral DbaClientX copy engine and verifies row counts.</para>
+/// </example>
+[Cmdlet(VerbsCommon.Copy, "DbaXAzureTableData", SupportsShouldProcess = true)]
+public sealed class CmdletCopyDbaXAzureTableData : AsyncPSCmdlet
+{
+    /// <summary>Source Azure Storage or Cosmos DB Table API connection string.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string SourceConnectionString { get; set; } = string.Empty;
+
+    /// <summary>Destination Azure Storage or Cosmos DB Table API connection string.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string DestinationConnectionString { get; set; } = string.Empty;
+
+    /// <summary>Source table.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string SourceTable { get; set; } = string.Empty;
+
+    /// <summary>Destination table.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string DestinationTable { get; set; } = string.Empty;
+
+    /// <summary>Optional source OData filter.</summary>
+    [Parameter]
+    public string? Filter { get; set; }
+
+    /// <summary>Optional source property projection. PartitionKey and RowKey are always copied.</summary>
+    [Parameter]
+    public string[]? Select { get; set; }
+
+    /// <summary>Entities requested per source page.</summary>
+    [Parameter]
+    [ValidateRange(1, int.MaxValue)]
+    public int PageSize { get; set; } = DbaTableCopyOptions.DefaultPageSize;
+
+    /// <summary>Maximum entities per same-partition destination transaction.</summary>
+    [Parameter]
+    [ValidateRange(1, 100)]
+    public int BatchSize { get; set; } = 100;
+
+    /// <summary>Destination write behavior.</summary>
+    [Parameter]
+    public DbaAzureTableWriteMode WriteMode { get; set; } = DbaAzureTableWriteMode.UpsertReplace;
+
+    /// <summary>Clear existing destination entities before copying.</summary>
+    [Parameter]
+    public SwitchParameter ClearDestination { get; set; }
+
+    /// <summary>Skip source and destination row-count scans.</summary>
+    [Parameter]
+    public SwitchParameter NoVerify { get; set; }
+
+    /// <summary>Do not create the destination table when it is missing.</summary>
+    [Parameter]
+    public SwitchParameter NoCreateTable { get; set; }
+
+    /// <summary>Return the copy result.</summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync()
+    {
+        var source = new DbaAzureTablesAdapter(
+            SourceConnectionString,
+            new DbaAzureTablesOptions
+            {
+                SourceFilter = Filter,
+                SelectColumns = Select,
+                EnableRowCounts = !NoVerify.IsPresent
+            });
+        var destination = new DbaAzureTablesAdapter(
+            DestinationConnectionString,
+            new DbaAzureTablesOptions
+            {
+                WriteMode = WriteMode,
+                CreateDestinationTable = !NoCreateTable.IsPresent,
+                AllowClearDestination = ClearDestination.IsPresent,
+                EnableRowCounts = !NoVerify.IsPresent,
+                BatchSize = BatchSize
+            });
+
+        if (ClearDestination.IsPresent &&
+            Equals(source.ServiceUri, destination.ServiceUri) &&
+            string.Equals(SourceTable, DestinationTable, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new PSArgumentException("Source and destination cannot be the same table when ClearDestination is used.");
+        }
+
+        if (!ShouldProcess($"{SourceTable} -> {DestinationTable}", "Copy Azure Table data"))
+        {
+            return;
+        }
+
+        var startedAt = DateTimeOffset.UtcNow;
+        var result = await new DbaTableCopyEngine().CopyAsync(
+                source,
+                destination,
+                new[] { new DbaTableCopyDefinition(SourceTable, DestinationTable) },
+                new DbaTableCopyOptions
+                {
+                    PageSize = PageSize,
+                    BatchSize = BatchSize,
+                    ClearDestination = ClearDestination.IsPresent,
+                    VerifyRowCounts = !NoVerify.IsPresent,
+                    Progress = WriteCopyProgress
+                },
+                CancelToken)
+            .ConfigureAwait(false);
+
+        WriteProgress(new ProgressRecord(3, "Copying Azure Table data", "Complete")
+        {
+            RecordType = ProgressRecordType.Completed
+        });
+
+        if (PassThru.IsPresent)
+        {
+            WriteObject(new PSObject(new
+            {
+                SourceTable,
+                DestinationTable,
+                result.SourceRows,
+                result.CopiedRows,
+                result.DestinationRows,
+                result.Verified,
+                StartedAt = startedAt,
+                CompletedAt = DateTimeOffset.UtcNow,
+                ElapsedMilliseconds = Math.Round(result.Duration.TotalMilliseconds, 2)
+            }));
+        }
+    }
+
+    private void WriteCopyProgress(DbaTableCopyProgress progress)
+    {
+        WriteProgress(new ProgressRecord(3, $"Copying {progress.TableName}", $"{progress.RowsCopied} row(s) copied")
+        {
+            PercentComplete = progress.PercentComplete.HasValue
+                ? Math.Min(100, (int)Math.Round(progress.PercentComplete.Value))
+                : -1
+        });
+    }
+}

--- a/DbaClientX.PowerShell/CmdletCopyDbaXAzureTableData.cs
+++ b/DbaClientX.PowerShell/CmdletCopyDbaXAzureTableData.cs
@@ -93,13 +93,6 @@ public sealed class CmdletCopyDbaXAzureTableData : AsyncPSCmdlet
                 BatchSize = BatchSize
             });
 
-        if (ClearDestination.IsPresent &&
-            Equals(source.ServiceUri, destination.ServiceUri) &&
-            string.Equals(SourceTable, DestinationTable, StringComparison.OrdinalIgnoreCase))
-        {
-            throw new PSArgumentException("Source and destination cannot be the same table when ClearDestination is used.");
-        }
-
         if (!ShouldProcess($"{SourceTable} -> {DestinationTable}", "Copy Azure Table data"))
         {
             return;

--- a/DbaClientX.PowerShell/CmdletGetDbaXAzureTableEntity.cs
+++ b/DbaClientX.PowerShell/CmdletGetDbaXAzureTableEntity.cs
@@ -1,0 +1,102 @@
+using DBAClientX.AzureTables;
+
+namespace DBAClientX.PowerShell;
+
+/// <summary>Reads Azure Table entities with native continuation-token paging.</summary>
+/// <example>
+/// <summary>Read all entities in one partition.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Get-DbaXAzureTableEntity -ConnectionString $connectionString -TableName Reports -Filter "PartitionKey eq 'daily'"</code>
+/// <para>Streams matching entities while following Azure continuation tokens internally.</para>
+/// </example>
+/// <example>
+/// <summary>Return page envelopes for checkpointed processing.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>Get-DbaXAzureTableEntity -ConnectionString $connectionString -TableName Reports -PageSize 500 -AsPage</code>
+/// <para>Returns each page with its opaque continuation token.</para>
+/// </example>
+[Cmdlet(VerbsCommon.Get, "DbaXAzureTableEntity")]
+[OutputType(typeof(DbaAzureTableEntity), typeof(DbaAzureTablePage))]
+public sealed class CmdletGetDbaXAzureTableEntity : AsyncPSCmdlet
+{
+    /// <summary>Azure Storage or Cosmos DB Table API connection string.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string ConnectionString { get; set; } = string.Empty;
+
+    /// <summary>Table to query.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string TableName { get; set; } = string.Empty;
+
+    /// <summary>Optional OData filter.</summary>
+    [Parameter]
+    public string? Filter { get; set; }
+
+    /// <summary>Optional property projection. PartitionKey and RowKey are always included.</summary>
+    [Parameter]
+    public string[]? Select { get; set; }
+
+    /// <summary>Maximum entities requested from Azure per page.</summary>
+    [Parameter]
+    [ValidateRange(1, int.MaxValue)]
+    public int PageSize { get; set; } = 1000;
+
+    /// <summary>Optional token at which to resume the query.</summary>
+    [Parameter]
+    public string? ContinuationToken { get; set; }
+
+    /// <summary>Return page envelopes instead of enumerating individual entities.</summary>
+    [Parameter]
+    public SwitchParameter AsPage { get; set; }
+
+    /// <inheritdoc />
+    protected override async Task ProcessRecordAsync()
+    {
+        var client = new DbaAzureTablesClient(ConnectionString);
+        var token = ContinuationToken;
+        var observedTokens = new HashSet<string>(StringComparer.Ordinal);
+        if (token != null)
+        {
+            observedTokens.Add(token);
+        }
+
+        do
+        {
+            var requestedToken = token;
+            var page = await client.QueryPageAsync(
+                    TableName,
+                    Filter,
+                    IncludeKeys(Select),
+                    requestedToken,
+                    PageSize,
+                    CancelToken)
+                .ConfigureAwait(false);
+
+            if (AsPage.IsPresent)
+            {
+                WriteObject(page);
+            }
+            else
+            {
+                foreach (var entity in page.Entities)
+                {
+                    WriteObject(entity);
+                }
+            }
+
+            token = page.ContinuationToken;
+            if (token != null &&
+                (string.Equals(token, requestedToken, StringComparison.Ordinal) || !observedTokens.Add(token)))
+            {
+                throw new InvalidOperationException("Azure Table query returned a repeated continuation token and cannot make progress.");
+            }
+        }
+        while (token != null);
+    }
+
+    private static IReadOnlyList<string>? IncludeKeys(IReadOnlyList<string>? select)
+        => select == null || select.Count == 0
+            ? select
+            : select.Concat(new[] { "PartitionKey", "RowKey" }).Distinct(StringComparer.Ordinal).ToArray();
+}

--- a/DbaClientX.PowerShell/CmdletWriteDbaXAzureTableEntity.cs
+++ b/DbaClientX.PowerShell/CmdletWriteDbaXAzureTableEntity.cs
@@ -63,7 +63,42 @@ public sealed class CmdletWriteDbaXAzureTableEntity : AsyncPSCmdlet
             return;
         }
 
-        using var table = PowerShellDataTableConverter.ToDataTable(_input, TableName);
+        var nativeEntities = new List<DbaAzureTableEntity>(_input.Count);
+        var hasNonEntityInput = false;
+        foreach (object? item in _input)
+        {
+            object? candidate = item is PSObject psObject ? psObject.BaseObject : item;
+            if (candidate is DbaAzureTableEntity entity)
+            {
+                nativeEntities.Add(entity);
+            }
+            else
+            {
+                hasNonEntityInput = true;
+            }
+        }
+
+        if (nativeEntities.Count > 0 && hasNonEntityInput)
+        {
+            throw new PSArgumentException("DbaAzureTableEntity input cannot be mixed with projected PowerShell objects in one write operation.");
+        }
+
+        int rows;
+        if (nativeEntities.Count > 0)
+        {
+            await new DbaAzureTablesClient(ConnectionString).WriteAsync(
+                    TableName,
+                    nativeEntities,
+                    WriteMode,
+                    BatchSize,
+                    createTable: !NoCreateTable.IsPresent,
+                    cancellationToken: CancelToken)
+                .ConfigureAwait(false);
+            rows = nativeEntities.Count;
+        }
+        else
+        {
+            using var table = PowerShellDataTableConverter.ToDataTable(_input, TableName);
         var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(
             ConnectionString,
             new DbaAzureTablesOptions
@@ -79,13 +114,15 @@ public sealed class CmdletWriteDbaXAzureTableEntity : AsyncPSCmdlet
                 new DbaTableCopyOptions { BatchSize = BatchSize, VerifyRowCounts = false },
                 CancelToken)
             .ConfigureAwait(false);
+            rows = table.Rows.Count;
+        }
 
         if (PassThru.IsPresent)
         {
             WriteObject(new PSObject(new
             {
                 TableName,
-                Rows = table.Rows.Count,
+                Rows = rows,
                 WriteMode,
                 BatchSize
             }));

--- a/DbaClientX.PowerShell/CmdletWriteDbaXAzureTableEntity.cs
+++ b/DbaClientX.PowerShell/CmdletWriteDbaXAzureTableEntity.cs
@@ -1,0 +1,94 @@
+using DBAClientX.AzureTables;
+using DBAClientX.DataMovement;
+
+namespace DBAClientX.PowerShell;
+
+/// <summary>Writes PowerShell pipeline objects to Azure Tables in partition-safe transactions.</summary>
+/// <para>Input must expose PartitionKey and RowKey properties. Each Azure transaction contains at most 100 entities and stays inside one partition.</para>
+/// <example>
+/// <summary>Upsert report rows.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>$rows | Write-DbaXAzureTableEntity -ConnectionString $connectionString -TableName Reports -WriteMode UpsertReplace -PassThru</code>
+/// <para>Creates the table when needed and replaces matching entities.</para>
+/// </example>
+[Cmdlet(VerbsCommunications.Write, "DbaXAzureTableEntity", SupportsShouldProcess = true)]
+public sealed class CmdletWriteDbaXAzureTableEntity : AsyncPSCmdlet
+{
+    private readonly List<object?> _input = new();
+
+    /// <summary>Azure Storage or Cosmos DB Table API connection string.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string ConnectionString { get; set; } = string.Empty;
+
+    /// <summary>Destination table.</summary>
+    [Parameter(Mandatory = true)]
+    [ValidateNotNullOrEmpty]
+    public string TableName { get; set; } = string.Empty;
+
+    /// <summary>Objects containing PartitionKey, RowKey, and optional entity properties.</summary>
+    [Parameter(Mandatory = true, ValueFromPipeline = true)]
+    [AllowNull]
+    public object? InputObject { get; set; }
+
+    /// <summary>Azure entity write mode.</summary>
+    [Parameter]
+    public DbaAzureTableWriteMode WriteMode { get; set; } = DbaAzureTableWriteMode.UpsertReplace;
+
+    /// <summary>Maximum entities per same-partition transaction.</summary>
+    [Parameter]
+    [ValidateRange(1, 100)]
+    public int BatchSize { get; set; } = 100;
+
+    /// <summary>Do not create the destination table when it is missing.</summary>
+    [Parameter]
+    public SwitchParameter NoCreateTable { get; set; }
+
+    /// <summary>Return a summary after the write.</summary>
+    [Parameter]
+    public SwitchParameter PassThru { get; set; }
+
+    /// <inheritdoc />
+    protected override Task ProcessRecordAsync()
+    {
+        _input.Add(InputObject);
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    protected override async Task EndProcessingAsync()
+    {
+        if (_input.Count == 0 || !ShouldProcess(TableName, $"Write {_input.Count} Azure Table input object(s)"))
+        {
+            return;
+        }
+
+        using var table = PowerShellDataTableConverter.ToDataTable(_input, TableName);
+        var destination = (IDbaTableCopyDestination)new DbaAzureTablesAdapter(
+            ConnectionString,
+            new DbaAzureTablesOptions
+            {
+                WriteMode = WriteMode,
+                CreateDestinationTable = !NoCreateTable.IsPresent,
+                BatchSize = BatchSize,
+                EnableRowCounts = false
+            });
+        await destination.WritePageAsync(
+                new DbaTableCopyDefinition(TableName, TableName),
+                table,
+                new DbaTableCopyOptions { BatchSize = BatchSize, VerifyRowCounts = false },
+                CancelToken)
+            .ConfigureAwait(false);
+
+        if (PassThru.IsPresent)
+        {
+            WriteObject(new PSObject(new
+            {
+                TableName,
+                Rows = table.Rows.Count,
+                WriteMode,
+                BatchSize
+            }));
+        }
+    }
+}

--- a/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
+++ b/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
@@ -29,6 +29,7 @@
         </PropertyGroup>
         <ItemGroup>
                 <ProjectReference Include="..\DbaClientX.Core\DbaClientX.Core.csproj" />
+                <ProjectReference Include="..\DbaClientX.AzureTables\DbaClientX.AzureTables.csproj" />
                 <ProjectReference Include="..\DbaClientX.SqlServer\DbaClientX.SqlServer.csproj" />
                 <ProjectReference Include="..\DbaClientX.SQLite\DbaClientX.SQLite.csproj" />
                 <ProjectReference Include="..\DbaClientX.MySql\DbaClientX.MySql.csproj" />

--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX SQLite provider</Description>
     <AssemblyName>DbaClientX.SQLite</AssemblyName>
     <AssemblyTitle>DbaClientX.SQLite</AssemblyTitle>
-    <VersionPrefix>0.11.0</VersionPrefix>
+    <VersionPrefix>0.12.0</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.SqlServer/DbaClientX.SqlServer.csproj
+++ b/DbaClientX.SqlServer/DbaClientX.SqlServer.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX SQL Server provider</Description>
     <AssemblyName>DbaClientX.SqlServer</AssemblyName>
     <AssemblyTitle>DbaClientX.SqlServer</AssemblyTitle>
-    <VersionPrefix>0.12.0</VersionPrefix>
+    <VersionPrefix>0.13.0</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.Tests/DbaProviderTableCopyAdapterTests.cs
+++ b/DbaClientX.Tests/DbaProviderTableCopyAdapterTests.cs
@@ -814,12 +814,12 @@ public class DbaProviderTableCopyAdapterBaseTests
                 new[] { "ProbeName" },
                 SourceOptions: new DbaTableCopySourceOptions(new[] { "ProbeName" }, new[] { "LastCompletedUtcMs" }));
 
-            using var page = await adapter.ReadPageAsync(new DbaTableCopyPageRequest(definition, 0, 10));
+            using var page = await adapter.ReadPageAsync(new DbaTableCopyPageRequest(definition, continuationToken: null, pageSize: 10));
 
-            Assert.Equal(1, page.Rows.Count);
-            Assert.Contains("__DbaXCRank_62D977CD", page.Columns.Cast<DataColumn>().Select(static column => column.ColumnName));
-            Assert.Equal("source-b", page.Rows[0]["__DbaXCRank_62D977CD"]);
-            Assert.DoesNotContain(page.Columns.Cast<DataColumn>(), static column => column.ColumnName.StartsWith("__DbaXR_", StringComparison.Ordinal));
+            Assert.Equal(1, page.Data.Rows.Count);
+            Assert.Contains("__DbaXCRank_62D977CD", page.Data.Columns.Cast<DataColumn>().Select(static column => column.ColumnName));
+            Assert.Equal("source-b", page.Data.Rows[0]["__DbaXCRank_62D977CD"]);
+            Assert.DoesNotContain(page.Data.Columns.Cast<DataColumn>(), static column => column.ColumnName.StartsWith("__DbaXR_", StringComparison.Ordinal));
         }
         finally
         {

--- a/DbaClientX.Tests/DbaTableCopyEngineTests.cs
+++ b/DbaClientX.Tests/DbaTableCopyEngineTests.cs
@@ -117,7 +117,7 @@ public class DbaTableCopyEngineTests
             new[] { new DbaTableCopyDefinition("SourceRows", "DestinationRows") },
             new DbaTableCopyOptions { PageSize = 1 });
 
-        Assert.Equal(new long[] { 0, 1, 2 }, source.RequestedOffsets);
+        Assert.Equal(new long[] { 0, 1 }, source.RequestedOffsets);
         Assert.Equal(2, destination.Rows.Rows.Count);
         Assert.Null(result.SourceRows);
         Assert.Equal(2, result.CopiedRows);
@@ -1005,6 +1005,77 @@ public class DbaTableCopyEngineTests
         Assert.False(destination.ClearCalled);
     }
 
+    [Fact]
+    public async Task CopyAsync_FollowsContinuationTokenAfterShortPage()
+    {
+        var source = new ScriptedTableCopySource(
+            count: null,
+            new DbaTableCopyPage(CreateRows(1), "page-2"),
+            new DbaTableCopyPage(CreateRows(1), continuationToken: null));
+        var destination = new MemoryTableCopyDestination();
+
+        var result = await new DbaTableCopyEngine().CopyAsync(
+            source,
+            destination,
+            new[] { new DbaTableCopyDefinition("SourceRows", "DestinationRows") },
+            new DbaTableCopyOptions { PageSize = 100 });
+
+        Assert.Equal(new string?[] { null, "page-2" }, source.RequestedTokens);
+        Assert.Equal(2, result.CopiedRows);
+        Assert.Equal(2, destination.Rows.Rows.Count);
+    }
+
+    [Fact]
+    public async Task CopyAsync_FollowsContinuationTokenAfterEmptyPage()
+    {
+        var source = new ScriptedTableCopySource(
+            count: null,
+            new DbaTableCopyPage(CreateRows(0), "page-2"),
+            new DbaTableCopyPage(CreateRows(1), continuationToken: null));
+        var destination = new MemoryTableCopyDestination();
+
+        var result = await new DbaTableCopyEngine().CopyAsync(
+            source,
+            destination,
+            new[] { new DbaTableCopyDefinition("SourceRows", "DestinationRows") });
+
+        Assert.Equal(new string?[] { null, "page-2" }, source.RequestedTokens);
+        Assert.Equal(1, result.CopiedRows);
+        Assert.Equal(1, destination.Rows.Rows.Count);
+    }
+
+    [Fact]
+    public async Task CopyAsync_RejectsRepeatedContinuationToken()
+    {
+        var source = new ScriptedTableCopySource(
+            count: null,
+            new DbaTableCopyPage(CreateRows(1), "same-token"),
+            new DbaTableCopyPage(CreateRows(0), "same-token"));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => new DbaTableCopyEngine().CopyAsync(
+            source,
+            new MemoryTableCopyDestination(),
+            new[] { new DbaTableCopyDefinition("SourceRows", "DestinationRows") }));
+
+        Assert.Contains("repeated continuation token", exception.Message);
+    }
+
+    [Fact]
+    public async Task CopyAsync_ReportsCountedStreamThatEndsEarlyAsUnverified()
+    {
+        var source = new ScriptedTableCopySource(
+            count: 2,
+            new DbaTableCopyPage(CreateRows(1), continuationToken: null));
+
+        var result = await new DbaTableCopyEngine().CopyAsync(
+            source,
+            new MemoryTableCopyDestination(),
+            new[] { new DbaTableCopyDefinition("SourceRows", "DestinationRows") });
+
+        Assert.Equal(1, result.CopiedRows);
+        Assert.False(result.Verified);
+    }
+
     private static void AssertProgress(DbaTableCopyProgress progress, long rowsCopied, long sourceRows, int pageRows)
     {
         Assert.Equal("Rows", progress.TableName);
@@ -1062,7 +1133,7 @@ public class DbaTableCopyEngineTests
             return Task.FromResult<long?>(ReturnUnknownSourceRowCount ? null : SourceRowCountOverride ?? _rows.Rows.Count);
         }
 
-        public Task<DataTable> ReadPageAsync(DbaTableCopyPageRequest request, CancellationToken cancellationToken = default)
+        public Task<DbaTableCopyPage> ReadPageAsync(DbaTableCopyPageRequest request, CancellationToken cancellationToken = default)
         {
             if (ThrowOnRead)
             {
@@ -1070,17 +1141,51 @@ public class DbaTableCopyEngineTests
             }
 
             ReadCalls++;
-            RequestedOffsets.Add(request.Offset);
+#pragma warning disable CS0618
+            var offset = request.Offset;
+#pragma warning restore CS0618
+            RequestedOffsets.Add(offset);
             RequestedPageSizes.Add(request.PageSize);
 
             var page = _rows.Clone();
             page.TableName = request.Definition.DestinationName;
-            foreach (var row in _rows.AsEnumerable().Skip((int)request.Offset).Take(request.PageSize))
+            foreach (var row in _rows.AsEnumerable().Skip((int)offset).Take(request.PageSize))
             {
                 page.ImportRow(row);
             }
 
-            return Task.FromResult(page);
+            long nextOffset = offset + page.Rows.Count;
+            return Task.FromResult(DbaTableCopyPage.FromOffset(
+                page,
+                page.Rows.Count == request.PageSize && nextOffset < _rows.Rows.Count ? nextOffset : null));
+        }
+    }
+
+    private sealed class ScriptedTableCopySource : IDbaTableCopySource
+    {
+        private readonly long? _count;
+        private readonly Queue<DbaTableCopyPage> _pages;
+
+        public ScriptedTableCopySource(long? count, params DbaTableCopyPage[] pages)
+        {
+            _count = count;
+            _pages = new Queue<DbaTableCopyPage>(pages);
+        }
+
+        public List<string?> RequestedTokens { get; } = new();
+
+        public Task<long?> CountRowsAsync(DbaTableCopyDefinition definition, CancellationToken cancellationToken = default)
+            => Task.FromResult(_count);
+
+        public Task<DbaTableCopyPage> ReadPageAsync(DbaTableCopyPageRequest request, CancellationToken cancellationToken = default)
+        {
+            RequestedTokens.Add(request.ContinuationToken);
+            if (_pages.Count == 0)
+            {
+                throw new InvalidOperationException("The scripted source has no page for this request.");
+            }
+
+            return Task.FromResult(_pages.Dequeue());
         }
     }
 

--- a/DbaClientX.Tests/DbaTableCopyEngineTests.cs
+++ b/DbaClientX.Tests/DbaTableCopyEngineTests.cs
@@ -316,6 +316,25 @@ public class DbaTableCopyEngineTests
     }
 
     [Fact]
+    public async Task CopyAsync_DisposesFirstPageWhenDestinationPagePreflightFails()
+    {
+        var pageData = CreateRows(1);
+        var disposed = false;
+        pageData.Disposed += (_, _) => disposed = true;
+        var source = new ScriptedTableCopySource(1, new DbaTableCopyPage(pageData));
+        var destination = new MemoryTableCopyDestination { ThrowOnValidatePage = true };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => new DbaTableCopyEngine().CopyAsync(
+            source,
+            destination,
+            new[] { new DbaTableCopyDefinition("SourceRows", "DestinationRows") },
+            new DbaTableCopyOptions { ClearDestination = true }));
+
+        Assert.True(disposed);
+        Assert.False(destination.ClearCalled);
+    }
+
+    [Fact]
     public async Task CopyAsync_DoesNotPartiallyClearDestinationWhenDestinationPreflightFails()
     {
         var source = new MemoryTableCopySource(CreateRows(1));

--- a/DbaClientX.sln
+++ b/DbaClientX.sln
@@ -20,6 +20,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.SQLite", "DbaCli
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.Oracle", "DbaClientX.Oracle\DbaClientX.Oracle.csproj", "{67F2B6FC-362C-495A-8270-02E0932C8EA9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.AzureTables", "DbaClientX.AzureTables\DbaClientX.AzureTables.csproj", "{A641FF8F-83CC-41AC-A809-C00B7DCA3E0E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.AzureTables.Tests", "DbaClientX.AzureTables.Tests\DbaClientX.AzureTables.Tests.csproj", "{08815FC8-468E-4186-9723-3A8B9FF790DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DbaClientX.Benchmarks", "DbaClientX.Benchmarks\DbaClientX.Benchmarks.csproj", "{12FCA2AE-215C-4EE0-8B15-678FED13AF82}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +68,18 @@ Global
 		{67F2B6FC-362C-495A-8270-02E0932C8EA9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{67F2B6FC-362C-495A-8270-02E0932C8EA9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{67F2B6FC-362C-495A-8270-02E0932C8EA9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A641FF8F-83CC-41AC-A809-C00B7DCA3E0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A641FF8F-83CC-41AC-A809-C00B7DCA3E0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A641FF8F-83CC-41AC-A809-C00B7DCA3E0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A641FF8F-83CC-41AC-A809-C00B7DCA3E0E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08815FC8-468E-4186-9723-3A8B9FF790DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08815FC8-468E-4186-9723-3A8B9FF790DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08815FC8-468E-4186-9723-3A8B9FF790DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08815FC8-468E-4186-9723-3A8B9FF790DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12FCA2AE-215C-4EE0-8B15-678FED13AF82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12FCA2AE-215C-4EE0-8B15-678FED13AF82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12FCA2AE-215C-4EE0-8B15-678FED13AF82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12FCA2AE-215C-4EE0-8B15-678FED13AF82}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.7.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -106,6 +106,7 @@ Build-Module -ModuleName 'DbaClientX' -NoInteractive {
         NETAssemblyTypeAcceleratorMode       = 'Assembly'
         NETAssemblyTypeAcceleratorAssemblies = @(
             'DbaClientX.Core'
+            'DbaClientX.AzureTables'
             'DbaClientX.SqlServer'
             'DbaClientX.MySql'
             'DbaClientX.Oracle'

--- a/Module/DbaClientX.psd1
+++ b/Module/DbaClientX.psd1
@@ -1,14 +1,14 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('ConvertTo-DbaXParameterMap', 'Copy-DbaXTableData', 'Get-DbaXMetadata', 'Get-DbaXProviderCapability', 'Get-DbaXSQLiteDiagnostics', 'Get-DbaXSqlServerManagement', 'Get-DbaXSqlServerMonitoring', 'Get-DbaXTableCopyPlan', 'Invoke-DbaXBulkInsert', 'Invoke-DbaXMySql', 'Invoke-DbaXMySqlNonQuery', 'Invoke-DbaXMySqlScalar', 'Invoke-DbaXMySqlTransaction', 'Invoke-DbaXNonQuery', 'Invoke-DbaXOracle', 'Invoke-DbaXOracleNonQuery', 'Invoke-DbaXOracleScalar', 'Invoke-DbaXOracleTransaction', 'Invoke-DbaXPostgreSql', 'Invoke-DbaXPostgreSqlNonQuery', 'Invoke-DbaXPostgreSqlTransaction', 'Invoke-DbaXQuery', 'Invoke-DbaXQueryStream', 'Invoke-DbaXSQLite', 'Invoke-DbaXSQLiteMaintenance', 'Invoke-DbaXSQLiteTransaction', 'Invoke-DbaXStoredProcedure', 'Invoke-DbaXTransaction', 'New-DbaXConnectionString', 'New-DbaXQuery', 'New-DbaXTableCopyDefinition', 'New-DbaXTableCopyPlan', 'Test-DbaXConnection', 'Write-DbaXTableData')
+    CmdletsToExport      = @('ConvertTo-DbaXParameterMap', 'Copy-DbaXAzureTableData', 'Copy-DbaXTableData', 'Get-DbaXAzureTableEntity', 'Get-DbaXMetadata', 'Get-DbaXProviderCapability', 'Get-DbaXSQLiteDiagnostics', 'Get-DbaXSqlServerManagement', 'Get-DbaXSqlServerMonitoring', 'Get-DbaXTableCopyPlan', 'Invoke-DbaXBulkInsert', 'Invoke-DbaXMySql', 'Invoke-DbaXMySqlNonQuery', 'Invoke-DbaXMySqlScalar', 'Invoke-DbaXMySqlTransaction', 'Invoke-DbaXNonQuery', 'Invoke-DbaXOracle', 'Invoke-DbaXOracleNonQuery', 'Invoke-DbaXOracleScalar', 'Invoke-DbaXOracleTransaction', 'Invoke-DbaXPostgreSql', 'Invoke-DbaXPostgreSqlNonQuery', 'Invoke-DbaXPostgreSqlTransaction', 'Invoke-DbaXQuery', 'Invoke-DbaXQueryStream', 'Invoke-DbaXSQLite', 'Invoke-DbaXSQLiteMaintenance', 'Invoke-DbaXSQLiteTransaction', 'Invoke-DbaXStoredProcedure', 'Invoke-DbaXTransaction', 'New-DbaXConnectionString', 'New-DbaXQuery', 'New-DbaXTableCopyDefinition', 'New-DbaXTableCopyPlan', 'Test-DbaXConnection', 'Write-DbaXAzureTableEntity', 'Write-DbaXTableData')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description          = 'Simple project to query Sql Server and other databases using PowerShell'
     FunctionsToExport    = @()
     GUID                 = 'c22cc272-c829-49e2-aaa1-58d3c36edb94'
-    ModuleVersion        = '1.0.3'
+    ModuleVersion        = '1.0.4'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Module/DbaClientX.psm1
+++ b/Module/DbaClientX.psm1
@@ -184,7 +184,7 @@ namespace DbaClientX.DevelopmentModuleLoadContext
 
                     $Mode = 'Assembly'
                     $RequestedTypes = @()
-                    $RequestedAssemblies = @('DbaClientX.Core', 'DbaClientX.SqlServer', 'DbaClientX.MySql', 'DbaClientX.Oracle', 'DbaClientX.PostgreSql', 'DbaClientX.SQLite', 'DBAClientX.PowerShell')
+                    $RequestedAssemblies = @('DbaClientX.Core', 'DbaClientX.AzureTables', 'DbaClientX.SqlServer', 'DbaClientX.MySql', 'DbaClientX.Oracle', 'DbaClientX.PostgreSql', 'DbaClientX.SQLite', 'DBAClientX.PowerShell')
 
                     if ($null -eq $ModuleAssembly) {
                         Write-Warning -Message 'Module assembly was not available. ALC dependency type exposure is disabled.'
@@ -378,11 +378,12 @@ namespace DbaClientX.DevelopmentModuleLoadContext
 
                     if ($script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered -ne $true) {
                         $script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered = $true
+                        $RegisteredPowerForgeTypeAccelerators = $script:PowerForgeRegisteredAssemblyTypeAccelerators
                         $PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove
                         $ExecutionContext.SessionState.Module.OnRemove = {
                             try {
                                 $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
-                                if ($null -eq $TypeAccelerators -or $null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {
+                                if ($null -eq $TypeAccelerators -or $null -eq $RegisteredPowerForgeTypeAccelerators) {
                                     return
                                 }
 
@@ -393,7 +394,7 @@ namespace DbaClientX.DevelopmentModuleLoadContext
                                 }
 
                                 $Existing = $GetTypeAccelerators.GetValue($null)
-                                foreach ($Entry in @($script:PowerForgeRegisteredAssemblyTypeAccelerators.GetEnumerator())) {
+                                foreach ($Entry in @($RegisteredPowerForgeTypeAccelerators.GetEnumerator())) {
                                     if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {
                                         $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null
                                     }
@@ -463,6 +464,290 @@ namespace DbaClientX.DevelopmentModuleLoadContext
                     & $ImportModule $PowerForgeDevelopmentBinaryPath -ErrorAction Stop
                 }
             }
+            if ($PSEdition -ne 'Core') {
+                # Desktop loads module dependencies into the default AppDomain, so expose the same configured scripting types as Core.
+                $RegisterPowerForgeDesktopAssemblyTypeAccelerators = {
+                    param([Parameter(Mandatory = $true)][string] $LibraryDirectory)
+
+                    $Mode = 'Assembly'
+                    $RequestedTypes = @()
+                    $RequestedAssemblies = @('DbaClientX.Core', 'DbaClientX.AzureTables', 'DbaClientX.SqlServer', 'DbaClientX.MySql', 'DbaClientX.Oracle', 'DbaClientX.PostgreSql', 'DbaClientX.SQLite', 'DBAClientX.PowerShell')
+                    $IgnoredLibraryFileNames = @('Microsoft.Data.SqlClient.SNI.arm64.dll', 'Microsoft.Data.SqlClient.SNI.dll', 'Microsoft.Data.SqlClient.SNI.x64.dll', 'Microsoft.Data.SqlClient.SNI.x86.dll')
+
+                    if ([string]::IsNullOrWhiteSpace($LibraryDirectory) -or -not (Test-Path -LiteralPath $LibraryDirectory)) {
+                        Write-Warning -Message 'Module library directory was not available. Desktop dependency type exposure is disabled.'
+                        return
+                    }
+
+                    if ($Mode -eq 'AllowList' -and $RequestedTypes.Count -eq 0) {
+                        Write-Warning -Message 'AllowList type accelerator mode was configured without type names. No Desktop dependency type accelerators will be registered.'
+                        return
+                    }
+
+                    if (($Mode -eq 'Assembly' -or $Mode -eq 'Enums') -and $RequestedAssemblies.Count -eq 0) {
+                        if ($RequestedTypes.Count -eq 0) {
+                            Write-Warning -Message "$Mode type accelerator mode was configured without assembly names or type names. No Desktop dependency type accelerators will be registered."
+                            return
+                        }
+
+                        Write-Warning -Message "$Mode type accelerator mode was configured without assembly names. Only explicitly configured type names will be registered."
+                    }
+
+                    $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+                    if ($null -eq $TypeAccelerators) {
+                        Write-Warning -Message 'PowerShell type accelerator APIs are not available. Desktop dependency type exposure is disabled.'
+                        return
+                    }
+
+                    $AddTypeAccelerator = $TypeAccelerators.GetMethod('Add', [type[]]@([string], [type]))
+                    $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
+                    if ($null -eq $AddTypeAccelerator -or $null -eq $GetTypeAccelerators) {
+                        Write-Warning -Message 'PowerShell type accelerator APIs are incomplete. Desktop dependency type exposure is disabled.'
+                        return
+                    }
+
+                    if ($null -eq $script:PowerForgeRegisteredAssemblyTypeAccelerators) {
+                        $script:PowerForgeRegisteredAssemblyTypeAccelerators = @{}
+                    }
+
+                    $ResolvedPowerForgeDesktopAssemblies = @{}
+                    $FailedPowerForgeDesktopAssemblies = @{}
+                    $LibraryDirectoryFullPath = [IO.Path]::GetFullPath($LibraryDirectory)
+                    $LibraryDirectoryPrefix = $LibraryDirectoryFullPath.TrimEnd([IO.Path]::DirectorySeparatorChar, [IO.Path]::AltDirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
+
+                    $TestPowerForgeDesktopIgnoredAssembly = {
+                        param([Parameter(Mandatory = $true)] $Assembly)
+
+                        return $IgnoredLibraryFileNames -contains ($Assembly.GetName().Name + '.dll')
+                    }
+
+                    $TestPowerForgeDesktopModuleAssembly = {
+                        param([Parameter(Mandatory = $true)] $Assembly)
+
+                        if ($Assembly.IsDynamic) {
+                            return $false
+                        }
+
+                        try {
+                            if ([string]::IsNullOrWhiteSpace($Assembly.Location)) {
+                                return $false
+                            }
+
+                            $AssemblyFullPath = [IO.Path]::GetFullPath($Assembly.Location)
+                            return $AssemblyFullPath.StartsWith($LibraryDirectoryPrefix, [StringComparison]::OrdinalIgnoreCase)
+                        } catch {
+                            return $false
+                        }
+                    }
+
+                    $ImportPowerForgeDesktopAssembly = {
+                        param([Parameter(Mandatory = $true)][string] $AssemblyName)
+
+                        $SimpleName = [IO.Path]::GetFileNameWithoutExtension($AssemblyName)
+                        $AssemblyFileName = $SimpleName + '.dll'
+                        if ($IgnoredLibraryFileNames -contains $AssemblyFileName) {
+                            $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+                            return $null
+                        }
+
+                        if ($ResolvedPowerForgeDesktopAssemblies.ContainsKey($SimpleName)) {
+                            return $ResolvedPowerForgeDesktopAssemblies[$SimpleName]
+                        }
+                        if ($FailedPowerForgeDesktopAssemblies.ContainsKey($SimpleName)) {
+                            return $null
+                        }
+
+                        foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+                            if ($Assembly.GetName().Name -eq $SimpleName -and (& $TestPowerForgeDesktopModuleAssembly -Assembly $Assembly)) {
+                                $ResolvedPowerForgeDesktopAssemblies[$SimpleName] = $Assembly
+                                return $Assembly
+                            }
+                        }
+
+                        $AssemblyPath = [IO.Path]::Combine($LibraryDirectory, $AssemblyFileName)
+                        if (Test-Path -LiteralPath $AssemblyPath) {
+                            try {
+                                $LoadedAssembly = [System.Reflection.Assembly]::LoadFrom($AssemblyPath)
+                                if (& $TestPowerForgeDesktopModuleAssembly -Assembly $LoadedAssembly) {
+                                    $ResolvedPowerForgeDesktopAssemblies[$SimpleName] = $LoadedAssembly
+                                    return $LoadedAssembly
+                                }
+
+                                $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+                                Write-Warning -Message "Desktop assembly '$SimpleName' resolved outside the module library directory. Skipping type accelerator exposure to avoid registering the wrong assembly version."
+                                return $null
+                            } catch {
+                                $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+                                Write-Warning -Message "Could not load Desktop assembly '$SimpleName' for type accelerator exposure: $($_.Exception.Message)"
+                                return $null
+                            }
+                        }
+
+                        foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+                            if ($Assembly.GetName().Name -eq $SimpleName) {
+                                $ResolvedPowerForgeDesktopAssemblies[$SimpleName] = $Assembly
+                                return $Assembly
+                            }
+                        }
+
+                        $FailedPowerForgeDesktopAssemblies[$SimpleName] = $true
+                        return $null
+                    }
+
+                    $FindPowerForgeDesktopType = {
+                        param([Parameter(Mandatory = $true)][string] $TypeName)
+
+                        foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+                            if ((& $TestPowerForgeDesktopIgnoredAssembly -Assembly $Assembly) -or
+                                -not (& $TestPowerForgeDesktopModuleAssembly -Assembly $Assembly)) {
+                                continue
+                            }
+
+                            $Type = $Assembly.GetType($TypeName, $false, $false)
+                            if ($null -ne $Type) {
+                                return $Type
+                            }
+                        }
+
+                        foreach ($File in Get-ChildItem -LiteralPath $LibraryDirectory -Filter '*.dll' -File -ErrorAction SilentlyContinue) {
+                            if ($IgnoredLibraryFileNames -contains $File.Name) {
+                                continue
+                            }
+
+                            $Assembly = & $ImportPowerForgeDesktopAssembly -AssemblyName $File.BaseName
+                            if ($null -eq $Assembly) {
+                                continue
+                            }
+
+                            $Type = $Assembly.GetType($TypeName, $false, $false)
+                            if ($null -ne $Type) {
+                                return $Type
+                            }
+                        }
+
+                        foreach ($Assembly in [AppDomain]::CurrentDomain.GetAssemblies()) {
+                            if (& $TestPowerForgeDesktopIgnoredAssembly -Assembly $Assembly) {
+                                continue
+                            }
+
+                            $AssemblyFileName = $Assembly.GetName().Name + '.dll'
+                            if (Test-Path -LiteralPath ([IO.Path]::Combine($LibraryDirectory, $AssemblyFileName))) {
+                                # A module-owned assembly with this identity exists but could not be selected above. Do not
+                                # silently fall back to a globally loaded copy with a different location or version.
+                                continue
+                            }
+
+                            $Type = $Assembly.GetType($TypeName, $false, $false)
+                            if ($null -ne $Type) {
+                                return $Type
+                            }
+                        }
+
+                        return $null
+                    }
+
+                    $AddPowerForgeDesktopTypeAccelerator = {
+                        param([Parameter(Mandatory = $true)][type] $Type)
+
+                        if ([string]::IsNullOrWhiteSpace($Type.FullName)) {
+                            return
+                        }
+
+                        $Name = $Type.FullName
+                        $Existing = $GetTypeAccelerators.GetValue($null)
+                        if ($Existing.ContainsKey($Name)) {
+                            $ExistingType = $Existing[$Name]
+                            if ([object]::ReferenceEquals($ExistingType, $Type)) {
+                                return
+                            }
+
+                            Write-Warning -Message "Type accelerator '$Name' already exists from $($ExistingType.Assembly.GetName().FullName). Keeping it and skipping the Desktop type from $($Type.Assembly.GetName().FullName)."
+                            return
+                        }
+
+                        try {
+                            $AddTypeAccelerator.Invoke($null, @($Name, $Type)) | Out-Null
+                        } catch {
+                            Write-Warning -Message "Type accelerator '$Name' could not be registered from $($Type.Assembly.GetName().Name): $($_.Exception.Message)"
+                            return
+                        }
+
+                        $script:PowerForgeRegisteredAssemblyTypeAccelerators[$Name] = $Type
+                    }
+
+                    if ($Mode -eq 'Assembly' -or $Mode -eq 'Enums') {
+                        foreach ($AssemblyName in $RequestedAssemblies) {
+                            $Assembly = & $ImportPowerForgeDesktopAssembly -AssemblyName $AssemblyName
+                            if ($null -eq $Assembly) {
+                                Write-Warning -Message "Assembly '$AssemblyName' was not found in the module library directory. No Desktop type accelerators were registered for it."
+                                continue
+                            }
+
+                            try {
+                                $ExportedTypes = @($Assembly.GetExportedTypes())
+                            } catch {
+                                Write-Warning -Message "Could not enumerate exported types from Desktop assembly '$AssemblyName' for type accelerator exposure: $($_.Exception.Message)"
+                                continue
+                            }
+
+                            foreach ($Type in $ExportedTypes) {
+                                if ($Mode -eq 'Enums' -and -not $Type.IsEnum) {
+                                    continue
+                                }
+
+                                & $AddPowerForgeDesktopTypeAccelerator -Type $Type
+                            }
+                        }
+                    }
+
+                    foreach ($TypeName in $RequestedTypes) {
+                        $Type = & $FindPowerForgeDesktopType -TypeName $TypeName
+                        if ($null -eq $Type) {
+                            Write-Warning -Message "Type '$TypeName' was not found in the module AppDomain. No Desktop type accelerator was registered."
+                            continue
+                        }
+
+                        & $AddPowerForgeDesktopTypeAccelerator -Type $Type
+                    }
+
+                    if ($script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered -ne $true) {
+                        $script:PowerForgeAssemblyTypeAcceleratorCleanupRegistered = $true
+                        $RegisteredPowerForgeTypeAccelerators = $script:PowerForgeRegisteredAssemblyTypeAccelerators
+                        $PreviousPowerForgeOnRemove = $ExecutionContext.SessionState.Module.OnRemove
+                        $ExecutionContext.SessionState.Module.OnRemove = {
+                            try {
+                                $TypeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')
+                                if ($null -eq $TypeAccelerators -or $null -eq $RegisteredPowerForgeTypeAccelerators) {
+                                    return
+                                }
+
+                                $GetTypeAccelerators = $TypeAccelerators.GetProperty('Get', [System.Reflection.BindingFlags] 'Static,Public,NonPublic')
+                                $RemoveTypeAccelerator = $TypeAccelerators.GetMethod('Remove', [type[]]@([string]))
+                                if ($null -eq $GetTypeAccelerators -or $null -eq $RemoveTypeAccelerator) {
+                                    return
+                                }
+
+                                $Existing = $GetTypeAccelerators.GetValue($null)
+                                foreach ($Entry in @($RegisteredPowerForgeTypeAccelerators.GetEnumerator())) {
+                                    if ($Existing.ContainsKey($Entry.Key) -and [object]::ReferenceEquals($Existing[$Entry.Key], $Entry.Value)) {
+                                        $RemoveTypeAccelerator.Invoke($null, @($Entry.Key)) | Out-Null
+                                    }
+                                }
+                            } finally {
+                                if ($null -ne $PreviousPowerForgeOnRemove) {
+                                    & $PreviousPowerForgeOnRemove @args
+                                }
+                            }
+                        }.GetNewClosure()
+                    }
+                }
+
+                try {
+                    & $RegisterPowerForgeDesktopAssemblyTypeAccelerators -LibraryDirectory ([IO.Path]::GetDirectoryName($PowerForgeDevelopmentBinaryPath))
+                } catch {
+                    Write-Warning -Message "Desktop type accelerator registration failed: $($_.Exception.Message)"
+                }
+            }
             $PowerForgeDevelopmentBinaryLoaded = $true
         } catch {
             if ($ErrorActionPreference -eq 'Stop') {
@@ -475,6 +760,6 @@ namespace DbaClientX.DevelopmentModuleLoadContext
 }
 
 $FunctionsToExport = @()
-$CmdletsToExport = @('ConvertTo-DbaXParameterMap', 'Copy-DbaXTableData', 'Get-DbaXMetadata', 'Get-DbaXProviderCapability', 'Get-DbaXSQLiteDiagnostics', 'Get-DbaXSqlServerManagement', 'Get-DbaXSqlServerMonitoring', 'Get-DbaXTableCopyPlan', 'Invoke-DbaXBulkInsert', 'Invoke-DbaXMySql', 'Invoke-DbaXMySqlNonQuery', 'Invoke-DbaXMySqlScalar', 'Invoke-DbaXMySqlTransaction', 'Invoke-DbaXNonQuery', 'Invoke-DbaXOracle', 'Invoke-DbaXOracleNonQuery', 'Invoke-DbaXOracleScalar', 'Invoke-DbaXOracleTransaction', 'Invoke-DbaXPostgreSql', 'Invoke-DbaXPostgreSqlNonQuery', 'Invoke-DbaXPostgreSqlTransaction', 'Invoke-DbaXQuery', 'Invoke-DbaXQueryStream', 'Invoke-DbaXSQLite', 'Invoke-DbaXSQLiteMaintenance', 'Invoke-DbaXSQLiteTransaction', 'Invoke-DbaXStoredProcedure', 'Invoke-DbaXTransaction', 'New-DbaXConnectionString', 'New-DbaXQuery', 'New-DbaXTableCopyDefinition', 'New-DbaXTableCopyPlan', 'Test-DbaXConnection', 'Write-DbaXTableData')
+$CmdletsToExport = @('ConvertTo-DbaXParameterMap', 'Copy-DbaXAzureTableData', 'Copy-DbaXTableData', 'Get-DbaXAzureTableEntity', 'Get-DbaXMetadata', 'Get-DbaXProviderCapability', 'Get-DbaXSQLiteDiagnostics', 'Get-DbaXSqlServerManagement', 'Get-DbaXSqlServerMonitoring', 'Get-DbaXTableCopyPlan', 'Invoke-DbaXBulkInsert', 'Invoke-DbaXMySql', 'Invoke-DbaXMySqlNonQuery', 'Invoke-DbaXMySqlScalar', 'Invoke-DbaXMySqlTransaction', 'Invoke-DbaXNonQuery', 'Invoke-DbaXOracle', 'Invoke-DbaXOracleNonQuery', 'Invoke-DbaXOracleScalar', 'Invoke-DbaXOracleTransaction', 'Invoke-DbaXPostgreSql', 'Invoke-DbaXPostgreSqlNonQuery', 'Invoke-DbaXPostgreSqlTransaction', 'Invoke-DbaXQuery', 'Invoke-DbaXQueryStream', 'Invoke-DbaXSQLite', 'Invoke-DbaXSQLiteMaintenance', 'Invoke-DbaXSQLiteTransaction', 'Invoke-DbaXStoredProcedure', 'Invoke-DbaXTransaction', 'New-DbaXConnectionString', 'New-DbaXQuery', 'New-DbaXTableCopyDefinition', 'New-DbaXTableCopyPlan', 'Test-DbaXConnection', 'Write-DbaXAzureTableEntity', 'Write-DbaXTableData')
 $AliasesToExport = @()
 Export-ModuleMember -Function $FunctionsToExport -Alias $AliasesToExport -Cmdlet $CmdletsToExport

--- a/Module/Tests/CmdletProviderNeutralSurface.Tests.ps1
+++ b/Module/Tests/CmdletProviderNeutralSurface.Tests.ps1
@@ -17,6 +17,9 @@ Describe 'Provider-neutral DbaClientX cmdlet surface' {
             'Invoke-DbaXStoredProcedure'
             'Invoke-DbaXQueryStream'
             'Invoke-DbaXBulkInsert'
+            'Get-DbaXAzureTableEntity'
+            'Write-DbaXAzureTableEntity'
+            'Copy-DbaXAzureTableData'
         )
 
         foreach ($commandName in $expectedCommands) {
@@ -35,6 +38,21 @@ Describe 'Provider-neutral DbaClientX cmdlet surface' {
         $sqlite = New-DbaXConnectionString -Provider SQLite -Database '.\app.db' -BusyTimeoutMs 2500
         $sqlite | Should -Match 'Data Source=.*app\.db'
         $sqlite | Should -Match 'Default Timeout=3'
+    }
+
+    It 'refuses to clear the source Azure Table when table-name casing differs' {
+        $key = [Convert]::ToBase64String([byte[]](1..32))
+        $connectionString = "DefaultEndpointsProtocol=https;AccountName=phaseonetest;AccountKey=$key;EndpointSuffix=core.windows.net"
+
+        {
+            Copy-DbaXAzureTableData `
+                -SourceConnectionString $connectionString `
+                -DestinationConnectionString $connectionString `
+                -SourceTable Reports `
+                -DestinationTable reports `
+                -ClearDestination `
+                -ErrorAction Stop
+        } | Should -Throw -ExpectedMessage '*cannot be the same table*'
     }
 
     It 'returns provider capability metadata' {

--- a/Module/Tests/CmdletProviderNeutralSurface.Tests.ps1
+++ b/Module/Tests/CmdletProviderNeutralSurface.Tests.ps1
@@ -52,7 +52,38 @@ Describe 'Provider-neutral DbaClientX cmdlet surface' {
                 -DestinationTable reports `
                 -ClearDestination `
                 -ErrorAction Stop
-        } | Should -Throw -ExpectedMessage '*cannot be the same table*'
+        } | Should -Throw -ExpectedMessage '*also used as source table*'
+    }
+
+    It 'routes native Azure entities without flattening their Properties dictionary' {
+        $key = [Convert]::ToBase64String([byte[]](1..32))
+        $connectionString = "DefaultEndpointsProtocol=https;AccountName=phaseonetest;AccountKey=$key;EndpointSuffix=core.windows.net"
+        $properties = [System.Collections.Generic.Dictionary[string, object]]::new()
+        $properties.Add('Amount', [decimal] 1.25)
+        $entity = [DBAClientX.AzureTables.DbaAzureTableEntity]::new('p1', 'r1', $properties)
+
+        {
+            $entity | Write-DbaXAzureTableEntity `
+                -ConnectionString $connectionString `
+                -TableName Reports `
+                -NoCreateTable `
+                -ErrorAction Stop
+        } | Should -Throw -ExpectedMessage "*property 'Amount'*unsupported CLR type*"
+    }
+
+    It 'rejects mixed native and projected Azure entity input' {
+        $key = [Convert]::ToBase64String([byte[]](1..32))
+        $connectionString = "DefaultEndpointsProtocol=https;AccountName=phaseonetest;AccountKey=$key;EndpointSuffix=core.windows.net"
+        $entity = [DBAClientX.AzureTables.DbaAzureTableEntity]::new('p1', 'r1')
+
+        {
+            @($entity, [pscustomobject] @{ PartitionKey = 'p1'; RowKey = 'r2' }) |
+                Write-DbaXAzureTableEntity `
+                    -ConnectionString $connectionString `
+                    -TableName Reports `
+                    -NoCreateTable `
+                    -ErrorAction Stop
+        } | Should -Throw -ExpectedMessage '*cannot be mixed*'
     }
 
     It 'returns provider capability metadata' {

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ DbaClientX is a lightweight database client for .NET and PowerShell. It keeps th
 [![DBAClientX.MySql](https://img.shields.io/nuget/v/DBAClientX.MySql?label=MySQL)](https://www.nuget.org/packages/DBAClientX.MySql)
 [![DBAClientX.SQLite](https://img.shields.io/nuget/v/DBAClientX.SQLite?label=SQLite)](https://www.nuget.org/packages/DBAClientX.SQLite)
 [![DBAClientX.Oracle](https://img.shields.io/nuget/v/DBAClientX.Oracle?label=Oracle)](https://www.nuget.org/packages/DBAClientX.Oracle)
+[![DbaClientX.AzureTables](https://img.shields.io/nuget/v/DbaClientX.AzureTables?label=Azure%20Tables)](https://www.nuget.org/packages/DbaClientX.AzureTables)
 
 ## PowerShell Module
 
@@ -39,7 +40,7 @@ The PowerShell module stays small and operator-friendly; the heavy database logi
 
 Use it when you need:
 
-- one codebase for SQL Server, PostgreSQL, MySQL, SQLite, and Oracle
+- one codebase for SQL Server, PostgreSQL, MySQL, SQLite, Oracle, and Azure Tables
 - sync and async query execution
 - consistent caller cancellation across query, scalar, non-query, reader, streaming, stored procedure, and bulk APIs; provider-specific cancellation failures are normalized to `OperationCanceledException` with the caller's token
 - parameterized commands and provider-specific parameter type preservation
@@ -57,6 +58,7 @@ Use it when you need:
 | MySQL | [DBAClientX.MySql](https://www.nuget.org/packages/DBAClientX.MySql) | `Invoke-DbaXMySql`, `Invoke-DbaXMySqlNonQuery`, `Invoke-DbaXMySqlScalar` | `Write-DbaXTableData -Provider MySql` | `Invoke-DbaXMySqlTransaction` |
 | SQLite | [DBAClientX.SQLite](https://www.nuget.org/packages/DBAClientX.SQLite) | `Invoke-DbaXSQLite` | `Write-DbaXTableData -Provider SQLite` | `Invoke-DbaXSQLiteTransaction` |
 | Oracle | [DBAClientX.Oracle](https://www.nuget.org/packages/DBAClientX.Oracle) | `Invoke-DbaXOracle`, `Invoke-DbaXOracleNonQuery`, `Invoke-DbaXOracleScalar` | `Write-DbaXTableData -Provider Oracle` | `Invoke-DbaXOracleTransaction` |
+| Azure Storage Tables / Cosmos DB Table API | [DbaClientX.AzureTables](https://www.nuget.org/packages/DbaClientX.AzureTables) | `Get-DbaXAzureTableEntity` | `Write-DbaXAzureTableEntity` | Same-partition transactions through the adapter |
 
 ## Data Movement
 
@@ -67,6 +69,8 @@ Start with the job you need to finish:
 | Write PowerShell objects, `DataTable`, `DataView`, `IDataReader`, or Excel-imported rows to a table | `Write-DbaXTableData` | Uses provider-native database writes |
 | Load a SQL Server staging table and let the command create the table, map columns, lock the table, preserve identities/nulls, fire triggers, check constraints, or report progress | `Write-DbaXTableData -Provider SqlServer` | SQL Server-specific knobs map to `SqlServerBulkInsertOptions` |
 | Copy one or more tables between database providers | `Copy-DbaXTableData` | Uses reusable copy definitions plus provider adapters |
+| Stream Azure Table entities between accounts or Table API endpoints | `Copy-DbaXAzureTableData` | Preserves native continuation tokens and keeps each write transaction inside one partition |
+| Query or upsert Azure Table entities from PowerShell | `Get-DbaXAzureTableEntity` / `Write-DbaXAzureTableEntity` | Requires `PartitionKey` and `RowKey`; transaction batches are capped at 100 entities and the service payload limit |
 | Export SQL rows to CSV, compressed CSV, or Excel | `SqlServer.QueryReader(...)` or `Invoke-DbaXQuery -ReturnType DataTable` plus PSWriteOffice `Export-OfficeCsv` / `Export-OfficeExcel` | Streams or buffers database rows into the file writer |
 | Import CSV, compressed CSV, or Excel into SQL Server | PSWriteOffice `Import-OfficeCsv -AsDataReader` / `Import-OfficeExcel -AsDataReader` plus `Write-DbaXTableData` | Reads the file as tabular data, then bulk-writes it |
 | Stream a reader into SQL Server bulk copy | `Write-DbaXTableData -Provider SqlServer -InputObject (, $reader)` | Pass the reader as a single input object with `, $reader` |
@@ -94,6 +98,7 @@ dotnet add package DBAClientX.PostgreSql
 dotnet add package DBAClientX.MySql
 dotnet add package DBAClientX.SQLite
 dotnet add package DBAClientX.Oracle
+dotnet add package DbaClientX.AzureTables
 ```
 
 Install only the provider packages you need.
@@ -118,6 +123,27 @@ Invoke-DbaXMySql -Server 'mysql01' -Database 'app' -Query 'select * from users l
 Invoke-DbaXOracle -Server 'ora01' -Database 'service' -Query 'select * from users fetch first 10 rows only' -Credential $Credential
 Invoke-DbaXSQLite -Database '.\app.db' -Query 'select * from users limit 10'
 ```
+
+### Azure Tables
+
+Azure queries expose the provider continuation tokens through `-AsPage`; ordinary use streams all returned entities:
+
+```powershell
+$daily = Get-DbaXAzureTableEntity `
+    -ConnectionString $sourceConnectionString `
+    -TableName Reports `
+    -Filter "PartitionKey eq 'daily'"
+
+$daily | Write-DbaXAzureTableEntity `
+    -ConnectionString $archiveConnectionString `
+    -TableName ReportsArchive `
+    -WriteMode UpsertReplace `
+    -PassThru
+```
+
+Use `Copy-DbaXAzureTableData` for a streaming account-to-account copy. Row-count verification is enabled by default and performs additional full-table scans; use `-NoVerify` when that cost is not appropriate. `-ClearDestination` is explicit and cannot target the same source table.
+
+Adapter authors upgrading to `DbaClientX.Core` 0.14 must return `DbaTableCopyPage` from `IDbaTableCopySource.ReadPageAsync`, carrying the provider's opaque continuation token in the page result. The offset constructor on `DbaTableCopyPageRequest` remains temporarily available for callers, but provider implementations should no longer invent paging state in consumers.
 
 ### Build SQL
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $daily | Write-DbaXAzureTableEntity `
     -PassThru
 ```
 
-Use `Copy-DbaXAzureTableData` for a streaming account-to-account copy. Row-count verification is enabled by default and performs additional full-table scans; use `-NoVerify` when that cost is not appropriate. `-ClearDestination` is explicit and cannot target the same source table.
+Use `Copy-DbaXAzureTableData` for a streaming account-to-account copy. Row-count verification is enabled by default and performs additional full-table scans; use `-NoVerify` when that cost is not appropriate. `-ClearDestination` is explicit and is rejected when any destination would clear a source used elsewhere in the same copy plan. The shared adapter applies Azure Storage or Cosmos DB Table API table-name casing rules; this safety decision is not duplicated in the PowerShell cmdlet.
 
 Adapter authors upgrading to `DbaClientX.Core` 0.14 must return `DbaTableCopyPage` from `IDbaTableCopySource.ReadPageAsync`, carrying the provider's opaque continuation token in the page result. The offset constructor on `DbaTableCopyPageRequest` remains temporarily available for callers, but provider implementations should no longer invent paging state in consumers.
 


### PR DESCRIPTION
## Summary

- add Azure Storage Tables and Cosmos DB Table API support with opaque continuation tokens, projection, filters, and partition-safe writes
- expose thin PowerShell commands for query, write, and provider-neutral copy workflows
- protect destructive clear operations from same-source and cross-definition overlap
- preflight types, key constraints, property/entity sizes, and transaction limits before clear or table creation
- preserve case-sensitive properties and provider-specific table-name semantics

## Validation

- the full DbaClientX test suite passes on net8.0 and net10.0
- Azure Tables contract tests pass on net8.0 and net10.0
- provider-neutral PowerShell surface tests pass
- the non-publishing module/package build prepared and payload-verified all project packages and the module archive
- live Azure Storage validation covered cursor paging, native Get-to-Write fidelity, copy into an auto-created destination, clear safety, invalid-input preflight, and cleanup
- an independent review and one targeted confirmation were completed; all reported findings are addressed

## Release state

Publishing was disabled. No NuGet or PowerShell Gallery package was published from this work.