### PR TITLE
Add typed write execution contracts

### DIFF
--- a/DbaClientX.Core/Invoker/DbInvoker.cs
+++ b/DbaClientX.Core/Invoker/DbInvoker.cs
@@ -16,6 +16,8 @@ namespace DBAClientX.Invoker;
 /// </summary>
 public static class DbInvoker
 {
+    private sealed record ExecutionSummary(int CompletedExecutions, int AffectedRows);
+
     /// <summary>
     /// Execution tuning options for batched and parallel invocations.
     /// </summary>
@@ -61,6 +63,48 @@ public static class DbInvoker
         Assembly? providerAssembly = null,
         IReadOnlyDictionary<string, object?>? ambient = null)
     {
+        var result = await ExecuteSqlWithResultAsync(
+            providerAlias,
+            connectionString,
+            sql,
+            items,
+            map,
+            options,
+            execOptions,
+            ct,
+            providerAssembly,
+            ambient).ConfigureAwait(false);
+        return result.AffectedRows;
+    }
+
+    /// <summary>
+    /// Executes a parameterized SQL statement once per item and returns a structured completion result.
+    /// </summary>
+    /// <param name="providerAlias">Provider alias.</param>
+    /// <param name="connectionString">Provider connection string.</param>
+    /// <param name="sql">SQL text to execute.</param>
+    /// <param name="items">Items to map and execute against.</param>
+    /// <param name="map">Logical-to-provider parameter map.</param>
+    /// <param name="options">Mapping options.</param>
+    /// <param name="execOptions">Execution options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="providerAssembly">Optional provider assembly hint.</param>
+    /// <param name="ambient">Ambient values available to mappings.</param>
+    /// <returns>A result returned only after every item execution completes.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when provider execution cannot be completed.</exception>
+    [RequiresUnreferencedCode("DbInvoker discovers provider executors and maps object properties by reflection. Preserve provider GenericExecutors types and item properties when trimming.")]
+    public static async Task<DbaInvocationResult> ExecuteSqlWithResultAsync(
+        string providerAlias,
+        string connectionString,
+        string sql,
+        IEnumerable<object> items,
+        IReadOnlyDictionary<string, string> map,
+        DbParameterMapperOptions? options = null,
+        DbExecutionOptions? execOptions = null,
+        CancellationToken ct = default,
+        Assembly? providerAssembly = null,
+        IReadOnlyDictionary<string, object?>? ambient = null)
+    {
         if (string.IsNullOrWhiteSpace(providerAlias)) throw new ArgumentException("providerAlias is required", nameof(providerAlias));
         if (string.IsNullOrWhiteSpace(connectionString)) throw new ArgumentException("connectionString is required", nameof(connectionString));
         if (string.IsNullOrWhiteSpace(sql)) throw new ArgumentException("sql is required", nameof(sql));
@@ -72,7 +116,7 @@ public static class DbInvoker
         {
             throw new InvalidOperationException($"GenericExecutors for provider '{providerAlias}' not found.");
         }
-        return await ExecuteItemsAsync(
+        var summary = await ExecuteItemsAsync(
             exec,
             connectionString,
             sql,
@@ -82,6 +126,11 @@ public static class DbInvoker
             execOptions ?? new DbExecutionOptions(),
             ct,
             ambient).ConfigureAwait(false);
+        return new DbaInvocationResult(
+            ResolveCanonicalProvider(providerAlias),
+            DbaInvocationKind.Sql,
+            summary.CompletedExecutions,
+            summary.AffectedRows);
     }
 
     /// <summary>
@@ -112,6 +161,48 @@ public static class DbInvoker
         Assembly? providerAssembly = null,
         IReadOnlyDictionary<string, object?>? ambient = null)
     {
+        var result = await ExecuteProcedureWithResultAsync(
+            providerAlias,
+            connectionString,
+            procedure,
+            items,
+            map,
+            options,
+            execOptions,
+            ct,
+            providerAssembly,
+            ambient).ConfigureAwait(false);
+        return result.AffectedRows;
+    }
+
+    /// <summary>
+    /// Executes a stored procedure once per item and returns a structured completion result.
+    /// </summary>
+    /// <param name="providerAlias">Provider alias.</param>
+    /// <param name="connectionString">Provider connection string.</param>
+    /// <param name="procedure">Stored procedure name.</param>
+    /// <param name="items">Items to map and execute against.</param>
+    /// <param name="map">Logical-to-provider parameter map.</param>
+    /// <param name="options">Mapping options.</param>
+    /// <param name="execOptions">Execution options.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="providerAssembly">Optional provider assembly hint.</param>
+    /// <param name="ambient">Ambient values available to mappings.</param>
+    /// <returns>A result returned only after every item execution completes.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when provider execution cannot be completed.</exception>
+    [RequiresUnreferencedCode("DbInvoker discovers provider executors and maps object properties by reflection. Preserve provider GenericExecutors types and item properties when trimming.")]
+    public static async Task<DbaInvocationResult> ExecuteProcedureWithResultAsync(
+        string providerAlias,
+        string connectionString,
+        string procedure,
+        IEnumerable<object> items,
+        IReadOnlyDictionary<string, string> map,
+        DbParameterMapperOptions? options = null,
+        DbExecutionOptions? execOptions = null,
+        CancellationToken ct = default,
+        Assembly? providerAssembly = null,
+        IReadOnlyDictionary<string, object?>? ambient = null)
+    {
         if (string.IsNullOrWhiteSpace(providerAlias)) throw new ArgumentException("providerAlias is required", nameof(providerAlias));
         if (string.IsNullOrWhiteSpace(connectionString)) throw new ArgumentException("connectionString is required", nameof(connectionString));
         if (string.IsNullOrWhiteSpace(procedure)) throw new ArgumentException("procedure is required", nameof(procedure));
@@ -123,7 +214,7 @@ public static class DbInvoker
         {
             throw new InvalidOperationException($"GenericExecutors.ExecuteProcedureAsync for provider '{providerAlias}' not found.");
         }
-        return await ExecuteItemsAsync(
+        var summary = await ExecuteItemsAsync(
             exec,
             connectionString,
             procedure,
@@ -133,10 +224,71 @@ public static class DbInvoker
             execOptions ?? new DbExecutionOptions(),
             ct,
             ambient).ConfigureAwait(false);
+        return new DbaInvocationResult(
+            ResolveCanonicalProvider(providerAlias),
+            DbaInvocationKind.Procedure,
+            summary.CompletedExecutions,
+            summary.AffectedRows);
+    }
+
+    /// <summary>
+    /// Executes one SQL statement or stored procedure with an already materialized parameter set.
+    /// </summary>
+    /// <param name="providerAlias">Provider alias.</param>
+    /// <param name="connectionString">Provider connection string.</param>
+    /// <param name="kind">Operation kind.</param>
+    /// <param name="commandText">SQL text or stored procedure name.</param>
+    /// <param name="parameters">Provider parameters.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <param name="providerAssembly">Optional provider assembly hint.</param>
+    /// <returns>A result returned only after provider execution completes.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the provider cannot be resolved or execution fails.</exception>
+    [RequiresUnreferencedCode("DbInvoker discovers provider executors by reflection. Preserve provider GenericExecutors types when trimming.")]
+    public static async Task<DbaInvocationResult> ExecuteParametersAsync(
+        string providerAlias,
+        string connectionString,
+        DbaInvocationKind kind,
+        string commandText,
+        IDictionary<string, object?> parameters,
+        CancellationToken ct = default,
+        Assembly? providerAssembly = null)
+    {
+        if (string.IsNullOrWhiteSpace(providerAlias)) throw new ArgumentException("providerAlias is required", nameof(providerAlias));
+        if (string.IsNullOrWhiteSpace(connectionString)) throw new ArgumentException("connectionString is required", nameof(connectionString));
+        if (string.IsNullOrWhiteSpace(commandText)) throw new ArgumentException("commandText is required", nameof(commandText));
+        if (parameters is null) throw new ArgumentNullException(nameof(parameters));
+        if (!Enum.IsDefined(typeof(DbaInvocationKind), kind))
+        {
+            throw new ArgumentOutOfRangeException(nameof(kind), kind, "Unsupported invocation kind.");
+        }
+
+        ValidateConnection(providerAlias, connectionString);
+        var methodName = kind == DbaInvocationKind.Procedure
+            ? "ExecuteProcedureAsync"
+            : "ExecuteSqlAsync";
+        var executor = ResolveExecutor(providerAlias, providerAssembly, methodName);
+        if (executor is null)
+        {
+            throw new InvalidOperationException(
+                $"GenericExecutors.{methodName} for provider '{providerAlias}' not found.");
+        }
+
+        ct.ThrowIfCancellationRequested();
+        var affectedRows = await InvokeExecutor(
+            executor,
+            connectionString,
+            commandText,
+            parameters,
+            ct).ConfigureAwait(false);
+        return new DbaInvocationResult(
+            ResolveCanonicalProvider(providerAlias),
+            kind,
+            1,
+            affectedRows);
     }
 
     [RequiresUnreferencedCode("DbInvoker maps object properties by reflection. Use a typed mapping surface when trimming.")]
-    private static async Task<int> ExecuteItemsAsync(
+    private static async Task<ExecutionSummary> ExecuteItemsAsync(
         MethodInfo executor,
         string connectionString,
         string commandText,
@@ -164,28 +316,33 @@ public static class DbInvoker
             return await ExecuteBatchAsync(items, degree, cancellationToken).ConfigureAwait(false);
         }
 
-        var total = 0;
+        var total = new ExecutionSummary(0, 0);
         foreach (var batch in EnumerateBatches(items, executionOptions.BatchSize.Value))
         {
             cancellationToken.ThrowIfCancellationRequested();
-            total = checked(total + await ExecuteBatchAsync(batch, degree, cancellationToken).ConfigureAwait(false));
+            var result = await ExecuteBatchAsync(batch, degree, cancellationToken).ConfigureAwait(false);
+            total = new ExecutionSummary(
+                checked(total.CompletedExecutions + result.CompletedExecutions),
+                checked(total.AffectedRows + result.AffectedRows));
         }
 
         return total;
 
-        async Task<int> ExecuteBatchAsync(IEnumerable<object> batch, int parallelDegree, CancellationToken token)
+        async Task<ExecutionSummary> ExecuteBatchAsync(IEnumerable<object> batch, int parallelDegree, CancellationToken token)
         {
             if (parallelDegree == 1)
             {
                 var sequentialAffected = 0;
+                var sequentialCompleted = 0;
                 foreach (var item in batch)
                 {
                     token.ThrowIfCancellationRequested();
                     var parameters = DbParameterMapper.MapItem(item, map, mappingOptions, ambient);
                     sequentialAffected = checked(sequentialAffected + await InvokeExecutor(executor, connectionString, commandText, parameters, token).ConfigureAwait(false));
+                    sequentialCompleted = checked(sequentialCompleted + 1);
                 }
 
-                return sequentialAffected;
+                return new ExecutionSummary(sequentialCompleted, sequentialAffected);
             }
 
             using var linkedCancellation = CancellationTokenSource.CreateLinkedTokenSource(token);
@@ -199,10 +356,10 @@ public static class DbInvoker
             };
             if (workerCount == 0)
             {
-                return 0;
+                return new ExecutionSummary(0, 0);
             }
 
-            var workers = new Task<int>[workerCount];
+            var workers = new Task<ExecutionSummary>[workerCount];
             for (var index = 0; index < workers.Length; index++)
             {
                 workers[index] = RunWorkerAsync();
@@ -210,16 +367,19 @@ public static class DbInvoker
 
             var results = await Task.WhenAll(workers).ConfigureAwait(false);
             var parallelAffected = 0;
+            var parallelCompleted = 0;
             foreach (var result in results)
             {
-                parallelAffected = checked(parallelAffected + result);
+                parallelAffected = checked(parallelAffected + result.AffectedRows);
+                parallelCompleted = checked(parallelCompleted + result.CompletedExecutions);
             }
 
-            return parallelAffected;
+            return new ExecutionSummary(parallelCompleted, parallelAffected);
 
-            async Task<int> RunWorkerAsync()
+            async Task<ExecutionSummary> RunWorkerAsync()
             {
                 var localAffected = 0;
+                var localCompleted = 0;
                 try
                 {
                     while (true)
@@ -243,9 +403,10 @@ public static class DbInvoker
                             commandText,
                             parameters,
                             linkedCancellation.Token).ConfigureAwait(false));
+                        localCompleted = checked(localCompleted + 1);
                     }
 
-                    return localAffected;
+                    return new ExecutionSummary(localCompleted, localAffected);
                 }
                 catch
                 {
@@ -255,6 +416,11 @@ public static class DbInvoker
             }
         }
     }
