### PR TITLE
Expose deferred SQLite transactions

### DIFF
--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX SQLite provider</Description>
     <AssemblyName>DbaClientX.SQLite</AssemblyName>
     <AssemblyTitle>DbaClientX.SQLite</AssemblyTitle>
-    <VersionPrefix>0.12.0</VersionPrefix>
+    <VersionPrefix>0.13.0</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.SQLite/SQLite.ManagedConnection.cs
+++ b/DbaClientX.SQLite/SQLite.ManagedConnection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Data;
 using System.Data.Common;
 using Microsoft.Data.Sqlite;
 
@@ -29,6 +30,42 @@ public partial class SQLite
             connection.Dispose();
             throw;
         }
+    }
+
+    /// <summary>Begins a provider-managed transaction on a connection opened by <see cref="OpenDbConnection"/>.</summary>
+    /// <param name="connection">The open managed SQLite connection.</param>
+    /// <param name="mode">Whether SQLite should acquire write intent immediately or defer until commands require it.</param>
+    /// <returns>The provider-neutral transaction owned by the caller.</returns>
+    /// <remarks>
+    /// Use <see cref="SQLiteTransactionMode.Deferred"/> for consistent read snapshots that must not reserve
+    /// the writer slot before their first command. Commands must set their <see cref="DbCommand.Transaction"/>
+    /// property to the returned transaction.
+    /// </remarks>
+    public virtual DbTransaction BeginDbTransaction(
+        DbConnection connection,
+        SQLiteTransactionMode mode = SQLiteTransactionMode.Immediate)
+    {
+        if (connection is null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+        if (connection is not SqliteConnection sqliteConnection)
+        {
+            throw new ArgumentException(
+                "The connection must be a managed Microsoft.Data.Sqlite connection.",
+                nameof(connection));
+        }
+        if (sqliteConnection.State != ConnectionState.Open)
+        {
+            throw new InvalidOperationException("The SQLite connection must be open before beginning a transaction.");
+        }
+
+        return mode switch
+        {
+            SQLiteTransactionMode.Immediate => sqliteConnection.BeginTransaction(),
+            SQLiteTransactionMode.Deferred => sqliteConnection.BeginTransaction(deferred: true),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unsupported SQLite transaction mode.")
+        };
     }
 
     private void ApplyManagedConnectionOptions(SqliteConnection connection, SQLiteConnectionOptions options)

--- a/DbaClientX.SQLite/SQLiteTransactionMode.cs
+++ b/DbaClientX.SQLite/SQLiteTransactionMode.cs
@@ -1,0 +1,11 @@
+namespace DBAClientX;
+
+/// <summary>Controls when a managed SQLite transaction acquires its database transaction.</summary>
+public enum SQLiteTransactionMode
+{
+    /// <summary>Starts the transaction immediately and reserves write intent.</summary>
+    Immediate,
+
+    /// <summary>Defers the database transaction until the first command and permits read snapshots alongside writers.</summary>
+    Deferred
+}

--- a/DbaClientX.Tests/SQLiteSessionTests.cs
+++ b/DbaClientX.Tests/SQLiteSessionTests.cs
@@ -36,6 +36,45 @@ public class SQLiteSessionTests
     }
 
     [Fact]
+    public void BeginDbTransaction_DeferredSnapshotAllowsConcurrentWriter()
+    {
+        string path = Path.Join(Path.GetTempPath(), Path.GetFileName($"{Guid.NewGuid():N}.db"));
+        try
+        {
+            using var sqlite = new SQLite();
+            sqlite.ExecuteNonQuery(path, "CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT NOT NULL);");
+            sqlite.ExecuteNonQuery(path, "INSERT INTO items (name) VALUES ('before');");
+            var options = new SQLiteConnectionOptions
+            {
+                BusyTimeoutMs = 250,
+                EnableWriteAheadLogging = true
+            };
+            using DbConnection reader = sqlite.OpenDbConnection(path, options);
+            using DbConnection writer = sqlite.OpenDbConnection(path, options);
+            using DbTransaction snapshot = sqlite.BeginDbTransaction(reader, SQLiteTransactionMode.Deferred);
+
+            Assert.Equal(1L, ReadCount(reader, snapshot));
+
+            using (DbTransaction write = sqlite.BeginDbTransaction(writer))
+            {
+                using DbCommand insert = writer.CreateCommand();
+                insert.Transaction = write;
+                insert.CommandText = "INSERT INTO items (name) VALUES ('during-snapshot');";
+                Assert.Equal(1, insert.ExecuteNonQuery());
+                write.Commit();
+            }
+
+            Assert.Equal(1L, ReadCount(reader, snapshot));
+            snapshot.Commit();
+            Assert.Equal(2L, ReadCount(reader, transaction: null));
+        }
+        finally
+        {
+            Cleanup(path);
+        }
+    }
+
+    [Fact]
     public void OpenSession_AppliesConfiguredBusyTimeout()
     {
         string path = Path.Join(Path.GetTempPath(), Path.GetFileName($"{Guid.NewGuid():N}.db"));
@@ -157,6 +196,14 @@ public class SQLiteSessionTests
         using DbCommand command = connection.CreateCommand();
         command.CommandText = $"PRAGMA {name};";
         return command.ExecuteScalar()!;
+    }
+
+    private static long ReadCount(DbConnection connection, DbTransaction? transaction)
+    {
+        using DbCommand command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "SELECT COUNT(*) FROM items;";
+        return Convert.ToInt64(command.ExecuteScalar());
     }
 
     private static void TryDelete(string path)


### PR DESCRIPTION
## Summary

- expose `SQLiteTransactionMode` and `BeginDbTransaction` for provider-managed connections
- support deferred SQLite transactions without requiring consumers to reference `Microsoft.Data.Sqlite`
- advance `DbaClientX.SQLite` to `0.13.0`

## Consumer impact

Managed-connection consumers can now request `SQLiteTransactionMode.Deferred` for consistent read snapshots that must coexist with writers. Immediate mode remains the default, so existing callers keep their current transaction behavior.