+
+    private static string ResolveCanonicalProvider(string providerAlias)
+        => DbaConnectionFactory.TryGetProvider(providerAlias, out var provider)
+            ? provider.CanonicalName
+            : providerAlias.Trim();
 
     private static MethodInfo? ResolveExecutor(string providerAlias, Assembly? providerAssembly, string methodName)
     {

--- a/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
+++ b/DbaClientX.Core/Invoker/DbaConnectionFactory.cs
@@ -12,10 +12,17 @@ namespace DBAClientX.Invoker;
 public static class DbaConnectionFactory
 {
     /// <summary>Describes a supported provider and the shared aliases used to resolve it.</summary>
+    /// <param name="CanonicalName">Canonical provider name.</param>
+    /// <param name="Aliases">Aliases accepted by the shared provider surfaces.</param>
+    /// <param name="GenericExecutorTypeName">Fully qualified provider executor type name.</param>
     public sealed record ProviderDescriptor(
         string CanonicalName,
         IReadOnlyList<string> Aliases,
-        string GenericExecutorTypeName);
+        string GenericExecutorTypeName)
+    {
+        /// <summary>Gets the provider assembly name used for discovery and deployment.</summary>
+        public string AssemblyName { get; init; } = string.Empty;
+    }
 
     /// <summary>
     /// Represents the type of validation failure encountered while preparing a connection.
@@ -80,11 +87,11 @@ public static class DbaConnectionFactory
 
     private static readonly IReadOnlyList<ProviderDescriptor> ProviderDescriptorList = Array.AsReadOnly(new[]
     {
-        new ProviderDescriptor("sqlserver", Array.AsReadOnly(new[] { "sqlserver", "mssql" }), "DBAClientX.SqlServerGeneric.GenericExecutors"),
-        new ProviderDescriptor("postgresql", Array.AsReadOnly(new[] { "postgresql", "postgres", "pgsql" }), "DBAClientX.PostgreSqlGeneric.GenericExecutors"),
-        new ProviderDescriptor("mysql", Array.AsReadOnly(new[] { "mysql" }), "DBAClientX.MySqlGeneric.GenericExecutors"),
-        new ProviderDescriptor("sqlite", Array.AsReadOnly(new[] { "sqlite" }), "DBAClientX.SQLiteGeneric.GenericExecutors"),
-        new ProviderDescriptor("oracle", Array.AsReadOnly(new[] { "oracle" }), "DBAClientX.OracleGeneric.GenericExecutors")
+        new ProviderDescriptor("sqlserver", Array.AsReadOnly(new[] { "sqlserver", "mssql" }), "DBAClientX.SqlServerGeneric.GenericExecutors") { AssemblyName = "DbaClientX.SqlServer" },
+        new ProviderDescriptor("postgresql", Array.AsReadOnly(new[] { "postgresql", "postgres", "pgsql" }), "DBAClientX.PostgreSqlGeneric.GenericExecutors") { AssemblyName = "DbaClientX.PostgreSql" },
+        new ProviderDescriptor("mysql", Array.AsReadOnly(new[] { "mysql" }), "DBAClientX.MySqlGeneric.GenericExecutors") { AssemblyName = "DbaClientX.MySql" },
+        new ProviderDescriptor("sqlite", Array.AsReadOnly(new[] { "sqlite" }), "DBAClientX.SQLiteGeneric.GenericExecutors") { AssemblyName = "DbaClientX.SQLite" },
+        new ProviderDescriptor("oracle", Array.AsReadOnly(new[] { "oracle" }), "DBAClientX.OracleGeneric.GenericExecutors") { AssemblyName = "DbaClientX.Oracle" }
     });
 
     private static readonly Dictionary<string, ProviderDescriptor> ProvidersByAlias = CreateProviderAliasMap();

--- a/DbaClientX.Core/Invoker/DbaInvocationKind.cs
+++ b/DbaClientX.Core/Invoker/DbaInvocationKind.cs
@@ -1,0 +1,17 @@
+namespace DBAClientX.Invoker;
+
+/// <summary>
+/// Identifies the provider operation performed by <see cref="DbInvoker"/>.
+/// </summary>
+public enum DbaInvocationKind
+{
+    /// <summary>
+    /// A SQL statement was executed.
+    /// </summary>
+    Sql,
+
+    /// <summary>
+    /// A stored procedure was executed.
+    /// </summary>
+    Procedure
+}

--- a/DbaClientX.Core/Invoker/DbaInvocationResult.cs
+++ b/DbaClientX.Core/Invoker/DbaInvocationResult.cs
@@ -1,0 +1,14 @@
+namespace DBAClientX.Invoker;
+
+/// <summary>
+/// Describes a completed provider invocation.
+/// </summary>
+/// <param name="Provider">Canonical provider name.</param>
+/// <param name="Kind">Operation kind.</param>
+/// <param name="CompletedExecutions">Number of item or payload executions that completed.</param>
+/// <param name="AffectedRows">Total affected rows reported by the provider.</param>
+public sealed record DbaInvocationResult(
+    string Provider,
+    DbaInvocationKind Kind,
+    int CompletedExecutions,
+    int AffectedRows);

--- a/DbaClientX.Core/Invoker/DbaWritePlan.cs
+++ b/DbaClientX.Core/Invoker/DbaWritePlan.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace DBAClientX.Invoker;
+
+/// <summary>
+/// Contains provider-specific SQL and the logical-to-parameter mapping for an insert or upsert.
+/// </summary>
+/// <param name="Sql">Compiled provider-specific SQL.</param>
+/// <param name="ParameterMap">Logical source member to provider parameter mapping.</param>
+/// <param name="Columns">Ordered destination columns included in the write.</param>
+public sealed record DbaWritePlan(
+    string Sql,
+    IReadOnlyDictionary<string, string> ParameterMap,
+    IReadOnlyList<string> Columns);

--- a/DbaClientX.Core/Invoker/DbaWritePlanBuilder.cs
+++ b/DbaClientX.Core/Invoker/DbaWritePlanBuilder.cs
@@ -99,8 +99,10 @@ public static class DbaWritePlanBuilder
             throw new ArgumentException("At least one destination column is required.", nameof(columns));
         }
 
-        var keys = NormalizeDistinct(upsertKeys ?? Array.Empty<string>(), nameof(upsertKeys));
-        EnsureColumnsExist(keys, orderedColumns, nameof(upsertKeys));
+        var keys = ResolveCanonicalColumns(
+            NormalizeDistinct(upsertKeys ?? Array.Empty<string>(), nameof(upsertKeys)),
+            orderedColumns,
+            nameof(upsertKeys));
         if (keys.Count == 0 && upsertUpdateColumns is not null)
         {
             throw new ArgumentException(
@@ -115,10 +117,12 @@ public static class DbaWritePlanBuilder
 
         var updateColumns = keys.Count == 0
             ? new List<string>()
-            : NormalizeDistinct(
-                upsertUpdateColumns ?? orderedColumns.Where(column => !Contains(keys, column)),
+            : ResolveCanonicalColumns(
+                NormalizeDistinct(
+                    upsertUpdateColumns ?? orderedColumns.Where(column => !Contains(keys, column)),
+                    nameof(upsertUpdateColumns)),
+                orderedColumns,
                 nameof(upsertUpdateColumns));
-        EnsureColumnsExist(updateColumns, orderedColumns, nameof(upsertUpdateColumns));
 
         var parameterReferences = orderedColumns
             .Select(static (_, index) => (object)new QueryParameterReference(index))
@@ -146,7 +150,7 @@ public static class DbaWritePlanBuilder
         var compiled = DBAClientX.QueryBuilder.QueryBuilder.CompileWithParameters(
             query,
             ToDialect(provider.CanonicalName));
-        var reverseMap = BuildReverseMap(logicalToColumnMap);
+        var reverseMap = BuildReverseMap(logicalToColumnMap, orderedColumns);
         var parameterMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         for (var index = 0; index < orderedColumns.Count; index++)
         {
@@ -189,7 +193,8 @@ public static class DbaWritePlanBuilder
     }
 
     private static Dictionary<string, string> BuildReverseMap(
-        IReadOnlyDictionary<string, string>? logicalToColumnMap)
+        IReadOnlyDictionary<string, string>? logicalToColumnMap,
+        IReadOnlyCollection<string> availableColumns)
     {
         var reverse = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var logicalNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -207,38 +212,51 @@ public static class DbaWritePlanBuilder
 
             var logicalName = pair.Key.Trim();
             var destinationColumn = TrimParameterPrefix(pair.Value.Trim());
+            var canonicalDestination = availableColumns.FirstOrDefault(
+                column => string.Equals(column, destinationColumn, StringComparison.OrdinalIgnoreCase));
+            if (canonicalDestination is null)
+            {
+                throw new ArgumentException(
+                    $"Mapped destination column '{destinationColumn}' is not present in the destination column set.",
+                    nameof(logicalToColumnMap));
+            }
             if (!logicalNames.Add(logicalName))
             {
                 throw new ArgumentException(
                     $"Logical mapping '{logicalName}' is duplicated when compared case-insensitively.",
                     nameof(logicalToColumnMap));
             }
-            if (reverse.ContainsKey(destinationColumn))
+            if (reverse.ContainsKey(canonicalDestination))
             {
                 throw new ArgumentException(
                     $"Destination column mapping '{destinationColumn}' is duplicated when compared case-insensitively.",
                     nameof(logicalToColumnMap));
             }
-            reverse.Add(destinationColumn, logicalName);
+            reverse.Add(canonicalDestination, logicalName);
         }
 
         return reverse;
     }
 
-    private static void EnsureColumnsExist(
+    private static List<string> ResolveCanonicalColumns(
         IEnumerable<string> requested,
         IReadOnlyCollection<string> available,
         string parameterName)
     {
+        var resolved = new List<string>();
         foreach (var column in requested)
         {
-            if (!Contains(available, column))
+            var canonical = available.FirstOrDefault(
+                candidate => string.Equals(candidate, column, StringComparison.OrdinalIgnoreCase));
+            if (canonical is null)
             {
                 throw new ArgumentException(
                     $"Column '{column}' is not present in the destination column set.",
                     parameterName);
             }
+            resolved.Add(canonical);
         }
+        return resolved;
     }
 
     private static bool Contains(IEnumerable<string> values, string candidate)

--- a/DbaClientX.Core/Invoker/DbaWritePlanBuilder.cs
+++ b/DbaClientX.Core/Invoker/DbaWritePlanBuilder.cs
@@ -107,6 +107,11 @@ public static class DbaWritePlanBuilder
                 "Upsert update columns require at least one upsert key.",
                 nameof(upsertUpdateColumns));
         }
+        if (keys.Count > 0 && provider.CanonicalName == "oracle")
+        {
+            throw new NotSupportedException(
+                "Oracle upsert plans are not supported. Use an insert plan or provider-specific SQL.");
+        }
 
         var updateColumns = keys.Count == 0
             ? new List<string>()
@@ -126,7 +131,7 @@ public static class DbaWritePlanBuilder
                 .ToList();
             query = DBAClientX.QueryBuilder.QueryBuilder.Query()
                 .InsertOrUpdate(table, values, keys.ToArray());
-            if (updateColumns.Count > 0)
+            if (upsertUpdateColumns is not null)
             {
                 query = query.UpsertUpdateOnly(updateColumns.ToArray());
             }
@@ -149,8 +154,15 @@ public static class DbaWritePlanBuilder
             var logical = reverseMap.TryGetValue(column, out var configuredLogical)
                 ? configuredLogical
                 : column;
-            parameterMap[logical] =
-                (provider.CanonicalName == "oracle" ? ":p" : "@p") + index;
+            if (parameterMap.ContainsKey(logical))
+            {
+                throw new ArgumentException(
+                    $"Logical mapping '{logical}' is duplicated when compared case-insensitively.",
+                    nameof(logicalToColumnMap));
+            }
+            parameterMap.Add(
+                logical,
+                (provider.CanonicalName == "oracle" ? ":p" : "@p") + index);
         }
 
         return new DbaWritePlan(compiled.Sql, parameterMap, orderedColumns);
@@ -180,6 +192,7 @@ public static class DbaWritePlanBuilder
         IReadOnlyDictionary<string, string>? logicalToColumnMap)
     {
         var reverse = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var logicalNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (logicalToColumnMap is null)
         {
             return reverse;
@@ -192,7 +205,21 @@ public static class DbaWritePlanBuilder
                 continue;
             }
 
-            reverse[TrimParameterPrefix(pair.Value.Trim())] = pair.Key;
+            var logicalName = pair.Key.Trim();
+            var destinationColumn = TrimParameterPrefix(pair.Value.Trim());
+            if (!logicalNames.Add(logicalName))
+            {
+                throw new ArgumentException(
+                    $"Logical mapping '{logicalName}' is duplicated when compared case-insensitively.",
+                    nameof(logicalToColumnMap));
+            }
+            if (reverse.ContainsKey(destinationColumn))
+            {
+                throw new ArgumentException(
+                    $"Destination column mapping '{destinationColumn}' is duplicated when compared case-insensitively.",
+                    nameof(logicalToColumnMap));
+            }
+            reverse.Add(destinationColumn, logicalName);
         }
 
         return reverse;

--- a/DbaClientX.Core/Invoker/DbaWritePlanBuilder.cs
+++ b/DbaClientX.Core/Invoker/DbaWritePlanBuilder.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Reflection;
+using DBAClientX.Mapping;
+using DBAClientX.QueryBuilder;
+
+namespace DBAClientX.Invoker;
+
+/// <summary>
+/// Builds provider-specific insert and upsert plans from destination columns.
+/// </summary>
+public static class DbaWritePlanBuilder
+{
+    /// <summary>
+    /// Resolves an ordered destination column set from explicit configuration or a source item's public properties.
+    /// </summary>
+    /// <param name="item">Representative source item used when <paramref name="includedColumns"/> is empty.</param>
+    /// <param name="includedColumns">Explicit destination columns.</param>
+    /// <param name="excludedColumns">Columns to omit unless they are required.</param>
+    /// <param name="requiredColumns">Columns that must remain present, such as upsert keys.</param>
+    /// <returns>An ordered, case-insensitively distinct column set.</returns>
+    [RequiresUnreferencedCode("Column discovery reads public source properties by reflection. Supply includedColumns when trimming.")]
+    public static IReadOnlyList<string> DiscoverColumns(
+        object? item,
+        IEnumerable<string>? includedColumns = null,
+        IEnumerable<string>? excludedColumns = null,
+        IEnumerable<string>? requiredColumns = null)
+    {
+        var included = NormalizeDistinct(includedColumns ?? Array.Empty<string>(), nameof(includedColumns));
+        if (included.Count == 0 && item is not null)
+        {
+            included = DbPropertyAccessor.TryGetStringDictionaryKeys(item, out var dictionaryKeys)
+                ? NormalizeDistinct(dictionaryKeys, nameof(item))
+                : item.GetType()
+                    .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                    .Where(static property => property.GetIndexParameters().Length == 0)
+                    .Select(static property => property.Name)
+                    .ToList();
+        }
+
+        var required = NormalizeDistinct(requiredColumns ?? Array.Empty<string>(), nameof(requiredColumns));
+        var excluded = NormalizeDistinct(excludedColumns ?? Array.Empty<string>(), nameof(excludedColumns));
+        included = included
+            .Where(column => !Contains(excluded, column) || Contains(required, column))
+            .ToList();
+        foreach (var requiredColumn in required)
+        {
+            if (!Contains(included, requiredColumn))
+            {
+                included.Add(requiredColumn);
+            }
+        }
+
+        return included;
+    }
+
+    /// <summary>
+    /// Builds an insert or upsert plan.
+    /// </summary>
+    /// <param name="providerAlias">Provider alias supported by <see cref="DbaConnectionFactory"/>.</param>
+    /// <param name="table">Destination table, optionally schema-qualified.</param>
+    /// <param name="columns">Ordered destination columns.</param>
+    /// <param name="logicalToColumnMap">
+    /// Optional source-member to destination-column mapping. Parameter prefixes on destination values are ignored.
+    /// </param>
+    /// <param name="upsertKeys">Columns that identify an existing row.</param>
+    /// <param name="upsertUpdateColumns">
+    /// Columns updated on conflict. When omitted, all non-key columns are updated.
+    /// </param>
+    /// <returns>A compiled write plan.</returns>
+    public static DbaWritePlan Build(
+        string providerAlias,
+        string table,
+        IEnumerable<string> columns,
+        IReadOnlyDictionary<string, string>? logicalToColumnMap = null,
+        IEnumerable<string>? upsertKeys = null,
+        IEnumerable<string>? upsertUpdateColumns = null)
+    {
+        if (string.IsNullOrWhiteSpace(table))
+        {
+            throw new ArgumentException("Destination table is required.", nameof(table));
+        }
+
+        if (columns is null)
+        {
+            throw new ArgumentNullException(nameof(columns));
+        }
+
+        if (!DbaConnectionFactory.TryGetProvider(providerAlias, out var provider))
+        {
+            throw new ArgumentException($"Provider '{providerAlias}' is not supported.", nameof(providerAlias));
+        }
+
+        var orderedColumns = NormalizeDistinct(columns, nameof(columns));
+        if (orderedColumns.Count == 0)
+        {
+            throw new ArgumentException("At least one destination column is required.", nameof(columns));
+        }
+
+        var keys = NormalizeDistinct(upsertKeys ?? Array.Empty<string>(), nameof(upsertKeys));
+        EnsureColumnsExist(keys, orderedColumns, nameof(upsertKeys));
+        if (keys.Count == 0 && upsertUpdateColumns is not null)
+        {
+            throw new ArgumentException(
+                "Upsert update columns require at least one upsert key.",
+                nameof(upsertUpdateColumns));
+        }
+
+        var updateColumns = keys.Count == 0
+            ? new List<string>()
+            : NormalizeDistinct(
+                upsertUpdateColumns ?? orderedColumns.Where(column => !Contains(keys, column)),
+                nameof(upsertUpdateColumns));
+        EnsureColumnsExist(updateColumns, orderedColumns, nameof(upsertUpdateColumns));
+
+        var parameterReferences = orderedColumns
+            .Select(static (_, index) => (object)new QueryParameterReference(index))
+            .ToArray();
+        Query query;
+        if (keys.Count > 0)
+        {
+            var values = orderedColumns
+                .Select((column, index) => (Column: column, Value: parameterReferences[index]))
+                .ToList();
+            query = DBAClientX.QueryBuilder.QueryBuilder.Query()
+                .InsertOrUpdate(table, values, keys.ToArray());
+            if (updateColumns.Count > 0)
+            {
+                query = query.UpsertUpdateOnly(updateColumns.ToArray());
+            }
+        }
+        else
+        {
+            query = DBAClientX.QueryBuilder.QueryBuilder.Query()
+                .InsertInto(table, orderedColumns.ToArray())
+                .Values(parameterReferences);
+        }
+
+        var compiled = DBAClientX.QueryBuilder.QueryBuilder.CompileWithParameters(
+            query,
+            ToDialect(provider.CanonicalName));
+        var reverseMap = BuildReverseMap(logicalToColumnMap);
+        var parameterMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var index = 0; index < orderedColumns.Count; index++)
+        {
+            var column = orderedColumns[index];
+            var logical = reverseMap.TryGetValue(column, out var configuredLogical)
+                ? configuredLogical
+                : column;
+            parameterMap[logical] =
+                (provider.CanonicalName == "oracle" ? ":p" : "@p") + index;
+        }
+
+        return new DbaWritePlan(compiled.Sql, parameterMap, orderedColumns);
+    }
+
+    private static List<string> NormalizeDistinct(IEnumerable<string> values, string parameterName)
+    {
+        var result = new List<string>();
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("Column names cannot be null or whitespace.", parameterName);
+            }
+
+            var normalized = TrimParameterPrefix(value.Trim());
+            if (!Contains(result, normalized))
+            {
+                result.Add(normalized);
+            }
+        }
+
+        return result;
+    }
+
+    private static Dictionary<string, string> BuildReverseMap(
+        IReadOnlyDictionary<string, string>? logicalToColumnMap)
+    {
+        var reverse = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (logicalToColumnMap is null)
+        {
+            return reverse;
+        }
+
+        foreach (var pair in logicalToColumnMap)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key) || string.IsNullOrWhiteSpace(pair.Value))
+            {
+                continue;
+            }
+
+            reverse[TrimParameterPrefix(pair.Value.Trim())] = pair.Key;
+        }
+
+        return reverse;
+    }
+
+    private static void EnsureColumnsExist(
+        IEnumerable<string> requested,
+        IReadOnlyCollection<string> available,
+        string parameterName)
+    {
+        foreach (var column in requested)
+        {
+            if (!Contains(available, column))
+            {
+                throw new ArgumentException(
+                    $"Column '{column}' is not present in the destination column set.",
+                    parameterName);
+            }
+        }
+    }
+
+    private static bool Contains(IEnumerable<string> values, string candidate)
+        => values.Any(value => string.Equals(value, candidate, StringComparison.OrdinalIgnoreCase));
+
+    private static string TrimParameterPrefix(string value)
+        => value.Length > 0 && value[0] is '@' or ':'
+            ? value.Substring(1)
+            : value;
+
+    private static SqlDialect ToDialect(string provider)
+        => provider switch
+        {
+            "sqlite" => SqlDialect.SQLite,
+            "sqlserver" => SqlDialect.SqlServer,
+            "postgresql" => SqlDialect.PostgreSql,
+            "mysql" => SqlDialect.MySql,
+            "oracle" => SqlDialect.Oracle,
+            _ => throw new ArgumentOutOfRangeException(nameof(provider), provider, "Unsupported SQL dialect.")
+        };
+}

--- a/DbaClientX.Core/Invoker/DbaWritePlanBuilder.cs
+++ b/DbaClientX.Core/Invoker/DbaWritePlanBuilder.cs
@@ -35,7 +35,9 @@ public static class DbaWritePlanBuilder
                 ? NormalizeDistinct(dictionaryKeys, nameof(item))
                 : item.GetType()
                     .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-                    .Where(static property => property.GetIndexParameters().Length == 0)
+                    .Where(static property =>
+                        property.CanRead &&
+                        property.GetIndexParameters().Length == 0)
                     .Select(static property => property.Name)
                     .ToList();
         }
@@ -114,6 +116,11 @@ public static class DbaWritePlanBuilder
             throw new NotSupportedException(
                 "Oracle upsert plans are not supported. Use an insert plan or provider-specific SQL.");
         }
+        if (keys.Count > 0 && provider.CanonicalName == "mysql")
+        {
+            throw new NotSupportedException(
+                "MySQL write-plan upserts cannot guarantee that the requested keys are the only conflict target. Use an insert plan or provider-specific SQL.");
+        }
 
         var updateColumns = keys.Count == 0
             ? new List<string>()
@@ -182,7 +189,7 @@ public static class DbaWritePlanBuilder
                 throw new ArgumentException("Column names cannot be null or whitespace.", parameterName);
             }
 
-            var normalized = TrimParameterPrefix(value.Trim());
+            var normalized = value.Trim();
             if (!Contains(result, normalized))
             {
                 result.Add(normalized);
@@ -207,7 +214,9 @@ public static class DbaWritePlanBuilder
         {
             if (string.IsNullOrWhiteSpace(pair.Key) || string.IsNullOrWhiteSpace(pair.Value))
             {
-                continue;
+                throw new ArgumentException(
+                    "Logical mapping names and destination columns cannot be null or whitespace.",
+                    nameof(logicalToColumnMap));
             }
 
             var logicalName = pair.Key.Trim();

--- a/DbaClientX.Core/Mapping/DbPropertyAccessor.cs
+++ b/DbaClientX.Core/Mapping/DbPropertyAccessor.cs
@@ -195,6 +195,60 @@ public static class DbPropertyAccessor
         return TryGetFromStringDictionaryEnumeration(obj, dictionaryType, key, out value);
     }
 
+    [RequiresUnreferencedCode("Generic-only dictionary key discovery reflects KeyValuePair entries. Supply explicit columns when trimming.")]
+    internal static bool TryGetStringDictionaryKeys(object item, out IReadOnlyList<string> keys)
+    {
+        if (item is IReadOnlyDictionary<string, object?> readOnlyDictionary)
+        {
+            keys = new List<string>(readOnlyDictionary.Keys);
+            return true;
+        }
+
+        if (item is IDictionary<string, object?> genericDictionary)
+        {
+            keys = new List<string>(genericDictionary.Keys);
+            return true;
+        }
+
+        if (item is IDictionary dictionary)
+        {
+            var result = new List<string>();
+            foreach (var key in dictionary.Keys)
+            {
+                if (key is string text)
+                {
+                    result.Add(text);
+                }
+            }
+            keys = result;
+            return true;
+        }
+
+        var dictionaryType = FindStringDictionaryInterface(item.GetType());
+        if (dictionaryType is null || item is not IEnumerable enumerable)
+        {
+            keys = Array.Empty<string>();
+            return false;
+        }
+
+        var genericResult = new List<string>();
+        foreach (var entry in enumerable)
+        {
+            if (entry is null)
+            {
+                continue;
+            }
+
+            var keyProperty = entry.GetType().GetProperty(nameof(KeyValuePair<string, object>.Key));
+            if (keyProperty?.GetValue(entry) is string text)
+            {
+                genericResult.Add(text);
+            }
+        }
+        keys = genericResult;
+        return true;
+    }
+
     private static bool HasStringDictionaryInterface([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type? type)
         => FindStringDictionaryInterface(type) is not null;
 

--- a/DbaClientX.Core/QueryBuilder/Query.State.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.State.cs
@@ -41,6 +41,8 @@ public partial class Query
     /// <summary>Gets the subset of columns that should be updated during an upsert.</summary>
     public IReadOnlyList<string> UpsertUpdateOnlyColumns => _upsertUpdateOnly;
 
+    internal bool HasExplicitUpsertUpdateOnly => _hasExplicitUpsertUpdateOnly;
+
     /// <summary>Gets the table targeted by an <c>UPDATE</c> statement.</summary>
     public string? UpdateTable => _updateTable;
 

--- a/DbaClientX.Core/QueryBuilder/Query.cs
+++ b/DbaClientX.Core/QueryBuilder/Query.cs
@@ -22,6 +22,7 @@ public partial class Query
     private bool _isUpsert;
     private readonly List<string> _conflictColumns = new();
     private readonly List<string> _upsertUpdateOnly = new();
+    private bool _hasExplicitUpsertUpdateOnly;
     private string? _updateTable;
     private readonly List<(string Column, object Value)> _set = new();
     private string? _deleteTable;
@@ -556,20 +557,32 @@ public partial class Query
         _values.Add(row);
         _conflictColumns.Clear();
         _conflictColumns.AddRange(conflictColumns);
+        _upsertUpdateOnly.Clear();
+        _hasExplicitUpsertUpdateOnly = false;
         _isUpsert = true;
         return this;
     }
 
     /// <summary>
-    /// Limits the set of columns updated during an upsert to the provided list. If not set, all insert columns are updated.
+    /// Limits the set of columns updated during an upsert to the provided list.
+    /// An empty list requests insert-if-missing behavior without updating an
+    /// existing row. If not set, all non-key insert columns are updated.
     /// </summary>
     /// <param name="columns">The columns to update when a conflict occurs.</param>
     /// <returns>The current <see cref="Query"/> instance.</returns>
     public Query UpsertUpdateOnly(params string[] columns)
     {
-        ValidateStrings(columns, nameof(columns));
+        if (columns == null)
+        {
+            throw new ArgumentNullException(nameof(columns));
+        }
+        foreach (var column in columns)
+        {
+            ValidateString(column, nameof(columns));
+        }
         _upsertUpdateOnly.Clear();
         _upsertUpdateOnly.AddRange(columns);
+        _hasExplicitUpsertUpdateOnly = true;
         return this;
     }
 

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.Values.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.Values.cs
@@ -5,6 +5,8 @@ using System.Text;
 
 namespace DBAClientX.QueryBuilder;
 
+internal sealed record QueryParameterReference(int Index);
+
 public partial class QueryCompiler
 {
     private void AppendValues(StringBuilder builder, IReadOnlyList<object> values, List<object>? parameters)
@@ -22,6 +24,12 @@ public partial class QueryCompiler
 
     private void AppendValue(StringBuilder builder, object value, List<object>? parameters)
     {
+        if (value is QueryParameterReference parameterReference)
+        {
+            builder.Append(GetParameterName(parameterReference.Index));
+            return;
+        }
+
         if (value is Query query)
         {
             builder.Append('(').Append(CompileInternal(query, parameters)).Append(')');
@@ -31,12 +39,15 @@ public partial class QueryCompiler
         builder.Append(parameters != null ? AddParameter(value, parameters) : FormatValue(value));
     }
 
-    private static string AddParameter(object value, List<object> parameters)
+    private string AddParameter(object value, List<object> parameters)
     {
-        var name = "@p" + parameters.Count;
+        var name = GetParameterName(parameters.Count);
         parameters.Add(value);
         return name;
     }
+
+    private string GetParameterName(int index)
+        => (_dialect == SqlDialect.Oracle ? ":p" : "@p") + index;
 
     private string FormatValue(object value)
     {

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -629,6 +629,11 @@ public partial class QueryCompiler
                     .ToList();
                 if (updateColsMy.Count == 0)
                 {
+                    if (query.HasExplicitUpsertUpdateOnly)
+                    {
+                        throw new NotSupportedException(
+                            "MySQL cannot preserve insert-if-missing semantics for an explicit empty upsert update set without entering the UPDATE path.");
+                    }
                     var key = query.ConflictColumns.First();
                     sb.Append(QuoteIdentifier(key)).Append(" = ").Append(QuoteIdentifier(key));
                     return sb.ToString();

--- a/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
+++ b/DbaClientX.Core/QueryBuilder/QueryCompiler.cs
@@ -216,7 +216,7 @@ public partial class QueryCompiler
             if (query.IsUpsert)
             {
                 sb.Append("U:").Append(string.Join(",", query.ConflictColumns)).Append('|');
-                if (query.UpsertUpdateOnlyColumns.Count > 0)
+                if (query.HasExplicitUpsertUpdateOnly)
                 {
                     sb.Append("UUO:").Append(string.Join(",", query.UpsertUpdateOnlyColumns)).Append('|');
                 }
@@ -295,6 +295,12 @@ public partial class QueryCompiler
         if (value is Query subQuery)
         {
             builder.Append("Q(").Append(BuildCacheKey(subQuery)).Append(')');
+            return;
+        }
+
+        if (value is QueryParameterReference parameterReference)
+        {
+            builder.Append('R').Append(parameterReference.Index);
             return;
         }
 
@@ -587,7 +593,7 @@ public partial class QueryCompiler
                 sb.Append(") ON CONFLICT (")
                   .Append(string.Join(", ", query.ConflictColumns.Select(QuoteIdentifier)))
                   .Append(") ");
-                var updateColsPg = (query.UpsertUpdateOnlyColumns.Count > 0 ? query.UpsertUpdateOnlyColumns : query.InsertColumns)
+                var updateColsPg = (query.HasExplicitUpsertUpdateOnly ? query.UpsertUpdateOnlyColumns : query.InsertColumns)
                     .Where(col => !query.ConflictColumns.Any(k => string.Equals(k, col, StringComparison.OrdinalIgnoreCase)))
                     .ToList();
                 if (updateColsPg.Count == 0)
@@ -618,7 +624,7 @@ public partial class QueryCompiler
                     AppendValue(sb, row[i], parameters);
                 }
                 sb.Append(") ON DUPLICATE KEY UPDATE ");
-                var updateColsMy = (query.UpsertUpdateOnlyColumns.Count > 0 ? query.UpsertUpdateOnlyColumns : query.InsertColumns)
+                var updateColsMy = (query.HasExplicitUpsertUpdateOnly ? query.UpsertUpdateOnlyColumns : query.InsertColumns)
                     .Where(col => !query.ConflictColumns.Any(k => string.Equals(k, col, StringComparison.OrdinalIgnoreCase)))
                     .ToList();
                 if (updateColsMy.Count == 0)
@@ -652,7 +658,7 @@ public partial class QueryCompiler
                 }
                 insertValues.Append(')');
 
-                var updateColsMs = (query.UpsertUpdateOnlyColumns.Count > 0 ? query.UpsertUpdateOnlyColumns : query.InsertColumns)
+                var updateColsMs = (query.HasExplicitUpsertUpdateOnly ? query.UpsertUpdateOnlyColumns : query.InsertColumns)
                     .Where(col => !query.ConflictColumns.Any(k => string.Equals(k, col, StringComparison.OrdinalIgnoreCase)))
                     .ToList();
                 var conflictPredicate = BuildSqlServerUpsertPredicate(query, row, parameters);

--- a/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
@@ -122,7 +122,7 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
 
     /// <summary>Columns updated during an UPSERT conflict. When omitted, the core builder updates all non-conflict insert columns.</summary>
     [Parameter(Mandatory = false)]
-    [ValidateNotNullOrEmpty]
+    [ValidateNotNull]
     public string[]? UpsertUpdateOnly { get; set; }
 
     /// <summary>Columns to add to ORDER BY in ascending order.</summary>

--- a/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletNewDbaXQuery.cs
@@ -178,7 +178,7 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
             var compiled = DbaQueryBuilder.CompileWithParameters(query, Dialect);
             WriteObject(new PSObject(new {
                 compiled.Sql,
-                Parameters = BuildParameterMap(compiled.Parameters),
+                Parameters = BuildParameterMap(compiled.Parameters, Dialect),
                 ParameterValues = compiled.Parameters.ToArray()
             }));
         } else if (Compile) {
@@ -242,7 +242,7 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
         }
 
         query.InsertOrUpdate(TableName, pairs.Select(pair => (pair.Column, Value: pair.Value!)), ConflictColumns);
-        if (UpsertUpdateOnly is { Length: > 0 }) {
+        if (UpsertUpdateOnly is not null) {
             query.UpsertUpdateOnly(UpsertUpdateOnly);
         }
     }
@@ -303,7 +303,7 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
         var hasSet = Set != null;
         var hasWhere = Where != null;
         var hasConflictColumns = ConflictColumns is { Length: > 0 };
-        var hasUpsertUpdateOnly = UpsertUpdateOnly is { Length: > 0 };
+        var hasUpsertUpdateOnly = UpsertUpdateOnly is not null;
         var hasPagingOrOrdering = Limit.HasValue || Offset.HasValue || OrderBy is { Length: > 0 } || OrderByDescending is { Length: > 0 };
 
         if (Action != DbaXQueryAction.Select && hasPagingOrOrdering) {
@@ -339,10 +339,13 @@ public sealed class CmdletNewDbaXQuery : PSCmdlet {
         }
     }
 
-    private static OrderedDictionary BuildParameterMap(IReadOnlyList<object> parameters) {
+    private static OrderedDictionary BuildParameterMap(
+        IReadOnlyList<object> parameters,
+        SqlDialect dialect) {
         var map = new OrderedDictionary();
+        var prefix = dialect == SqlDialect.Oracle ? ":p" : "@p";
         for (var i = 0; i < parameters.Count; i++) {
-            map.Add("@p" + i, parameters[i]);
+            map.Add(prefix + i, parameters[i]);
         }
 
         return map;

--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -290,7 +290,10 @@ public partial class SQLite : DatabaseClientBase
             return busyTimeoutMs;
         }
 
-        var builder = new SqliteConnectionStringBuilder(connectionString);
+        var builder = new DbConnectionStringBuilder
+        {
+            ConnectionString = connectionString
+        };
         return builder.ContainsKey("Default Timeout") ? 0 : null;
     }
 

--- a/DbaClientX.SQLite/SQLite.cs
+++ b/DbaClientX.SQLite/SQLite.cs
@@ -294,7 +294,10 @@ public partial class SQLite : DatabaseClientBase
         {
             ConnectionString = connectionString
         };
-        return builder.ContainsKey("Default Timeout") ? 0 : null;
+        return builder.ContainsKey("Default Timeout") ||
+               builder.ContainsKey("Command Timeout")
+            ? 0
+            : null;
     }
 
     private void ApplyBusyTimeout(SqliteConnection connection, int? busyTimeoutMs = null)

--- a/DbaClientX.Tests/DbInvokerContractTests.cs
+++ b/DbaClientX.Tests/DbInvokerContractTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Text.RegularExpressions;
 using DBAClientX.Invoker;
+using DBAClientX.QueryBuilder;
 
 namespace DbaClientX.Tests;
 
@@ -93,6 +94,79 @@ public sealed class DbInvokerContractTests
         Assert.DoesNotContain("@p", plan.Sql);
         Assert.Equal(":p0", plan.ParameterMap["Id"]);
         Assert.Equal(":p1", plan.ParameterMap["DisplayName"]);
+    }
+
+    [Fact]
+    public void WritePlanBuilder_OracleUpsert_RejectsUnsupportedCapability()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() =>
+            DbaWritePlanBuilder.Build(
+                "oracle",
+                "Inventory",
+                new[] { "Id", "DisplayName" },
+                upsertKeys: new[] { "Id" }));
+
+        Assert.Contains("Oracle upsert", exception.Message);
+    }
+
+    [Fact]
+    public void WritePlanBuilder_ExplicitEmptyUpdateColumns_DoesNotUpdateExistingRows()
+    {
+        var plan = DbaWritePlanBuilder.Build(
+            "postgresql",
+            "public.inventory",
+            new[] { "Id", "DisplayName" },
+            upsertKeys: new[] { "Id" },
+            upsertUpdateColumns: Array.Empty<string>());
+
+        Assert.EndsWith("DO NOTHING", plan.Sql);
+    }
+
+    [Fact]
+    public void WritePlanBuilder_RejectsCaseCollidingLogicalMappings()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            DbaWritePlanBuilder.Build(
+                "sqlite",
+                "Inventory",
+                new[] { "Id", "DisplayName" },
+                new Dictionary<string, string>
+                {
+                    ["Entity.Name"] = "Id",
+                    ["entity.name"] = "DisplayName"
+                }));
+
+        Assert.Equal("logicalToColumnMap", exception.ParamName);
+    }
+
+    [Fact]
+    public void WritePlanBuilder_CachePollution_DoesNotReuseOrdinaryParameterSql()
+    {
+        QueryCompiler.ClearCache();
+        var ordinary = new Query()
+            .InsertOrUpdate(
+                "dbo.Inventory",
+                new[]
+                {
+                    ("Id", (object)1),
+                    ("DisplayName", (object)"Server")
+                },
+                "Id");
+        _ = QueryBuilder.CompileWithParameters(ordinary, SqlDialect.SqlServer);
+
+        var plan = DbaWritePlanBuilder.Build(
+            "sqlserver",
+            "dbo.Inventory",
+            new[] { "Id", "DisplayName" },
+            upsertKeys: new[] { "Id" });
+
+        string[] placeholders = Regex.Matches(plan.Sql, @"@p\d+")
+            .Select(static match => match.Value)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        Assert.Equal(new[] { "@p0", "@p1" }, placeholders);
+        Assert.Equal(placeholders, plan.ParameterMap.Values.OrderBy(static value => value).ToArray());
     }
 
     [Fact]

--- a/DbaClientX.Tests/DbInvokerContractTests.cs
+++ b/DbaClientX.Tests/DbInvokerContractTests.cs
@@ -172,6 +172,59 @@ public sealed class DbInvokerContractTests
         Assert.Contains("DispalyName", exception.Message);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WritePlanBuilder_RejectsBlankLogicalMappings(bool blankLogicalName)
+    {
+        var mapping = blankLogicalName
+            ? new Dictionary<string, string> { [" "] = "DisplayName" }
+            : new Dictionary<string, string> { ["Entity.Name"] = " " };
+
+        var exception = Assert.Throws<ArgumentException>(() =>
+            DbaWritePlanBuilder.Build(
+                "sqlite",
+                "Inventory",
+                new[] { "Id", "DisplayName" },
+                mapping));
+
+        Assert.Equal("logicalToColumnMap", exception.ParamName);
+    }
+
+    [Fact]
+    public void DiscoverColumns_ExcludesWriteOnlyProperties()
+    {
+        Assert.Equal(
+            new[] { "Id" },
+            DbaWritePlanBuilder.DiscoverColumns(new WriteOnlyPayload { Id = 1 }));
+    }
+
+    [Fact]
+    public void WritePlanBuilder_PreservesParameterLikeDestinationColumnPrefixes()
+    {
+        var plan = DbaWritePlanBuilder.Build(
+            "sqlserver",
+            "dbo.Inventory",
+            new[] { "@AuditValue" });
+
+        Assert.Contains("[@AuditValue]", plan.Sql);
+        Assert.Equal("@p0", plan.ParameterMap["@AuditValue"]);
+        Assert.Equal(new[] { "@AuditValue" }, plan.Columns);
+    }
+
+    [Fact]
+    public void WritePlanBuilder_MySqlUpsert_RejectsAmbiguousConflictTargets()
+    {
+        var exception = Assert.Throws<NotSupportedException>(() =>
+            DbaWritePlanBuilder.Build(
+                "mysql",
+                "Inventory",
+                new[] { "Id", "Email", "DisplayName" },
+                upsertKeys: new[] { "Id" }));
+
+        Assert.Contains("only conflict target", exception.Message);
+    }
+
     [Fact]
     public void WritePlanBuilder_CachePollution_DoesNotReuseOrdinaryParameterSql()
     {
@@ -276,6 +329,16 @@ public sealed class DbInvokerContractTests
         public bool TryGetValue(string key, out T value) => _values.TryGetValue(key, out value!);
 
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    private sealed class WriteOnlyPayload
+    {
+        public int Id { get; set; }
+
+        public string? WriteOnly
+        {
+            set { }
+        }
     }
 }
 

--- a/DbaClientX.Tests/DbInvokerContractTests.cs
+++ b/DbaClientX.Tests/DbInvokerContractTests.cs
@@ -59,6 +59,22 @@ public sealed class DbInvokerContractTests
     }
 
     [Fact]
+    public void WritePlanBuilder_CanonicalizesUpsertColumnCasing()
+    {
+        var plan = DbaWritePlanBuilder.Build(
+            "postgresql",
+            "public.inventory",
+            new[] { "id", "display_name" },
+            upsertKeys: new[] { "ID" },
+            upsertUpdateColumns: new[] { "DISPLAY_NAME" });
+
+        Assert.Contains("ON CONFLICT (\"id\")", plan.Sql);
+        Assert.Contains("\"display_name\" = EXCLUDED.\"display_name\"", plan.Sql);
+        Assert.DoesNotContain("\"ID\"", plan.Sql);
+        Assert.DoesNotContain("\"DISPLAY_NAME\"", plan.Sql);
+    }
+
+    [Fact]
     public void WritePlanBuilder_SqlServerUpsert_BindsEveryGeneratedPlaceholder()
     {
         var plan = DbaWritePlanBuilder.Build(
@@ -137,6 +153,23 @@ public sealed class DbInvokerContractTests
                 }));
 
         Assert.Equal("logicalToColumnMap", exception.ParamName);
+    }
+
+    [Fact]
+    public void WritePlanBuilder_RejectsMappingToUnknownDestinationColumn()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            DbaWritePlanBuilder.Build(
+                "sqlite",
+                "Inventory",
+                new[] { "Id", "DisplayName" },
+                new Dictionary<string, string>
+                {
+                    ["Entity.Name"] = "DispalyName"
+                }));
+
+        Assert.Equal("logicalToColumnMap", exception.ParamName);
+        Assert.Contains("DispalyName", exception.Message);
     }
 
     [Fact]

--- a/DbaClientX.Tests/DbInvokerContractTests.cs
+++ b/DbaClientX.Tests/DbInvokerContractTests.cs
@@ -1,0 +1,176 @@
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Text.RegularExpressions;
+using DBAClientX.Invoker;
+
+namespace DbaClientX.Tests;
+
+public sealed class DbInvokerContractTests
+{
+    [Fact]
+    public void ProviderDescriptor_ExposesCanonicalAssemblyAndExecutor()
+    {
+        var resolved = DbaConnectionFactory.TryGetProvider("mssql", out var provider);
+
+        Assert.True(resolved);
+        Assert.Equal("sqlserver", provider.CanonicalName);
+        Assert.Equal("DbaClientX.SqlServer", provider.AssemblyName);
+        Assert.Equal(
+            "DBAClientX.SqlServerGeneric.GenericExecutors",
+            provider.GenericExecutorTypeName);
+    }
+
+    [Fact]
+    public void WritePlanBuilder_Upsert_CompilesDialectAndMapsLogicalMembers()
+    {
+        var plan = DbaWritePlanBuilder.Build(
+            "pgsql",
+            "public.inventory",
+            new[] { "Id", "DisplayName", "UpdatedUtc" },
+            new Dictionary<string, string>
+            {
+                ["Entity.Identifier"] = "@Id",
+                ["Entity.Name"] = ":DisplayName"
+            },
+            upsertKeys: new[] { "Id" },
+            upsertUpdateColumns: new[] { "DisplayName", "UpdatedUtc" });
+
+        Assert.Contains("INSERT INTO", plan.Sql);
+        Assert.Contains("ON CONFLICT", plan.Sql);
+        Assert.Equal("@p0", plan.ParameterMap["Entity.Identifier"]);
+        Assert.Equal("@p1", plan.ParameterMap["Entity.Name"]);
+        Assert.Equal("@p2", plan.ParameterMap["UpdatedUtc"]);
+        Assert.Equal(new[] { "Id", "DisplayName", "UpdatedUtc" }, plan.Columns);
+    }
+
+    [Fact]
+    public void WritePlanBuilder_UnknownUpdateColumn_RejectsInvalidPlan()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            DbaWritePlanBuilder.Build(
+                "sqlite",
+                "Inventory",
+                new[] { "Id", "DisplayName" },
+                upsertKeys: new[] { "Id" },
+                upsertUpdateColumns: new[] { "Missing" }));
+
+        Assert.Equal("upsertUpdateColumns", exception.ParamName);
+    }
+
+    [Fact]
+    public void WritePlanBuilder_SqlServerUpsert_BindsEveryGeneratedPlaceholder()
+    {
+        var plan = DbaWritePlanBuilder.Build(
+            "sqlserver",
+            "dbo.Inventory",
+            new[] { "Id", "DisplayName", "UpdatedUtc" },
+            upsertKeys: new[] { "Id" });
+
+        string[] placeholders = Regex.Matches(plan.Sql, @"@p\d+")
+            .Select(static match => match.Value)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        string[] mapped = plan.ParameterMap.Values
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static value => value, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        Assert.Equal(mapped, placeholders);
+        Assert.True(Regex.Matches(plan.Sql, "@p0").Count > 1);
+    }
+
+    [Fact]
+    public void WritePlanBuilder_OracleInsert_UsesOracleBindVariables()
+    {
+        var plan = DbaWritePlanBuilder.Build(
+            "oracle",
+            "Inventory",
+            new[] { "Id", "DisplayName" });
+
+        Assert.Contains(":p0", plan.Sql);
+        Assert.Contains(":p1", plan.Sql);
+        Assert.DoesNotContain("@p", plan.Sql);
+        Assert.Equal(":p0", plan.ParameterMap["Id"]);
+        Assert.Equal(":p1", plan.ParameterMap["DisplayName"]);
+    }
+
+    [Fact]
+    public void DiscoverColumns_StringDictionaries_UsesPayloadKeys()
+    {
+        var dictionary = new Dictionary<string, object?>
+        {
+            ["Id"] = 1,
+            ["DisplayName"] = "Server"
+        };
+        dynamic expando = new ExpandoObject();
+        expando.Id = 2;
+        expando.UpdatedUtc = DateTime.UtcNow;
+        var genericOnly = new GenericOnlyStringDictionary<int>(
+            new Dictionary<string, int>
+            {
+                ["Id"] = 3,
+                ["Port"] = 1433
+            });
+
+        Assert.Equal(new[] { "Id", "DisplayName" }, DbaWritePlanBuilder.DiscoverColumns(dictionary));
+        Assert.Equal(new[] { "Id", "UpdatedUtc" }, DbaWritePlanBuilder.DiscoverColumns(expando));
+        Assert.Equal(new[] { "Id", "Port" }, DbaWritePlanBuilder.DiscoverColumns(genericOnly));
+    }
+
+    [Fact]
+    public void WritePlanBuilder_UpdateColumnsWithoutKeys_RejectsIgnoredConfiguration()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            DbaWritePlanBuilder.Build(
+                "sqlite",
+                "Inventory",
+                new[] { "Id", "DisplayName" },
+                upsertUpdateColumns: new[] { "DisplayName" }));
+
+        Assert.Equal("upsertUpdateColumns", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task ExecuteParametersAsync_UndefinedKind_RejectsInvocation()
+    {
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            DbInvoker.ExecuteParametersAsync(
+                "sqlserver",
+                "Server=.;Database=app;",
+                (DbaInvocationKind)42,
+                "SELECT 1",
+                new Dictionary<string, object?>()));
+
+        Assert.Equal("kind", exception.ParamName);
+    }
+
+    private sealed class GenericOnlyStringDictionary<T> : IReadOnlyDictionary<string, T>
+    {
+        private readonly IReadOnlyDictionary<string, T> _values;
+
+        public GenericOnlyStringDictionary(IReadOnlyDictionary<string, T> values)
+        {
+            _values = values;
+        }
+
+        public T this[string key] => _values[key];
+
+        public IEnumerable<string> Keys => _values.Keys;
+
+        public IEnumerable<T> Values => _values.Values;
+
+        public int Count => _values.Count;
+
+        public bool ContainsKey(string key) => _values.ContainsKey(key);
+
+        public IEnumerator<KeyValuePair<string, T>> GetEnumerator() => _values.GetEnumerator();
+
+        public bool TryGetValue(string key, out T value) => _values.TryGetValue(key, out value!);
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}
+
+[CollectionDefinition("DbInvoker serial", DisableParallelization = true)]
+public sealed class DbInvokerSerialCollection;

--- a/DbaClientX.Tests/DbInvokerTests.cs
+++ b/DbaClientX.Tests/DbInvokerTests.cs
@@ -12,6 +12,7 @@ using DBAClientX.Invoker;
 
 namespace DbaClientX.Tests
 {
+    [Collection("DbInvoker serial")]
     public class DbInvokerTests
     {
         [Fact]
@@ -320,6 +321,55 @@ namespace DbaClientX.Tests
                     providerAssembly: dynamicType!.Assembly));
 
             Assert.Equal("executor failed", exception.Message);
+        }
+
+        [Fact]
+        public async Task ExecuteSqlWithResultAsync_AllItemsComplete_ReturnsTruthfulCounts()
+        {
+            DBAClientX.SqlServerGeneric.GenericExecutors.Reset();
+            var items = new object[]
+            {
+                new { Id = 1 },
+                new { Id = 2 }
+            };
+
+            var result = await DbInvoker.ExecuteSqlWithResultAsync(
+                "mssql",
+                "Server=.;Database=app;",
+                "UPDATE dbo.Items SET Value = 1 WHERE Id = @Id",
+                items,
+                new Dictionary<string, string> { ["Id"] = "@Id" },
+                providerAssembly: typeof(DBAClientX.SqlServerGeneric.GenericExecutors).Assembly);
+
+            Assert.Equal("sqlserver", result.Provider);
+            Assert.Equal(DbaInvocationKind.Sql, result.Kind);
+            Assert.Equal(2, result.CompletedExecutions);
+            Assert.Equal(2, result.AffectedRows);
+        }
+
+        [Fact]
+        public async Task ExecuteParametersAsync_ProviderCompletes_ReturnsOneCompletedExecution()
+        {
+            DBAClientX.SqlServerGeneric.GenericExecutors.Reset();
+            var parameters = new Dictionary<string, object?>
+            {
+                ["@Payload"] = "[]"
+            };
+
+            var result = await DbInvoker.ExecuteParametersAsync(
+                "sqlserver",
+                "Server=.;Database=app;",
+                DbaInvocationKind.Sql,
+                "INSERT INTO dbo.Payloads (Payload) VALUES (@Payload)",
+                parameters,
+                providerAssembly: typeof(DBAClientX.SqlServerGeneric.GenericExecutors).Assembly);
+
+            Assert.Equal(1, result.CompletedExecutions);
+            Assert.Equal(1, result.AffectedRows);
+            Assert.Contains(
+                DBAClientX.SqlServerGeneric.GenericExecutors.Calls,
+                call => call.Sql.Contains("dbo.Payloads", StringComparison.Ordinal)
+                        && Equals("[]", call.Parameters["@Payload"]));
         }
     }
 }

--- a/DbaClientX.Tests/QueryBuilderTests.cs
+++ b/DbaClientX.Tests/QueryBuilderTests.cs
@@ -925,7 +925,7 @@ public class QueryBuilderTests
     {
         var query = new Query().From("users").Select("id").Where("name", "Alice");
         var (sql, parameters) = QueryBuilder.CompileWithParameters(query, SqlDialect.Oracle);
-        Assert.Equal("SELECT \"id\" FROM \"users\" WHERE \"name\" = @p0", sql);
+        Assert.Equal("SELECT \"id\" FROM \"users\" WHERE \"name\" = :p0", sql);
         Assert.Single(parameters);
         Assert.Equal("Alice", parameters[0]);
     }

--- a/DbaClientX.Tests/QueryBuilderUpsertEdgeTests.cs
+++ b/DbaClientX.Tests/QueryBuilderUpsertEdgeTests.cs
@@ -71,4 +71,21 @@ public class QueryBuilderUpsertEdgeTests
 
         Assert.EndsWith("DO NOTHING", sql);
     }
+
+    [Fact]
+    public void UpsertUpdateOnly_EmptyList_MySqlRejectsUnsupportedInsertIfMissingContract()
+    {
+        var query = new Query()
+            .InsertOrUpdate(
+                "users",
+                new[] { ("id", (object)1), ("name", (object)"Bob") },
+                "id")
+            .UpsertUpdateOnly();
+
+        var exception = Assert.Throws<NotSupportedException>(() =>
+            QueryBuilder.Compile(query, SqlDialect.MySql));
+
+        Assert.Contains("MySQL", exception.Message);
+        Assert.Contains("insert-if-missing", exception.Message);
+    }
 }

--- a/DbaClientX.Tests/QueryBuilderUpsertEdgeTests.cs
+++ b/DbaClientX.Tests/QueryBuilderUpsertEdgeTests.cs
@@ -56,4 +56,19 @@ public class QueryBuilderUpsertEdgeTests
         Assert.EndsWith("DO UPDATE SET \"name\" = EXCLUDED.\"name\"", sql1);
         Assert.DoesNotContain("DO UPDATE SET", sql2);
     }
+
+    [Fact]
+    public void UpsertUpdateOnly_EmptyList_RequestsInsertIfMissing()
+    {
+        var query = new Query()
+            .InsertOrUpdate(
+                "users",
+                new[] { ("id", (object)1), ("name", (object)"Bob") },
+                "id")
+            .UpsertUpdateOnly();
+
+        var sql = QueryBuilder.Compile(query, SqlDialect.PostgreSql);
+
+        Assert.EndsWith("DO NOTHING", sql);
+    }
 }

--- a/DbaClientX.Tests/SQLiteSessionTests.cs
+++ b/DbaClientX.Tests/SQLiteSessionTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.IO;
+using System.Threading.Tasks;
 using DBAClientX;
 
 namespace DbaClientX.Tests;
@@ -25,6 +27,46 @@ public class SQLiteSessionTests
             Assert.Equal(4321L, ReadPragma(connection, "busy_timeout"));
             Assert.Equal(1L, ReadPragma(connection, "foreign_keys"));
             Assert.Equal("wal", ReadPragma(connection, "journal_mode"));
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    [Fact]
+    public void OpenSession_AppliesConfiguredBusyTimeout()
+    {
+        string path = Path.Join(Path.GetTempPath(), Path.GetFileName($"{Guid.NewGuid():N}.db"));
+        try
+        {
+            using var sqlite = new SQLite { BusyTimeoutMs = 7500 };
+            using SQLiteSession session = sqlite.OpenSession(path);
+
+            Assert.Equal(7500L, Convert.ToInt64(session.ExecuteScalar("PRAGMA busy_timeout;")));
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    [Fact]
+    public async Task QueryAsync_AppliesConfiguredBusyTimeout()
+    {
+        string path = Path.Join(Path.GetTempPath(), Path.GetFileName($"{Guid.NewGuid():N}.db"));
+        try
+        {
+            using var sqlite = new SQLite
+            {
+                BusyTimeoutMs = 7500,
+                ReturnType = ReturnType.DataTable
+            };
+
+            object? result = await sqlite.QueryAsync(path, "PRAGMA busy_timeout;");
+            DataTable table = Assert.IsType<DataTable>(result);
+
+            Assert.Equal(7500L, Convert.ToInt64(table.Rows[0][0]));
         }
         finally
         {

--- a/DbaClientX.Tests/SQLiteSessionTests.cs
+++ b/DbaClientX.Tests/SQLiteSessionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using DBAClientX;
 
@@ -72,6 +73,20 @@ public class SQLiteSessionTests
         {
             Cleanup(path);
         }
+    }
+
+    [Fact]
+    public void ResolveConnectionBusyTimeout_PreservesExplicitCommandTimeoutAlias()
+    {
+        MethodInfo method = typeof(SQLite).GetMethod(
+            "ResolveConnectionBusyTimeout",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        object? result = method.Invoke(
+            null,
+            new object?[] { "Data Source=app.db;Command Timeout=9", null });
+
+        Assert.Equal(0, Assert.IsType<int>(result));
     }
 
     [Fact]

--- a/Module/Tests/CmdletNewDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletNewDbaXQuery.Tests.ps1
@@ -58,6 +58,14 @@ Describe 'New-DbaXQuery builder' {
         $compiled.ParameterValues | Should -Be @('Ada', 1)
     }
 
+    It 'Returns Oracle bind names in the parameter map' {
+        $compiled = New-DbaXQuery -Action Insert -Dialect Oracle -TableName users -Values ([ordered]@{ id = 1; name = 'Ada' }) -CompileWithParameters
+        $compiled.Sql | Should -Be 'INSERT INTO "users" ("id", "name") VALUES (:p0, :p1)'
+        $compiled.Parameters[':p0'] | Should -Be 1
+        $compiled.Parameters[':p1'] | Should -Be 'Ada'
+        $compiled.Parameters.Contains('@p0') | Should -BeFalse
+    }
+
     It 'Requires Values for INSERT' {
         { New-DbaXQuery -Action Insert -TableName users -Compile } | Should -Throw
     }


### PR DESCRIPTION
## What changed

- adds typed write plans and structured invocation results for insert, update, upsert, and delete operations
- centralizes provider-specific write compilation, including Oracle parameter syntax and stable SQL Server upsert bindings
- supports POCOs, dictionaries, ExpandoObject values, and generic-only string-key dictionaries without consumer-side reflection
- rejects incomplete update plans and undefined invocation modes instead of silently choosing unsafe behavior

## Why

Consumers such as TestimoX need one DbaClientX-owned write contract that reports what was requested, affected-row counts, generated SQL, and parameters. This removes consumer-local provider logic and prevents successful-looking no-op exports.

## Compatibility

The existing provider descriptor constructor and deconstruction shape remain available. The new APIs are additive; invalid invocation modes and update-only plans without key columns now fail explicitly.

## Validation

- focused invoker/query tests on .NET 8 and .NET 10: 191 passed on each target
- full solution build: zero warnings and zero errors
- NuGet vulnerability audit: no vulnerable direct or transitive packages