### PR TITLE
Use PowerForge native documentation

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -32,7 +32,7 @@ jobs:
             - name: Setup PowerShell modules
               shell: pwsh
               run: |
-                  Install-Module PSPublishModule -MinimumVersion 3.0.55 -Force -Scope CurrentUser -AllowClobber
+                  Install-Module PSPublishModule -MinimumVersion 3.0.88 -Force -Scope CurrentUser -AllowClobber
 
             - name: Refresh DbaClientX module manifest
               shell: pwsh
@@ -165,7 +165,7 @@ jobs:
                       Register-PSRepository -Default
                   }
                   Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-                  Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.55 -Force -SkipPublisherCheck -AllowClobber
+                  Install-Module -Name PSPublishModule -Repository PSGallery -MinimumVersion 3.0.88 -Force -SkipPublisherCheck -AllowClobber
                   Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
                   Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
 

--- a/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
+++ b/DbaClientX.PowerShell/DbaClientX.PowerShell.csproj
@@ -78,17 +78,6 @@
 	</Target>
 
         <PropertyGroup>
-                <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
                 <GenerateDocumentationFile>true</GenerateDocumentationFile>
-                <!-- Fail the build if documentation is missing. -->
-                <XmlDoc2CmdletDocArguments>-strict</XmlDoc2CmdletDocArguments>
         </PropertyGroup>
-
-	<ItemGroup>
-		<!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
-                <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
     <PackageVersion Include="Azure.Data.Tables" Version="12.11.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.8.0" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />

--- a/FabricClientX.PowerShell/FabricClientX.PowerShell.csproj
+++ b/FabricClientX.PowerShell/FabricClientX.PowerShell.csproj
@@ -56,15 +56,7 @@
   <PropertyGroup>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <XmlDoc2CmdletDocArguments>-strict</XmlDoc2CmdletDocArguments>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 
   <Target Name="RemoveFilesAfterBuild" AfterTargets="Build">
     <Delete Files="$(OutDir)System.Management.Automation.dll" />

--- a/Module-FabricClientX/Build/Build-Module.ps1
+++ b/Module-FabricClientX/Build/Build-Module.ps1
@@ -10,7 +10,7 @@ param(
     [string] $GitHubApiKeyPath = 'C:\Support\Important\GitHubAPI.txt'
 )
 
-Import-Module PSPublishModule -MinimumVersion 3.0.55 -Force -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.88 -Force -ErrorAction Stop
 
 Build-Module -ModuleName 'FabricClientX' -NoInteractive {
     $manifest = @{
@@ -29,7 +29,7 @@ Build-Module -ModuleName 'FabricClientX' -NoInteractive {
 
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'DefaultPSM1' -EnableFormatting -Sort None
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
-    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable -PathReadme 'Docs\Readme.md' -Path 'Docs' -SyncExternalHelpToProjectRoot
 
     $build = @{
         Enable                               = $true

--- a/Module-FabricClientX/Docs/Get-FabricXItem.md
+++ b/Module-FabricClientX/Docs/Get-FabricXItem.md
@@ -1,0 +1,108 @@
+---
+external help file: FabricClientX-help.xml
+Module Name: FabricClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Get-FabricXItem
+## SYNOPSIS
+Gets items from a Microsoft Fabric workspace.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-FabricXItem [-WorkspaceId] <guid> -TokenProvider <IFabricTokenProvider> [-Type <string>] [-OperationId <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets items from a Microsoft Fabric workspace.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-FabricXItem -TokenProvider $provider -WorkspaceId $workspaceId -Type SemanticModel
+```
+
+Uses the Fabric Core Items API and follows all continuation pages.
+
+## PARAMETERS
+
+### -OperationId
+Optional non-zero W3C trace identifier used to correlate the request.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TokenProvider
+Caller-owned token provider configured for the Fabric API scope.
+
+```yaml
+Type: IFabricTokenProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+Optional Fabric item type, such as SemanticModel or Warehouse.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkspaceId
+Workspace identifier.
+
+```yaml
+Type: Guid
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `FabricClientX.FabricItem`
+
+## RELATED LINKS
+
+- None

--- a/Module-FabricClientX/Docs/Get-FabricXPowerBISemanticModel.md
+++ b/Module-FabricClientX/Docs/Get-FabricXPowerBISemanticModel.md
@@ -1,0 +1,92 @@
+---
+external help file: FabricClientX-help.xml
+Module Name: FabricClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Get-FabricXPowerBISemanticModel
+## SYNOPSIS
+Gets Power BI semantic models in a workspace.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-FabricXPowerBISemanticModel [-WorkspaceId] <guid> -TokenProvider <IFabricTokenProvider> [-OperationId <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets Power BI semantic models in a workspace.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-FabricXPowerBISemanticModel -TokenProvider $powerBiProvider -WorkspaceId $workspaceId | Where-Object IsRefreshable
+```
+
+Returns typed semantic models with a stable OperationId property.
+
+## PARAMETERS
+
+### -OperationId
+Optional non-zero W3C trace identifier used to correlate the request.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TokenProvider
+Caller-owned token provider configured for the Power BI API scope.
+
+```yaml
+Type: IFabricTokenProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkspaceId
+Power BI workspace identifier.
+
+```yaml
+Type: Guid
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `FabricClientX.PowerBI.PowerBiSemanticModel`
+
+## RELATED LINKS
+
+- None

--- a/Module-FabricClientX/Docs/Get-FabricXWorkspace.md
+++ b/Module-FabricClientX/Docs/Get-FabricXWorkspace.md
@@ -1,0 +1,108 @@
+---
+external help file: FabricClientX-help.xml
+Module Name: FabricClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Get-FabricXWorkspace
+## SYNOPSIS
+Gets Microsoft Fabric workspaces visible to the authenticated principal.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-FabricXWorkspace -TokenProvider <IFabricTokenProvider> [-Role <string[]>] [-PreferWorkspaceSpecificEndpoint] [-OperationId <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets Microsoft Fabric workspaces visible to the authenticated principal.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-FabricXWorkspace -TokenProvider $provider
+```
+
+Returns workspace objects with a stable OperationId property.
+
+## PARAMETERS
+
+### -OperationId
+Optional non-zero W3C trace identifier used to correlate the request.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreferWorkspaceSpecificEndpoint
+Includes workspace-specific endpoints when the service supports them.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Role
+Optional workspace roles such as Admin, Member, Contributor, or Viewer.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TokenProvider
+Caller-owned token provider configured for the Fabric API scope.
+
+```yaml
+Type: IFabricTokenProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `FabricClientX.FabricWorkspace`
+
+## RELATED LINKS
+
+- None

--- a/Module-FabricClientX/Docs/Invoke-FabricXCsvWorkflow.md
+++ b/Module-FabricClientX/Docs/Invoke-FabricXCsvWorkflow.md
@@ -1,0 +1,300 @@
+---
+external help file: FabricClientX-help.xml
+Module Name: FabricClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-FabricXCsvWorkflow
+## SYNOPSIS
+Plans and executes an OfficeIMO CSV to Fabric Warehouse and optional Power BI workflow.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-FabricXCsvWorkflow [-CsvPath] <string> -SourceName <string> -WarehouseConnectionString <string> -WarehouseConnectionOptions <SqlServerConnectionOptions> -DestinationTable <string> [-CsvLoadOptions <CsvLoadOptions>] [-CsvReaderOptions <CsvDataReaderOptions>] [-BatchSize <Int32>] [-BulkCopyTimeout <Int32>] [-Refresh] [-PowerBiTokenProvider <IFabricTokenProvider>] [-WorkspaceId <Guid>] [-SemanticModelId <Guid>] [-Wait] [-TimeoutMinutes <int>] [-OperationId <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Plans and executes an OfficeIMO CSV to Fabric Warehouse and optional Power BI workflow.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Invoke-FabricXCsvWorkflow -CsvPath .\sales.csv -SourceName Sales -WarehouseConnectionString $warehouse -WarehouseConnectionOptions $warehouseOptions -DestinationTable dbo.Sales -Refresh -PowerBiTokenProvider $powerBiProvider -WorkspaceId $workspaceId -SemanticModelId $modelId -Wait
+```
+
+Creates a redacted plan before performing the confirmed Warehouse write and refresh.
+
+## PARAMETERS
+
+### -BatchSize
+Optional SQL bulk-copy batch size.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BulkCopyTimeout
+Optional SQL bulk-copy timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CsvLoadOptions
+Optional OfficeIMO CSV parsing options.
+
+```yaml
+Type: CsvLoadOptions
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CsvPath
+Path to an OfficeIMO-compatible CSV file.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CsvReaderOptions
+Optional OfficeIMO CSV data-reader projection options.
+
+```yaml
+Type: CsvDataReaderOptions
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationTable
+Warehouse destination table.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OperationId
+Optional non-zero W3C trace identifier used across all workflow stages.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PowerBiTokenProvider
+Caller-owned token provider configured for the Power BI API scope.
+
+```yaml
+Type: IFabricTokenProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Refresh
+Requests a Power BI semantic-model refresh after successful ingestion.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SemanticModelId
+Power BI semantic-model identifier used when Refresh is selected.
+
+```yaml
+Type: Guid
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceName
+Logical source name used in the redacted plan.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TimeoutMinutes
+Maximum refresh settlement wait in minutes.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Wait
+Waits for the requested refresh to settle.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WarehouseConnectionOptions
+Caller-owned Fabric Warehouse connection and authentication options.
+
+```yaml
+Type: SqlServerConnectionOptions
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WarehouseConnectionString
+Fabric Warehouse connection string without embedded credentials.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkspaceId
+Power BI workspace identifier used when Refresh is selected.
+
+```yaml
+Type: Guid
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `FabricClientX.OfficeIMO.CsvFabricWorkflowResult`
+
+## RELATED LINKS
+
+- None

--- a/Module-FabricClientX/Docs/Invoke-FabricXPowerBIRefresh.md
+++ b/Module-FabricClientX/Docs/Invoke-FabricXPowerBIRefresh.md
@@ -1,0 +1,189 @@
+---
+external help file: FabricClientX-help.xml
+Module Name: FabricClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-FabricXPowerBIRefresh
+## SYNOPSIS
+Requests a Power BI semantic-model refresh and optionally waits for settlement.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-FabricXPowerBIRefresh [-WorkspaceId] <guid> [-SemanticModelId] <guid> -TokenProvider <IFabricTokenProvider> [-Wait] [-TimeoutMinutes <int>] [-PollIntervalSeconds <int>] [-NotifyOption <string>] [-RetryCount <Int32>] [-OperationId <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Requests a Power BI semantic-model refresh and optionally waits for settlement.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Invoke-FabricXPowerBIRefresh -TokenProvider $powerBiProvider -WorkspaceId $workspaceId -SemanticModelId $modelId -Wait -TimeoutMinutes 30
+```
+
+Returns refresh identity, terminal status, and the stable OperationId.
+
+## PARAMETERS
+
+### -NotifyOption
+Power BI notification option. Omit it for service-principal enhanced refreshes.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: NoNotification, MailOnFailure, MailOnCompletion
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OperationId
+Optional non-zero W3C trace identifier used to correlate the request.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PollIntervalSeconds
+Polling interval in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RetryCount
+Optional Power BI service-side retry count.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SemanticModelId
+Semantic-model identifier.
+
+```yaml
+Type: Guid
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TimeoutMinutes
+Maximum settlement wait in minutes.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TokenProvider
+Caller-owned token provider configured for the Power BI API scope.
+
+```yaml
+Type: IFabricTokenProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Wait
+Waits until the refresh reaches a terminal state.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkspaceId
+Power BI workspace identifier.
+
+```yaml
+Type: Guid
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `FabricClientX.PowerBI.PowerBiRefreshStartResult`
+- `FabricClientX.PowerBI.PowerBiRefreshSettlement`
+
+## RELATED LINKS
+
+- None

--- a/Module-FabricClientX/Docs/New-FabricXTokenProvider.md
+++ b/Module-FabricClientX/Docs/New-FabricXTokenProvider.md
@@ -1,0 +1,76 @@
+---
+external help file: FabricClientX-help.xml
+Module Name: FabricClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# New-FabricXTokenProvider
+## SYNOPSIS
+Creates a short-lived FabricClientX token provider from a caller-acquired secure token.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-FabricXTokenProvider [-AccessToken] <securestring> [-ExpiresOn] <DateTimeOffset> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a short-lived FabricClientX token provider from a caller-acquired secure token.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> $azToken = Get-AzAccessToken -ResourceUrl 'https://api.fabric.microsoft.com' -AsSecureString; $provider = New-FabricXTokenProvider -AccessToken $azToken.Token -ExpiresOn $azToken.ExpiresOn
+```
+
+The returned provider can be reused by Fabric discovery cmdlets until the token nears expiry.
+
+## PARAMETERS
+
+### -AccessToken
+Caller-acquired Microsoft Entra access token.
+
+```yaml
+Type: SecureString
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpiresOn
+Token expiry reported by the identity provider.
+
+```yaml
+Type: DateTimeOffset
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `FabricClientX.IFabricTokenProvider`
+
+## RELATED LINKS
+
+- None

--- a/Module-FabricClientX/Docs/New-FabricXWarehouseConnectionOptions.md
+++ b/Module-FabricClientX/Docs/New-FabricXWarehouseConnectionOptions.md
@@ -1,0 +1,76 @@
+---
+external help file: FabricClientX-help.xml
+Module Name: FabricClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# New-FabricXWarehouseConnectionOptions
+## SYNOPSIS
+Creates Fabric Warehouse connection options from a caller-acquired secure SQL token.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-FabricXWarehouseConnectionOptions [-AccessToken] <securestring> [-ExpiresOn] <DateTimeOffset> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates Fabric Warehouse connection options from a caller-acquired secure SQL token.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> $token = Get-AzAccessToken -ResourceUrl 'https://database.windows.net' -AsSecureString; $options = New-FabricXWarehouseConnectionOptions -AccessToken $token.Token -ExpiresOn $token.ExpiresOn
+```
+
+The reusable callback preserves SqlClient pooling while the fixed token remains valid.
+
+## PARAMETERS
+
+### -AccessToken
+Caller-acquired Microsoft Entra token for the Azure SQL resource.
+
+```yaml
+Type: SecureString
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExpiresOn
+Token expiry reported by the identity provider.
+
+```yaml
+Type: DateTimeOffset
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `DBAClientX.SqlServerConnectionOptions`
+
+## RELATED LINKS
+
+- None

--- a/Module-FabricClientX/Docs/Readme.md
+++ b/Module-FabricClientX/Docs/Readme.md
@@ -1,0 +1,35 @@
+---
+Module Name: FabricClientX
+Module Guid: ac8e01db-4199-4b08-a176-a1a6d3d23a88
+Download Help Link: https://github.com/EvotecIT/DbaClientX
+Help Version: 0.1.0
+Locale: en-US
+---
+# FabricClientX Module
+## Description
+Microsoft Fabric and Power BI automation for PowerShell
+
+## FabricClientX Cmdlets
+### [Get-FabricXItem](Get-FabricXItem.md)
+Gets items from a Microsoft Fabric workspace.
+
+### [Get-FabricXPowerBISemanticModel](Get-FabricXPowerBISemanticModel.md)
+Gets Power BI semantic models in a workspace.
+
+### [Get-FabricXWorkspace](Get-FabricXWorkspace.md)
+Gets Microsoft Fabric workspaces visible to the authenticated principal.
+
+### [Invoke-FabricXCsvWorkflow](Invoke-FabricXCsvWorkflow.md)
+Plans and executes an OfficeIMO CSV to Fabric Warehouse and optional Power BI workflow.
+
+### [Invoke-FabricXPowerBIRefresh](Invoke-FabricXPowerBIRefresh.md)
+Requests a Power BI semantic-model refresh and optionally waits for settlement.
+
+### [New-FabricXTokenProvider](New-FabricXTokenProvider.md)
+Creates a short-lived FabricClientX token provider from a caller-acquired secure token.
+
+### [New-FabricXWarehouseConnectionOptions](New-FabricXWarehouseConnectionOptions.md)
+Creates Fabric Warehouse connection options from a caller-acquired secure SQL token.
+
+### [Stop-FabricXPowerBIRefresh](Stop-FabricXPowerBIRefresh.md)
+Cancels an accepted Power BI semantic-model refresh after explicit confirmation.

--- a/Module-FabricClientX/Docs/Stop-FabricXPowerBIRefresh.md
+++ b/Module-FabricClientX/Docs/Stop-FabricXPowerBIRefresh.md
@@ -1,0 +1,76 @@
+---
+external help file: FabricClientX-help.xml
+Module Name: FabricClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Stop-FabricXPowerBIRefresh
+## SYNOPSIS
+Cancels an accepted Power BI semantic-model refresh after explicit confirmation.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Stop-FabricXPowerBIRefresh [-Refresh] <PowerBiRefreshStartResult> -TokenProvider <IFabricTokenProvider> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Cancels an accepted Power BI semantic-model refresh after explicit confirmation.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> $refresh | Stop-FabricXPowerBIRefresh -TokenProvider $powerBiProvider -Confirm
+```
+
+Cancellation is never performed by discovery or settlement commands.
+
+## PARAMETERS
+
+### -Refresh
+Accepted refresh returned by Invoke-FabricXPowerBIRefresh.
+
+```yaml
+Type: PowerBiRefreshStartResult
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -TokenProvider
+Caller-owned token provider configured for the Power BI API scope.
+
+```yaml
+Type: IFabricTokenProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `FabricClientX.PowerBI.PowerBiRefreshStartResult`
+
+## OUTPUTS
+
+- `FabricClientX.FabricResponse`
+
+## RELATED LINKS
+
+- None

--- a/Module-FabricClientX/en-US/FabricClientX-help.xml
+++ b/Module-FabricClientX/en-US/FabricClientX-help.xml
@@ -1,0 +1,1442 @@
+<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-FabricXItem</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>FabricXItem</command:noun>
+      <maml:description>
+        <maml:para>Gets items from a Microsoft Fabric workspace.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Gets items from a Microsoft Fabric workspace.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-FabricXItem</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OperationId</maml:name>
+          <maml:description>
+            <maml:para>Optional non-zero W3C trace identifier used to correlate the request.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TokenProvider</maml:name>
+          <maml:description>
+            <maml:para>Caller-owned token provider configured for the Fabric API scope.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">IFabricTokenProvider</command:parameterValue>
+          <dev:type>
+            <maml:name>IFabricTokenProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Optional Fabric item type, such as SemanticModel or Warehouse.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>WorkspaceId</maml:name>
+          <maml:description>
+            <maml:para>Workspace identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OperationId</maml:name>
+        <maml:description>
+          <maml:para>Optional non-zero W3C trace identifier used to correlate the request.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TokenProvider</maml:name>
+        <maml:description>
+          <maml:para>Caller-owned token provider configured for the Fabric API scope.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">IFabricTokenProvider</command:parameterValue>
+        <dev:type>
+          <maml:name>IFabricTokenProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>Optional Fabric item type, such as SemanticModel or Warehouse.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>WorkspaceId</maml:name>
+        <maml:description>
+          <maml:para>Workspace identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>FabricClientX.FabricItem</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>List semantic models in one workspace.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-FabricXItem -TokenProvider $provider -WorkspaceId $workspaceId -Type SemanticModel</dev:code>
+        <dev:remarks>
+          <maml:para>Uses the Fabric Core Items API and follows all continuation pages.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-FabricXPowerBISemanticModel</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>FabricXPowerBISemanticModel</command:noun>
+      <maml:description>
+        <maml:para>Gets Power BI semantic models in a workspace.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Gets Power BI semantic models in a workspace.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-FabricXPowerBISemanticModel</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OperationId</maml:name>
+          <maml:description>
+            <maml:para>Optional non-zero W3C trace identifier used to correlate the request.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TokenProvider</maml:name>
+          <maml:description>
+            <maml:para>Caller-owned token provider configured for the Power BI API scope.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">IFabricTokenProvider</command:parameterValue>
+          <dev:type>
+            <maml:name>IFabricTokenProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>WorkspaceId</maml:name>
+          <maml:description>
+            <maml:para>Power BI workspace identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OperationId</maml:name>
+        <maml:description>
+          <maml:para>Optional non-zero W3C trace identifier used to correlate the request.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TokenProvider</maml:name>
+        <maml:description>
+          <maml:para>Caller-owned token provider configured for the Power BI API scope.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">IFabricTokenProvider</command:parameterValue>
+        <dev:type>
+          <maml:name>IFabricTokenProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>WorkspaceId</maml:name>
+        <maml:description>
+          <maml:para>Power BI workspace identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>FabricClientX.PowerBI.PowerBiSemanticModel</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>List refreshable semantic models.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-FabricXPowerBISemanticModel -TokenProvider $powerBiProvider -WorkspaceId $workspaceId | Where-Object IsRefreshable</dev:code>
+        <dev:remarks>
+          <maml:para>Returns typed semantic models with a stable OperationId property.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-FabricXWorkspace</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>FabricXWorkspace</command:noun>
+      <maml:description>
+        <maml:para>Gets Microsoft Fabric workspaces visible to the authenticated principal.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Gets Microsoft Fabric workspaces visible to the authenticated principal.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-FabricXWorkspace</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OperationId</maml:name>
+          <maml:description>
+            <maml:para>Optional non-zero W3C trace identifier used to correlate the request.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PreferWorkspaceSpecificEndpoint</maml:name>
+          <maml:description>
+            <maml:para>Includes workspace-specific endpoints when the service supports them.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Role</maml:name>
+          <maml:description>
+            <maml:para>Optional workspace roles such as Admin, Member, Contributor, or Viewer.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TokenProvider</maml:name>
+          <maml:description>
+            <maml:para>Caller-owned token provider configured for the Fabric API scope.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">IFabricTokenProvider</command:parameterValue>
+          <dev:type>
+            <maml:name>IFabricTokenProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OperationId</maml:name>
+        <maml:description>
+          <maml:para>Optional non-zero W3C trace identifier used to correlate the request.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PreferWorkspaceSpecificEndpoint</maml:name>
+        <maml:description>
+          <maml:para>Includes workspace-specific endpoints when the service supports them.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Role</maml:name>
+        <maml:description>
+          <maml:para>Optional workspace roles such as Admin, Member, Contributor, or Viewer.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TokenProvider</maml:name>
+        <maml:description>
+          <maml:para>Caller-owned token provider configured for the Fabric API scope.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">IFabricTokenProvider</command:parameterValue>
+        <dev:type>
+          <maml:name>IFabricTokenProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>FabricClientX.FabricWorkspace</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>List accessible workspaces.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-FabricXWorkspace -TokenProvider $provider</dev:code>
+        <dev:remarks>
+          <maml:para>Returns workspace objects with a stable OperationId property.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-FabricXCsvWorkflow</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>FabricXCsvWorkflow</command:noun>
+      <maml:description>
+        <maml:para>Plans and executes an OfficeIMO CSV to Fabric Warehouse and optional Power BI workflow.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Plans and executes an OfficeIMO CSV to Fabric Warehouse and optional Power BI workflow.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-FabricXCsvWorkflow</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL bulk-copy batch size.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BulkCopyTimeout</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL bulk-copy timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CsvLoadOptions</maml:name>
+          <maml:description>
+            <maml:para>Optional OfficeIMO CSV parsing options.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">CsvLoadOptions</command:parameterValue>
+          <dev:type>
+            <maml:name>CsvLoadOptions</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>CsvPath</maml:name>
+          <maml:description>
+            <maml:para>Path to an OfficeIMO-compatible CSV file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CsvReaderOptions</maml:name>
+          <maml:description>
+            <maml:para>Optional OfficeIMO CSV data-reader projection options.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">CsvDataReaderOptions</command:parameterValue>
+          <dev:type>
+            <maml:name>CsvDataReaderOptions</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationTable</maml:name>
+          <maml:description>
+            <maml:para>Warehouse destination table.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OperationId</maml:name>
+          <maml:description>
+            <maml:para>Optional non-zero W3C trace identifier used across all workflow stages.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PowerBiTokenProvider</maml:name>
+          <maml:description>
+            <maml:para>Caller-owned token provider configured for the Power BI API scope.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IFabricTokenProvider</command:parameterValue>
+          <dev:type>
+            <maml:name>IFabricTokenProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Refresh</maml:name>
+          <maml:description>
+            <maml:para>Requests a Power BI semantic-model refresh after successful ingestion.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SemanticModelId</maml:name>
+          <maml:description>
+            <maml:para>Power BI semantic-model identifier used when Refresh is selected.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceName</maml:name>
+          <maml:description>
+            <maml:para>Logical source name used in the redacted plan.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeoutMinutes</maml:name>
+          <maml:description>
+            <maml:para>Maximum refresh settlement wait in minutes.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Wait</maml:name>
+          <maml:description>
+            <maml:para>Waits for the requested refresh to settle.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WarehouseConnectionOptions</maml:name>
+          <maml:description>
+            <maml:para>Caller-owned Fabric Warehouse connection and authentication options.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SqlServerConnectionOptions</command:parameterValue>
+          <dev:type>
+            <maml:name>SqlServerConnectionOptions</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WarehouseConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Fabric Warehouse connection string without embedded credentials.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WorkspaceId</maml:name>
+          <maml:description>
+            <maml:para>Power BI workspace identifier used when Refresh is selected.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BatchSize</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL bulk-copy batch size.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BulkCopyTimeout</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL bulk-copy timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CsvLoadOptions</maml:name>
+        <maml:description>
+          <maml:para>Optional OfficeIMO CSV parsing options.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">CsvLoadOptions</command:parameterValue>
+        <dev:type>
+          <maml:name>CsvLoadOptions</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>CsvPath</maml:name>
+        <maml:description>
+          <maml:para>Path to an OfficeIMO-compatible CSV file.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CsvReaderOptions</maml:name>
+        <maml:description>
+          <maml:para>Optional OfficeIMO CSV data-reader projection options.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">CsvDataReaderOptions</command:parameterValue>
+        <dev:type>
+          <maml:name>CsvDataReaderOptions</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationTable</maml:name>
+        <maml:description>
+          <maml:para>Warehouse destination table.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OperationId</maml:name>
+        <maml:description>
+          <maml:para>Optional non-zero W3C trace identifier used across all workflow stages.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PowerBiTokenProvider</maml:name>
+        <maml:description>
+          <maml:para>Caller-owned token provider configured for the Power BI API scope.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IFabricTokenProvider</command:parameterValue>
+        <dev:type>
+          <maml:name>IFabricTokenProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Refresh</maml:name>
+        <maml:description>
+          <maml:para>Requests a Power BI semantic-model refresh after successful ingestion.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SemanticModelId</maml:name>
+        <maml:description>
+          <maml:para>Power BI semantic-model identifier used when Refresh is selected.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceName</maml:name>
+        <maml:description>
+          <maml:para>Logical source name used in the redacted plan.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TimeoutMinutes</maml:name>
+        <maml:description>
+          <maml:para>Maximum refresh settlement wait in minutes.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Wait</maml:name>
+        <maml:description>
+          <maml:para>Waits for the requested refresh to settle.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WarehouseConnectionOptions</maml:name>
+        <maml:description>
+          <maml:para>Caller-owned Fabric Warehouse connection and authentication options.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SqlServerConnectionOptions</command:parameterValue>
+        <dev:type>
+          <maml:name>SqlServerConnectionOptions</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WarehouseConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Fabric Warehouse connection string without embedded credentials.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WorkspaceId</maml:name>
+        <maml:description>
+          <maml:para>Power BI workspace identifier used when Refresh is selected.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>FabricClientX.OfficeIMO.CsvFabricWorkflowResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Stream a CSV into Warehouse and settle a semantic-model refresh.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Invoke-FabricXCsvWorkflow -CsvPath .\sales.csv -SourceName Sales -WarehouseConnectionString $warehouse -WarehouseConnectionOptions $warehouseOptions -DestinationTable dbo.Sales -Refresh -PowerBiTokenProvider $powerBiProvider -WorkspaceId $workspaceId -SemanticModelId $modelId -Wait</dev:code>
+        <dev:remarks>
+          <maml:para>Creates a redacted plan before performing the confirmed Warehouse write and refresh.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-FabricXPowerBIRefresh</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>FabricXPowerBIRefresh</command:noun>
+      <maml:description>
+        <maml:para>Requests a Power BI semantic-model refresh and optionally waits for settlement.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Requests a Power BI semantic-model refresh and optionally waits for settlement.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-FabricXPowerBIRefresh</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NotifyOption</maml:name>
+          <maml:description>
+            <maml:para>Power BI notification option. Omit it for service-principal enhanced refreshes.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">NoNotification</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MailOnFailure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MailOnCompletion</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OperationId</maml:name>
+          <maml:description>
+            <maml:para>Optional non-zero W3C trace identifier used to correlate the request.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PollIntervalSeconds</maml:name>
+          <maml:description>
+            <maml:para>Polling interval in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RetryCount</maml:name>
+          <maml:description>
+            <maml:para>Optional Power BI service-side retry count.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>SemanticModelId</maml:name>
+          <maml:description>
+            <maml:para>Semantic-model identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TimeoutMinutes</maml:name>
+          <maml:description>
+            <maml:para>Maximum settlement wait in minutes.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TokenProvider</maml:name>
+          <maml:description>
+            <maml:para>Caller-owned token provider configured for the Power BI API scope.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">IFabricTokenProvider</command:parameterValue>
+          <dev:type>
+            <maml:name>IFabricTokenProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Wait</maml:name>
+          <maml:description>
+            <maml:para>Waits until the refresh reaches a terminal state.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>WorkspaceId</maml:name>
+          <maml:description>
+            <maml:para>Power BI workspace identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+          <dev:type>
+            <maml:name>Guid</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NotifyOption</maml:name>
+        <maml:description>
+          <maml:para>Power BI notification option. Omit it for service-principal enhanced refreshes.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">NoNotification</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MailOnFailure</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MailOnCompletion</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OperationId</maml:name>
+        <maml:description>
+          <maml:para>Optional non-zero W3C trace identifier used to correlate the request.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PollIntervalSeconds</maml:name>
+        <maml:description>
+          <maml:para>Polling interval in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RetryCount</maml:name>
+        <maml:description>
+          <maml:para>Optional Power BI service-side retry count.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>SemanticModelId</maml:name>
+        <maml:description>
+          <maml:para>Semantic-model identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TimeoutMinutes</maml:name>
+        <maml:description>
+          <maml:para>Maximum settlement wait in minutes.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TokenProvider</maml:name>
+        <maml:description>
+          <maml:para>Caller-owned token provider configured for the Power BI API scope.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">IFabricTokenProvider</command:parameterValue>
+        <dev:type>
+          <maml:name>IFabricTokenProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Wait</maml:name>
+        <maml:description>
+          <maml:para>Waits until the refresh reaches a terminal state.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>WorkspaceId</maml:name>
+        <maml:description>
+          <maml:para>Power BI workspace identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Guid</command:parameterValue>
+        <dev:type>
+          <maml:name>Guid</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>FabricClientX.PowerBI.PowerBiRefreshStartResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>FabricClientX.PowerBI.PowerBiRefreshSettlement</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Refresh a semantic model and wait for its terminal state.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Invoke-FabricXPowerBIRefresh -TokenProvider $powerBiProvider -WorkspaceId $workspaceId -SemanticModelId $modelId -Wait -TimeoutMinutes 30</dev:code>
+        <dev:remarks>
+          <maml:para>Returns refresh identity, terminal status, and the stable OperationId.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-FabricXTokenProvider</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>FabricXTokenProvider</command:noun>
+      <maml:description>
+        <maml:para>Creates a short-lived FabricClientX token provider from a caller-acquired secure token.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a short-lived FabricClientX token provider from a caller-acquired secure token.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-FabricXTokenProvider</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>AccessToken</maml:name>
+          <maml:description>
+            <maml:para>Caller-acquired Microsoft Entra access token.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+          <dev:type>
+            <maml:name>SecureString</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>ExpiresOn</maml:name>
+          <maml:description>
+            <maml:para>Token expiry reported by the identity provider.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DateTimeOffset</command:parameterValue>
+          <dev:type>
+            <maml:name>DateTimeOffset</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>AccessToken</maml:name>
+        <maml:description>
+          <maml:para>Caller-acquired Microsoft Entra access token.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+        <dev:type>
+          <maml:name>SecureString</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>ExpiresOn</maml:name>
+        <maml:description>
+          <maml:para>Token expiry reported by the identity provider.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DateTimeOffset</command:parameterValue>
+        <dev:type>
+          <maml:name>DateTimeOffset</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>FabricClientX.IFabricTokenProvider</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Create a provider from an Az.Accounts token result.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$azToken = Get-AzAccessToken -ResourceUrl 'https://api.fabric.microsoft.com' -AsSecureString; $provider = New-FabricXTokenProvider -AccessToken $azToken.Token -ExpiresOn $azToken.ExpiresOn</dev:code>
+        <dev:remarks>
+          <maml:para>The returned provider can be reused by Fabric discovery cmdlets until the token nears expiry.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-FabricXWarehouseConnectionOptions</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>FabricXWarehouseConnectionOptions</command:noun>
+      <maml:description>
+        <maml:para>Creates Fabric Warehouse connection options from a caller-acquired secure SQL token.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates Fabric Warehouse connection options from a caller-acquired secure SQL token.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-FabricXWarehouseConnectionOptions</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>AccessToken</maml:name>
+          <maml:description>
+            <maml:para>Caller-acquired Microsoft Entra token for the Azure SQL resource.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+          <dev:type>
+            <maml:name>SecureString</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>ExpiresOn</maml:name>
+          <maml:description>
+            <maml:para>Token expiry reported by the identity provider.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DateTimeOffset</command:parameterValue>
+          <dev:type>
+            <maml:name>DateTimeOffset</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>AccessToken</maml:name>
+        <maml:description>
+          <maml:para>Caller-acquired Microsoft Entra token for the Azure SQL resource.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+        <dev:type>
+          <maml:name>SecureString</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>ExpiresOn</maml:name>
+        <maml:description>
+          <maml:para>Token expiry reported by the identity provider.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DateTimeOffset</command:parameterValue>
+        <dev:type>
+          <maml:name>DateTimeOffset</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>DBAClientX.SqlServerConnectionOptions</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Create options from an Az.Accounts database token.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$token = Get-AzAccessToken -ResourceUrl 'https://database.windows.net' -AsSecureString; $options = New-FabricXWarehouseConnectionOptions -AccessToken $token.Token -ExpiresOn $token.ExpiresOn</dev:code>
+        <dev:remarks>
+          <maml:para>The reusable callback preserves SqlClient pooling while the fixed token remains valid.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Stop-FabricXPowerBIRefresh</command:name>
+      <command:verb>Stop</command:verb>
+      <command:noun>FabricXPowerBIRefresh</command:noun>
+      <maml:description>
+        <maml:para>Cancels an accepted Power BI semantic-model refresh after explicit confirmation.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Cancels an accepted Power BI semantic-model refresh after explicit confirmation.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Stop-FabricXPowerBIRefresh</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="0" aliases="None">
+          <maml:name>Refresh</maml:name>
+          <maml:description>
+            <maml:para>Accepted refresh returned by Invoke-FabricXPowerBIRefresh.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PowerBiRefreshStartResult</command:parameterValue>
+          <dev:type>
+            <maml:name>PowerBiRefreshStartResult</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TokenProvider</maml:name>
+          <maml:description>
+            <maml:para>Caller-owned token provider configured for the Power BI API scope.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">IFabricTokenProvider</command:parameterValue>
+          <dev:type>
+            <maml:name>IFabricTokenProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="0" aliases="None">
+        <maml:name>Refresh</maml:name>
+        <maml:description>
+          <maml:para>Accepted refresh returned by Invoke-FabricXPowerBIRefresh.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">PowerBiRefreshStartResult</command:parameterValue>
+        <dev:type>
+          <maml:name>PowerBiRefreshStartResult</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TokenProvider</maml:name>
+        <maml:description>
+          <maml:para>Caller-owned token provider configured for the Power BI API scope.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">IFabricTokenProvider</command:parameterValue>
+        <dev:type>
+          <maml:name>IFabricTokenProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>FabricClientX.PowerBI.PowerBiRefreshStartResult</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>FabricClientX.FabricResponse</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Cancel a refresh returned by Invoke-FabricXPowerBIRefresh.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$refresh | Stop-FabricXPowerBIRefresh -TokenProvider $powerBiProvider -Confirm</dev:code>
+        <dev:remarks>
+          <maml:para>Cancellation is never performed by discovery or settlement commands.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+</helpItems>

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -10,7 +10,7 @@
     [string] $GitHubApiKeyPath = 'C:\Support\Important\GitHubAPI.txt'
 )
 
-Import-Module PSPublishModule -MinimumVersion 3.0.55 -Force -ErrorAction Stop
+Import-Module PSPublishModule -MinimumVersion 3.0.88 -Force -ErrorAction Stop
 
 Build-Module -ModuleName 'DbaClientX' -NoInteractive {
     # Usual defaults as per standard module
@@ -84,7 +84,7 @@ Build-Module -ModuleName 'DbaClientX' -NoInteractive {
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable -PathReadme 'Docs\Readme.md' -Path 'Docs' -SyncExternalHelpToProjectRoot
 
     $newConfigurationBuildSplat = @{
         Enable                               = $true

--- a/Module/Docs/ConvertTo-DbaXParameterMap.md
+++ b/Module/Docs/ConvertTo-DbaXParameterMap.md
@@ -1,0 +1,124 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# ConvertTo-DbaXParameterMap
+## SYNOPSIS
+Converts objects into provider parameter dictionaries using the DbaClientX parameter mapper.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+ConvertTo-DbaXParameterMap -InputObject <Object> -Map <hashtable> [-Ambient <hashtable>] [-EnumsAsString] [-PreserveDateTimeOffset] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Converts objects into provider parameter dictionaries using the DbaClientX parameter mapper.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> [pscustomobject]@{ UserName = 'Ada' } | ConvertTo-DbaXParameterMap -Map @{ UserName = '@UserName' }
+```
+
+Returns a dictionary containing the provider parameter name and value.
+
+## PARAMETERS
+
+### -Ambient
+Optional ambient values used when the input object does not contain a mapped property.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnumsAsString
+Converts enum values to strings rather than their underlying numeric value.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+Input object whose properties should be mapped to provider parameters.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Map
+Logical property name to provider parameter name map.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreserveDateTimeOffset
+Preserves DateTimeOffset values instead of converting them to UTC DateTime values.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.Object`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Copy-DbaXAzureTableData.md
+++ b/Module/Docs/Copy-DbaXAzureTableData.md
@@ -1,0 +1,252 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Copy-DbaXAzureTableData
+## SYNOPSIS
+Copies Azure Table data between storage accounts or Table API endpoints.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Copy-DbaXAzureTableData -SourceConnectionString <string> -DestinationConnectionString <string> -SourceTable <string> -DestinationTable <string> [-Filter <string>] [-Select <string[]>] [-PageSize <int>] [-BatchSize <int>] [-WriteMode <DbaAzureTableWriteMode>] [-ClearDestination] [-NoVerify] [-NoCreateTable] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Copies Azure Table data between storage accounts or Table API endpoints.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Copy-DbaXAzureTableData -SourceConnectionString $source -DestinationConnectionString $destination -SourceTable Reports -DestinationTable ReportsArchive -Filter "PartitionKey eq 'daily'" -PassThru
+```
+
+Streams pages through the provider-neutral DbaClientX copy engine and verifies row counts.
+
+## PARAMETERS
+
+### -BatchSize
+Maximum entities per same-partition destination transaction.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClearDestination
+Clear existing destination entities before copying.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationConnectionString
+Destination Azure Storage or Cosmos DB Table API connection string.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationTable
+Destination table.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Filter
+Optional source OData filter.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoCreateTable
+Do not create the destination table when it is missing.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoVerify
+Skip source and destination row-count scans.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+Entities requested per source page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+Return the copy result.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Select
+Optional source property projection. PartitionKey and RowKey are always copied.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceConnectionString
+Source Azure Storage or Cosmos DB Table API connection string.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceTable
+Source table.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WriteMode
+Destination write behavior.
+
+```yaml
+Type: DbaAzureTableWriteMode
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Add, UpsertMerge, UpsertReplace
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Copy-DbaXTableData.md
+++ b/Module/Docs/Copy-DbaXTableData.md
@@ -1,0 +1,634 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Copy-DbaXTableData
+## SYNOPSIS
+Copies table data from one DbaClientX provider connection to another using paged reads and provider-native bulk writes.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Copy-DbaXTableData -SourceProvider <DbaXBulkProvider> -SourceConnectionString <string> -DestinationProvider <DbaXBulkProvider> -DestinationConnectionString <string> [-SourceTable <string>] [-DestinationTable <string>] [-Definition <DbaTableCopyDefinition[]>] [-OrderBy <string[]>] [-AllowUnordered] [-PageSize <int>] [-BatchSize <Int32>] [-BulkCopyTimeout <Int32>] [-ColumnMap <hashtable>] [-ExcludeColumn <string[]>] [-BooleanColumn <string[]>] [-Int32Column <string[]>] [-Int64Column <string[]>] [-DecimalColumn <string[]>] [-StringColumn <string[]>] [-DateTimeColumn <string[]>] [-DeduplicateSourceBy <string[]>] [-DeduplicateSourceOrderBy <string[]>] [-DeduplicateSourceCaseInsensitive] [-TreatMissingTablesAsEmpty] [-AllowSameTableCopy] [-SourceFabricWarehouse] [-DestinationFabricWarehouse] [-ClearDestination] [-NoVerify] [-OperationId <string>] [-TableLock] [-CheckConstraints] [-FireTriggers] [-KeepIdentity] [-KeepNulls] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Use this cmdlet for table-to-table imports, exports, and migrations across SQL Server, PostgreSQL, MySQL, Oracle, and SQLite. The reusable copy orchestration lives in DbaClientX.Core while this cmdlet supplies PowerShell-friendly parameters and progress output.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Copy-DbaXTableData -SourceProvider SQLite -SourceConnectionString 'Data Source=C:\Data\history.db' -SourceTable ProbeResults -DestinationProvider SqlServer -DestinationConnectionString 'Server=.;Database=History;Encrypt=True;TrustServerCertificate=True;Integrated Security=True' -DestinationTable dbo.ProbeResults -OrderBy Id -PageSize 10000 -BatchSize 5000 -ClearDestination -PassThru
+```
+
+Reads the SQLite table in deterministic pages and writes each page through SQL Server bulk copy.
+
+### EXAMPLE 2
+```powershell
+PS> Copy-DbaXTableData -SourceProvider SqlServer -SourceConnectionString $source -SourceTable staging.Customers -DestinationProvider PostgreSql -DestinationConnectionString $dest -DestinationTable public.customers -OrderBy CustomerId -PageSize 25000 -PassThru
+```
+
+Copies all rows from SQL Server into PostgreSQL using provider-native read and write paths.
+
+### EXAMPLE 3
+```powershell
+PS> $definitions | Copy-DbaXTableData -SourceProvider SQLite -SourceConnectionString $source -DestinationProvider SqlServer -DestinationConnectionString $dest -BatchSize 5000 -PassThru
+```
+
+Runs reusable DbaTableCopyDefinition objects produced by .NET planning code or constructed directly in PowerShell.
+
+## PARAMETERS
+
+### -AllowSameTableCopy
+Allows copying from and to the same provider database table. Use only when intentionally owning the consequences.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowUnordered
+Allows paged copies without an explicit order. Use only for ad hoc copies where provider natural order is acceptable.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BatchSize
+Optional number of rows per provider bulk-write batch.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BooleanColumn
+Column names converted to Boolean values before bulk writing.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BulkCopyTimeout
+Optional provider bulk-copy timeout in seconds. SQLite destinations do not support this option.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CheckConstraints
+SQL Server destination option to check destination constraints during each bulk copy.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClearDestination
+Deletes destination table rows before copying source rows.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ColumnMap
+Mapping from source column names to destination column names.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DateTimeColumn
+Column names converted to DateTime values before bulk writing.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DecimalColumn
+Column names converted to Decimal values before bulk writing.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeduplicateSourceBy
+Source key columns used to keep one effective row per key before copying.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeduplicateSourceCaseInsensitive
+Uses case-insensitive source keys when deduplicating source rows.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeduplicateSourceOrderBy
+Source columns used to choose the winning row for each deduplicated source key.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Definition
+Reusable table copy definitions to execute. Use this for multi-table plans generated by DbaClientX.Core.
+
+```yaml
+Type: DbaTableCopyDefinition[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -DestinationConnectionString
+Connection string used to write destination rows.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationFabricWarehouse
+Applies Microsoft Fabric Warehouse TDS and direct bulk-copy compatibility validation to a SQL Server destination.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationProvider
+Provider used to write destination rows.
+
+```yaml
+Type: DbaXBulkProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationTable
+Destination table name. Include schema or owner when required by the provider.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludeColumn
+Source column names excluded from destination pages before bulk writing.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FireTriggers
+SQL Server destination option to fire insert triggers during each bulk copy.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Int32Column
+Column names converted to Int32 values before bulk writing.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Int64Column
+Column names converted to Int64 values before bulk writing.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -KeepIdentity
+SQL Server destination option to preserve identity values from the source data.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -KeepNulls
+SQL Server destination option to preserve null values from the source data.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NoVerify
+Skips source and destination row-count verification after the copy.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OperationId
+Optional non-zero 32-character W3C trace identifier used to correlate this copy with downstream workflows.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OrderBy
+Column names used to order paged source reads. Provide stable key columns for deterministic copies.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+Number of rows read from the source per page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+Writes a result object with copied table counts, verification state, and elapsed time.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceConnectionString
+Connection string used to read source rows.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceFabricWarehouse
+Applies Microsoft Fabric Warehouse TDS compatibility validation to a SQL Server source.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceProvider
+Provider used to read source rows.
+
+```yaml
+Type: DbaXBulkProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceTable
+Source table name. Include schema or owner when required by the provider.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StringColumn
+Column names converted to String values before bulk writing.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TableLock
+SQL Server destination option to acquire a bulk update lock for the duration of each bulk copy.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TreatMissingTablesAsEmpty
+Treats missing source or destination tables as empty during row counts and clear operations.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `DBAClientX.DataMovement.DbaTableCopyDefinition[]`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-DbaXAzureTableEntity.md
+++ b/Module/Docs/Get-DbaXAzureTableEntity.md
@@ -1,0 +1,164 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Get-DbaXAzureTableEntity
+## SYNOPSIS
+Reads Azure Table entities with native continuation-token paging.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-DbaXAzureTableEntity -ConnectionString <string> -TableName <string> [-Filter <string>] [-Select <string[]>] [-PageSize <int>] [-ContinuationToken <string>] [-AsPage] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Reads Azure Table entities with native continuation-token paging.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-DbaXAzureTableEntity -ConnectionString $connectionString -TableName Reports -Filter "PartitionKey eq 'daily'"
+```
+
+Streams matching entities while following Azure continuation tokens internally.
+
+### EXAMPLE 2
+```powershell
+PS> Get-DbaXAzureTableEntity -ConnectionString $connectionString -TableName Reports -PageSize 500 -AsPage
+```
+
+Returns each page with its opaque continuation token.
+
+## PARAMETERS
+
+### -AsPage
+Return page envelopes instead of enumerating individual entities.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectionString
+Azure Storage or Cosmos DB Table API connection string.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ContinuationToken
+Optional token at which to resume the query.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Filter
+Optional OData filter.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+Maximum entities requested from Azure per page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Select
+Optional property projection. PartitionKey and RowKey are always included.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TableName
+Table to query.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `DBAClientX.AzureTables.DbaAzureTableEntity`
+- `DBAClientX.AzureTables.DbaAzureTablePage`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-DbaXMetadata.md
+++ b/Module/Docs/Get-DbaXMetadata.md
@@ -1,0 +1,147 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Get-DbaXMetadata
+## SYNOPSIS
+Gets database metadata without requiring SQL Server Management Objects.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-DbaXMetadata [-Provider] <DbaXProvider> [-Type] <DbaXMetadataType> [-ConnectionString] <string> [-Schema <string>] [-Table <string>] [-ExcludeViews] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Returns provider-neutral metadata for databases, tables/views, columns, indexes, foreign keys, and routines using native catalog queries from the selected provider.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-DbaXMetadata -Provider SqlServer -Type Table -ConnectionString 'Server=.;Database=master;Integrated Security=True;Encrypt=True;TrustServerCertificate=True'
+```
+
+Lists tables and views visible through the supplied SQL Server connection.
+
+### EXAMPLE 2
+```powershell
+PS> Get-DbaXMetadata -Provider SQLite -Type Column -ConnectionString '.\app.db' -Table Users
+```
+
+Returns column metadata for the Users table in the SQLite database file.
+
+## PARAMETERS
+
+### -ConnectionString
+Specifies a provider connection string, or a SQLite database path when Provider is SQLite.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludeViews
+Excludes views when requesting table metadata.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Provider
+Specifies the database provider.
+
+```yaml
+Type: DbaXProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Schema
+Optional schema or owner filter where the selected provider supports schemas.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Table
+Optional table filter for column, index, and foreign key metadata.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+Selects the metadata type to return.
+
+```yaml
+Type: DbaXMetadataType
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Database, Table, Column, Index, ForeignKey, Routine
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-DbaXProviderCapability.md
+++ b/Module/Docs/Get-DbaXProviderCapability.md
@@ -1,0 +1,60 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Get-DbaXProviderCapability
+## SYNOPSIS
+Gets the capabilities exposed by DbaClientX providers.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-DbaXProviderCapability [[-Provider] <DbaXProvider[]>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Gets the capabilities exposed by DbaClientX providers.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-DbaXProviderCapability
+```
+
+Returns one object per supported provider.
+
+## PARAMETERS
+
+### -Provider
+Optional provider filter.
+
+```yaml
+Type: DbaXProvider[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-DbaXSQLiteDiagnostics.md
+++ b/Module/Docs/Get-DbaXSQLiteDiagnostics.md
@@ -1,0 +1,76 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Get-DbaXSQLiteDiagnostics
+## SYNOPSIS
+Collects SQLite file and database diagnostics through the DbaClientX SQLite provider.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-DbaXSQLiteDiagnostics [-Database] <string> [-BusyTimeoutMs <Int32>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Collects SQLite file and database diagnostics through the DbaClientX SQLite provider.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-DbaXSQLiteDiagnostics -Database .\app.db
+```
+
+Returns file, integrity, journal, and SQLite version diagnostics.
+
+## PARAMETERS
+
+### -BusyTimeoutMs
+Optional busy timeout in milliseconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+SQLite database path or SQLite connection string.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: Path, ConnectionString
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-DbaXSqlServerManagement.md
+++ b/Module/Docs/Get-DbaXSqlServerManagement.md
@@ -1,0 +1,259 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Get-DbaXSqlServerManagement
+## SYNOPSIS
+Gets SQL Server-specific management metadata without requiring SQL Server Management Objects.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-DbaXSqlServerManagement [-Type] <DbaXSqlServerManagementType> [-ConnectionString] <string> [-Name <string>] [-Schema <string>] [-Table <string>] [-DestinationSchema <string>] [-DestinationTable <string>] [-RoleName <string>] [-MemberName <string>] [-PrincipalName <string>] [-IncludeDisabled] [-IncludeSystem] [-IncludeAdvanced] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Returns SQL Server Agent, security, dependency, scripting, copy-plan, inventory, instance property, and configuration metadata using native SQL Server catalog queries.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-DbaXSqlServerManagement -Type AgentJob -ConnectionString 'Server=.;Database=msdb;Integrated Security=True;Encrypt=True;TrustServerCertificate=True'
+```
+
+Lists SQL Server Agent jobs visible through the supplied connection.
+
+### EXAMPLE 2
+```powershell
+PS> Get-DbaXSqlServerManagement -Type DatabasePrincipal -ConnectionString 'Server=.;Database=AppDb;Integrated Security=True;Encrypt=True;TrustServerCertificate=True'
+```
+
+Lists database principals in the current database.
+
+## PARAMETERS
+
+### -ConnectionString
+Specifies a SQL Server connection string.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationSchema
+Destination schema name for table copy plans.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationTable
+Destination table name for table copy plans.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeAdvanced
+Includes advanced SQL Server configuration values.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeDisabled
+Includes disabled SQL Server Agent jobs or schedules where applicable.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeSystem
+Includes system principals where applicable.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MemberName
+Optional member name filter for role membership metadata.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Optional name filter used by Agent jobs, principals, instance properties, and configurations.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PrincipalName
+Optional grantee principal name filter for permission metadata.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RoleName
+Optional role name filter for role membership metadata.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Schema
+Optional schema filter used by dependency, scripting, and copy-plan metadata.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Table
+Source table name for table copy plans.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+Selects the SQL Server management metadata type to return.
+
+```yaml
+Type: DbaXSqlServerManagementType
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: AgentJob, AgentJobStep, AgentSchedule, ServerPrincipal, DatabasePrincipal, RoleMembership, Permission, InstanceProperty, Configuration, Dependency, ModuleScript, TableScript, TableCopyPlan, Inventory
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-DbaXSqlServerMonitoring.md
+++ b/Module/Docs/Get-DbaXSqlServerMonitoring.md
@@ -1,0 +1,316 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Get-DbaXSqlServerMonitoring
+## SYNOPSIS
+Collects a SQL Server monitoring snapshot through the DbaClientX SQL Server provider.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-DbaXSqlServerMonitoring -Server <string> [-Database <string>] [-Scope <SqlServerMonitoringScope>] [-Port <Int32>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-TrustServerCertificate] [-IncludeSystemDatabases] [-IncludeDisabledAgentJobs] [-MaxFullBackupAgeHours <Double>] [-MaxDifferentialBackupAgeHours <Double>] [-MaxLogBackupAgeMinutes <Double>] [-MaxCheckDbAgeDays <Double>] [-WaitStatisticThresholdPercent <decimal>] [-ConnectTimeoutSeconds <Int32>] [-ApplicationName <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Collects a SQL Server monitoring snapshot through the DbaClientX SQL Server provider.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-DbaXSqlServerMonitoring -Server . -Database master -TrustServerCertificate
+```
+
+Returns a typed monitoring snapshot for the local SQL Server instance.
+
+## PARAMETERS
+
+### -ApplicationName
+Optional SQL Server application name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectTimeoutSeconds
+Optional connection timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+Optional SQL credential.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Database used for connection-level checks.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeDisabledAgentJobs
+Includes disabled SQL Server Agent jobs.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeSystemDatabases
+Includes system databases in database-level collectors.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxCheckDbAgeDays
+Maximum age in days for last known good CHECKDB before status is considered overdue.
+
+```yaml
+Type: Double
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxDifferentialBackupAgeHours
+Maximum age in hours for differential backups before status is considered overdue.
+
+```yaml
+Type: Double
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxFullBackupAgeHours
+Maximum age in hours for full backups before status is considered overdue.
+
+```yaml
+Type: Double
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxLogBackupAgeMinutes
+Maximum age in minutes for log backups before status is considered overdue.
+
+```yaml
+Type: Double
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Optional SQL login password.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Port
+Optional TCP port.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Scope
+Monitoring areas to collect.
+
+```yaml
+Type: SqlServerMonitoringScope
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: None, Connectivity, DatabaseState, BackupFreshness, CheckDbFreshness, AgentJobs, Baseline, WaitStatistics, AvailabilityGroups, All
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+SQL Server instance name or address.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TrustServerCertificate
+Trusts the SQL Server certificate while keeping encryption enabled.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+Optional SQL login name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WaitStatisticThresholdPercent
+Maximum cumulative wait percentage to include in wait statistics.
+
+```yaml
+Type: Decimal
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Get-DbaXTableCopyPlan.md
+++ b/Module/Docs/Get-DbaXTableCopyPlan.md
@@ -1,0 +1,284 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Get-DbaXTableCopyPlan
+## SYNOPSIS
+Discovers provider metadata and builds a DbaClientX table-copy plan.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-DbaXTableCopyPlan -Provider <DbaXProvider> -ConnectionString <string> [-DestinationConnectionString <string>] [-SourceSchema <string>] [-SourceTable <string>] [-DestinationSchema <string>] [-IncludeViews] [-TableMappings <hashtable>] [-ColumnMappings <hashtable>] [-ExcludedColumns <string[]>] [-ColumnTypeConversions <hashtable>] [-IncludeDestinationIdentityColumns] [-IncludeSourceGeneratedColumns] [-IncludeDestinationGeneratedColumns] [-SkipDestinationColumnMatch] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Discovers provider metadata and builds a DbaClientX table-copy plan.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-DbaXTableCopyPlan -Provider SqlServer -ConnectionString $source -DestinationConnectionString $destination -DestinationSchema archive
+```
+
+Discovers source and destination metadata, then calls the shared DbaClientX planner.
+
+## PARAMETERS
+
+### -ColumnMappings
+Optional global source column to destination column mappings.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ColumnTypeConversions
+Optional global column type conversions.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectionString
+Source provider connection string, or SQLite source database path.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationConnectionString
+Optional destination provider connection string, or SQLite destination database path.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationSchema
+Destination schema used for generated destination names.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludedColumns
+Optional global excluded columns.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeDestinationGeneratedColumns
+Includes destination generated columns in generated pages.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeDestinationIdentityColumns
+Includes destination identity columns in generated pages.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeSourceGeneratedColumns
+Includes source generated columns in generated pages.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeViews
+Includes views in generated copy definitions.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Provider
+Provider used to discover metadata.
+
+```yaml
+Type: DbaXProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipDestinationColumnMatch
+Does not require source columns to exist in destination metadata.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceSchema
+Restricts source metadata to a schema.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceTable
+Restricts source metadata to a table.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TableMappings
+Optional source table to destination table mappings.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DbaXBulkInsert.md
+++ b/Module/Docs/Invoke-DbaXBulkInsert.md
@@ -1,0 +1,172 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXBulkInsert
+## SYNOPSIS
+Invokes a provider-native DbaClientX bulk insert from tabular PowerShell input.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXBulkInsert -Provider <DbaXProvider> -ConnectionString <string> -DestinationTable <string> -InputObject <Object> [-BatchSize <Int32>] [-BulkCopyTimeout <Int32>] [-UseTransaction] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Invokes a provider-native DbaClientX bulk insert from tabular PowerShell input.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> $rows | Invoke-DbaXBulkInsert -Provider SqlServer -ConnectionString $connectionString -DestinationTable dbo.Import -PassThru
+```
+
+Converts pipeline input to a DataTable and writes it using the SQL Server bulk provider.
+
+## PARAMETERS
+
+### -BatchSize
+Optional rows per provider bulk batch.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BulkCopyTimeout
+Optional provider bulk-copy timeout in seconds. SQLite does not support this option.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectionString
+Provider connection string, or SQLite database path.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationTable
+Destination table name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+Tabular input to write. Accepts DataTable, DataView, IDataReader, DataRow, hashtable, and object pipeline input.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -PassThru
+Returns a small result object with provider, destination table, and row count.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Provider
+Provider used for the bulk insert.
+
+```yaml
+Type: DbaXProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseTransaction
+Executes the bulk insert inside a provider transaction where supported.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.Object`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DbaXMySql.md
+++ b/Module/Docs/Invoke-DbaXMySql.md
@@ -1,0 +1,236 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXMySql
+## SYNOPSIS
+Invokes commands against a MySQL database.
+
+## SYNTAX
+### Query (Default)
+```powershell
+Invoke-DbaXMySql -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-Stream] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Connects to a MySQL server using provided credentials and executes a SQL query.
+
+Results can be streamed or returned in different formats based on the ReturnType.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> $credential = Get-Credential 'app_reader'
+Invoke-DbaXMySql -Server 'mysql01' -Database 'app' -Credential $credential -Query @'
+SELECT
+    id,
+    email,
+    created_at
+FROM users
+WHERE is_active = 1
+ORDER BY created_at DESC
+LIMIT 25;
+'@
+```
+
+Returns recent active users as DataRow objects.
+
+### EXAMPLE 2
+```powershell
+PS> $credential = Get-Credential 'app_reader'
+Invoke-DbaXMySql -Server 'mysql01' -Database 'app' -Credential $credential -Query @'
+SELECT id, message, created_at
+FROM audit_log
+ORDER BY created_at DESC
+LIMIT 1000;
+'@ -Stream
+```
+
+Streams rows without buffering the entire result.
+
+## PARAMETERS
+
+### -Credential
+Credential for authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the name of the database.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Provides additional parameters for the query.
+
+```yaml
+Type: Hashtable
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Password for authentication.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+The SQL statement to execute.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Sets the timeout for the command in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReturnType
+Selects the format of the returned data.
+
+```yaml
+Type: ReturnType
+Parameter Sets: Query
+Aliases: As
+Possible values: DataSet, DataTable, DataRow, PSObject
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the MySQL server to connect to.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Stream
+Streams results without buffering.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+User name for authentication.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- [MySQL provider on MS Learn](https://learn.microsoft.com/ef/core/providers/?tabs=dotnet-core-cli#mysql)
+- [Project documentation](https://github.com/EvotecIT/DbaClientX)
+
+## NOTES
+
+### Note
+
+Network operations may incur latency; consider using -Stream for large result sets.

--- a/Module/Docs/Invoke-DbaXMySqlNonQuery.md
+++ b/Module/Docs/Invoke-DbaXMySqlNonQuery.md
@@ -1,0 +1,181 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXMySqlNonQuery
+## SYNOPSIS
+Executes a non-query SQL command against MySQL.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXMySqlNonQuery -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Runs an SQL statement such as INSERT, UPDATE, or DELETE and returns the number of affected rows.
+
+Requires explicit credentials for authentication.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Invoke-DbaXMySqlNonQuery -Server 'mysqlsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'DELETE FROM Users WHERE Disabled = 1'
+```
+
+Removes disabled users and outputs the number of rows deleted.
+
+## PARAMETERS
+
+### -Credential
+Credential for authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the target database.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Provides parameters for the SQL command.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Password for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+The SQL command to execute.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Sets the command timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the MySQL server.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+User name for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- [MySQL provider on MS Learn](https://learn.microsoft.com/ef/core/providers/?tabs=dotnet-core-cli#mysql)
+- [Project documentation](https://github.com/EvotecIT/DbaClientX)
+
+## NOTES
+
+### Note
+
+Use caution with destructive statements; the cmdlet respects -WhatIf and -Confirm.

--- a/Module/Docs/Invoke-DbaXMySqlScalar.md
+++ b/Module/Docs/Invoke-DbaXMySqlScalar.md
@@ -1,0 +1,193 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXMySqlScalar
+## SYNOPSIS
+Executes a scalar SQL query against MySQL.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXMySqlScalar -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Runs a SQL statement and returns a single value. Supports asynchronous execution and type conversion via ReturnType.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> $credential = Get-Credential 'app_reader'
+Invoke-DbaXMySqlScalar -Server 'mysql01' -Database 'app' -Credential $credential -Query @'
+SELECT COUNT(*)
+FROM users
+WHERE is_active = 1;
+'@
+```
+
+Returns the number of users.
+
+## PARAMETERS
+
+### -Credential
+Credential for authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the target database.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Provides parameters for the SQL command.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Password for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+The SQL command to execute.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Sets the command timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReturnType
+Selects the format of the returned value.
+
+```yaml
+Type: ReturnType
+Parameter Sets: __AllParameterSets
+Aliases: As
+Possible values: DataSet, DataTable, DataRow, PSObject
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the MySQL server.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+User name for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DbaXMySqlTransaction.md
+++ b/Module/Docs/Invoke-DbaXMySqlTransaction.md
@@ -1,0 +1,188 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXMySqlTransaction
+## SYNOPSIS
+Runs a script block inside a MySQL transaction.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXMySqlTransaction -Server <string> -Database <string> -ScriptBlock <scriptblock> [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-QueryTimeout <int>] [-IsolationLevel <IsolationLevel>] [-ArgumentList <Object[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a MySQL client, begins a transaction, invokes the script block, and commits on success.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Invoke-DbaXMySqlTransaction -Server 'mysql01' -Database 'App' -Credential $credential -ArgumentList $credential -ScriptBlock { param($client, $login) $client.ExecuteNonQuery('mysql01', 'App', $login.UserName, $login.GetNetworkCredential().Password, 'UPDATE Jobs SET Enabled = 1 WHERE Id = 42', $null, $true) }
+```
+
+Use the same credential inside the transaction script block.
+
+## PARAMETERS
+
+### -ArgumentList
+Additional arguments passed to the script block after the transaction client.
+
+```yaml
+Type: Object[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+MySQL credential.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the database name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsolationLevel
+Isolation level to use for the transaction.
+
+```yaml
+Type: IsolationLevel
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Chaos, ReadUncommitted, ReadCommitted, RepeatableRead, Serializable, Snapshot, Unspecified
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+MySQL password.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Command timeout to assign to the transaction client.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScriptBlock
+Script block executed with the transaction client as the first argument.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the MySQL server.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+MySQL user name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DbaXNonQuery.md
+++ b/Module/Docs/Invoke-DbaXNonQuery.md
@@ -1,0 +1,216 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXNonQuery
+## SYNOPSIS
+Executes a non-query SQL command against SQL Server.
+
+## SYNTAX
+### DefaultCredentials (Default)
+```powershell
+Invoke-DbaXNonQuery -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Runs an SQL statement such as INSERT, UPDATE, or DELETE and returns the number of affected rows.
+
+Supports SQL authentication or integrated security based on provided credentials.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> $sql = @'
+             CREATE TABLE #DbaClientXDemo
+             (
+                 Id int NOT NULL,
+                 Name nvarchar(50) NOT NULL
+             );
+
+             INSERT INTO #DbaClientXDemo (Id, Name)
+             VALUES (1, N'Alpha'), (2, N'Beta');
+             '@
+
+             Invoke-DbaXNonQuery -Server 'localhost' -Database 'master' -TrustServerCertificate -Query $sql
+```
+
+Executes a multi-line command and returns the number of affected rows.
+
+### EXAMPLE 2
+```powershell
+PS> $credential = Get-Credential 'app_writer'
+Invoke-DbaXNonQuery -Server 'sql01' -Database 'app' -Query 'UPDATE dbo.Users SET LastSeenUtc = SYSUTCDATETIME() WHERE Id = @Id' -Credential $credential -Parameters @{ Id = 42 }
+```
+
+Executes the statement using the supplied credentials.
+
+## PARAMETERS
+
+### -Credential
+Optional SQL authentication credential.
+
+```yaml
+Type: PSCredential
+Parameter Sets: DefaultCredentials
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the target database.
+
+```yaml
+Type: String
+Parameter Sets: DefaultCredentials
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Provides parameters for the SQL command.
+
+```yaml
+Type: Hashtable
+Parameter Sets: DefaultCredentials
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Optional password for SQL authentication.
+
+```yaml
+Type: String
+Parameter Sets: DefaultCredentials
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+The SQL command to execute.
+
+```yaml
+Type: String
+Parameter Sets: DefaultCredentials
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Sets the command timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: DefaultCredentials
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the SQL Server instance.
+
+```yaml
+Type: String
+Parameter Sets: DefaultCredentials
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TrustServerCertificate
+Trusts the SQL Server TLS certificate without validating the certificate chain.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: DefaultCredentials
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+Optional user name for SQL authentication.
+
+```yaml
+Type: String
+Parameter Sets: DefaultCredentials
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- [Using SqlClient](https://learn.microsoft.com/dotnet/framework/data/adonet/using-sqlclient)
+- [Project documentation](https://github.com/EvotecIT/DbaClientX)
+
+## NOTES
+
+### Note
+
+Use caution with destructive statements; the cmdlet respects -WhatIf and -Confirm.

--- a/Module/Docs/Invoke-DbaXOracle.md
+++ b/Module/Docs/Invoke-DbaXOracle.md
@@ -1,0 +1,232 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXOracle
+## SYNOPSIS
+Invokes commands against an Oracle database.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXOracle -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-Stream] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Connects to an Oracle server using provided credentials and executes a SQL query.
+
+Results can be returned in different formats based on the ReturnType.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> $credential = Get-Credential 'app_reader'
+Invoke-DbaXOracle -Server 'oracle01' -Database 'ORCLPDB1' -Credential $credential -Query @'
+SELECT
+    USER AS ConnectedUser,
+    SYS_CONTEXT('USERENV', 'SERVICE_NAME') AS ServiceName
+FROM dual
+'@
+```
+
+Returns Oracle session context as DataRow objects.
+
+### EXAMPLE 2
+```powershell
+PS> $credential = Get-Credential 'app_reader'
+Invoke-DbaXOracle -Server 'oracle01' -Database 'ORCLPDB1' -Credential $credential -Query @'
+SELECT owner, table_name
+FROM all_tables
+WHERE owner = USER
+ORDER BY table_name
+'@ -Stream
+```
+
+Streams rows without buffering the entire result.
+
+## PARAMETERS
+
+### -Credential
+Credential for authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the name of the database.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Provides additional parameters for the query.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Password for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+The SQL statement to execute.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Sets the timeout for the command in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReturnType
+Selects the format of the returned data.
+
+```yaml
+Type: ReturnType
+Parameter Sets: __AllParameterSets
+Aliases: As
+Possible values: DataSet, DataTable, DataRow, PSObject
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the Oracle server to connect to.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Stream
+Streams results without buffering.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+User name for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- [Oracle provider documentation](https://learn.microsoft.com/dotnet/standard/data/sqlite/?tabs=netcore-cli)
+- [Project documentation](https://github.com/EvotecIT/DbaClientX)
+
+## NOTES
+
+### Note
+
+Network operations may incur latency; consider using -Stream for large result sets.

--- a/Module/Docs/Invoke-DbaXOracleNonQuery.md
+++ b/Module/Docs/Invoke-DbaXOracleNonQuery.md
@@ -1,0 +1,178 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXOracleNonQuery
+## SYNOPSIS
+Executes a non-query SQL command against Oracle.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXOracleNonQuery -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Runs an SQL statement such as INSERT, UPDATE, or DELETE and returns the number of affected rows.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Invoke-DbaXOracleNonQuery -Server 'oraclesrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'DELETE FROM Users WHERE Disabled = 1'
+```
+
+Removes disabled users and outputs the number of rows deleted.
+
+## PARAMETERS
+
+### -Credential
+Credential for authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the target database.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Provides parameters for the SQL command.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Password for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+The SQL command to execute.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Sets the command timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the Oracle server.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+User name for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- [Project documentation](https://github.com/EvotecIT/DbaClientX)
+
+## NOTES
+
+### Note
+
+Use caution with destructive statements; the cmdlet respects -WhatIf and -Confirm.

--- a/Module/Docs/Invoke-DbaXOracleScalar.md
+++ b/Module/Docs/Invoke-DbaXOracleScalar.md
@@ -1,0 +1,188 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXOracleScalar
+## SYNOPSIS
+Executes a scalar SQL query against Oracle.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXOracleScalar -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Runs a SQL statement and returns a single value. Supports type conversion via ReturnType.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Invoke-DbaXOracleScalar -Server 'oraclesrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'SELECT COUNT(*) FROM Users'
+```
+
+Returns the number of users.
+
+## PARAMETERS
+
+### -Credential
+Credential for authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the target database.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Provides parameters for the SQL command.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Password for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+The SQL command to execute.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Sets the command timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReturnType
+Selects the format of the returned value.
+
+```yaml
+Type: ReturnType
+Parameter Sets: __AllParameterSets
+Aliases: As
+Possible values: DataSet, DataTable, DataRow, PSObject
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the Oracle server.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+User name for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DbaXOracleTransaction.md
+++ b/Module/Docs/Invoke-DbaXOracleTransaction.md
@@ -1,0 +1,188 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXOracleTransaction
+## SYNOPSIS
+Runs a script block inside an Oracle transaction.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXOracleTransaction -Server <string> -Database <string> -ScriptBlock <scriptblock> [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-QueryTimeout <int>] [-IsolationLevel <IsolationLevel>] [-ArgumentList <Object[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates an Oracle client, begins a transaction, invokes the script block, and commits on success.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Invoke-DbaXOracleTransaction -Server 'oracle01' -Database 'FREEPDB1' -Credential $credential -ArgumentList $credential -ScriptBlock { param($client, $login) $client.ExecuteNonQuery('oracle01', 'FREEPDB1', $login.UserName, $login.GetNetworkCredential().Password, 'UPDATE Jobs SET Enabled = 1 WHERE Id = 42', $null, $true) }
+```
+
+Use the same credential inside the transaction script block.
+
+## PARAMETERS
+
+### -ArgumentList
+Additional arguments passed to the script block after the transaction client.
+
+```yaml
+Type: Object[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+Oracle credential.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the Oracle service name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: ServiceName
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsolationLevel
+Isolation level to use for the transaction.
+
+```yaml
+Type: IsolationLevel
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Chaos, ReadUncommitted, ReadCommitted, RepeatableRead, Serializable, Snapshot, Unspecified
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Oracle password.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Command timeout to assign to the transaction client.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScriptBlock
+Script block executed with the transaction client as the first argument.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the Oracle server.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+Oracle user name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DbaXPostgreSql.md
+++ b/Module/Docs/Invoke-DbaXPostgreSql.md
@@ -1,0 +1,248 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXPostgreSql
+## SYNOPSIS
+Invokes commands against a PostgreSQL database.
+
+## SYNTAX
+### Query (Default)
+```powershell
+Invoke-DbaXPostgreSql -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-Stream] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### StoredProcedure
+```powershell
+Invoke-DbaXPostgreSql -Server <string> -Database <string> -StoredProcedure <string> [-QueryTimeout <int>] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Connects to a PostgreSQL server and executes a query or stored procedure with optional parameters.
+
+Results can be streamed or returned in DataRow, DataTable, DataSet or PSObject formats.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> $credential = Get-Credential 'app_reader'
+Invoke-DbaXPostgreSql -Server 'pg01' -Database 'app' -Credential $credential -Query @'
+SELECT
+    current_database() AS database_name,
+    current_user AS connected_as,
+    version() AS server_version;
+'@
+```
+
+Executes the query and returns each row as a DataRow.
+
+### EXAMPLE 2
+```powershell
+PS> $credential = Get-Credential 'app_writer'
+Invoke-DbaXPostgreSql -Server 'pg01' -Database 'app' -Credential $credential -StoredProcedure 'refresh_stats' -ReturnType DataTable
+```
+
+Runs the stored procedure and outputs a DataTable.
+
+## PARAMETERS
+
+### -Credential
+The credential for authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the database name on the server.
+
+```yaml
+Type: String
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Supplies parameters for the query or stored procedure.
+
+```yaml
+Type: Hashtable
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+The password for authentication.
+
+```yaml
+Type: String
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+Provides the SQL query text to execute.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Sets the command timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReturnType
+Selects the format of returned data.
+
+```yaml
+Type: ReturnType
+Parameter Sets: Query, StoredProcedure
+Aliases: As
+Possible values: DataSet, DataTable, DataRow, PSObject
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the PostgreSQL server to connect to.
+
+```yaml
+Type: String
+Parameter Sets: Query, StoredProcedure
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StoredProcedure
+Names the stored procedure to invoke.
+
+```yaml
+Type: String
+Parameter Sets: StoredProcedure
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Stream
+Streams results instead of buffering them.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+The user name for authentication.
+
+```yaml
+Type: String
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- [Npgsql provider on MS Learn](https://learn.microsoft.com/ef/core/providers/npgsql/)
+- [Project documentation](https://github.com/EvotecIT/DbaClientX)
+
+## NOTES
+
+### Note
+
+Credentials are transmitted to the server; ensure secure channels when running over a network.

--- a/Module/Docs/Invoke-DbaXPostgreSqlNonQuery.md
+++ b/Module/Docs/Invoke-DbaXPostgreSqlNonQuery.md
@@ -1,0 +1,181 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXPostgreSqlNonQuery
+## SYNOPSIS
+Executes a non-query SQL command against PostgreSQL.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXPostgreSqlNonQuery -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Runs statements like INSERT, UPDATE, or DELETE and returns the number of affected rows.
+
+Requires explicit credentials for authentication.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Invoke-DbaXPostgreSqlNonQuery -Server 'pgsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'DELETE FROM data WHERE Archived = 1'
+```
+
+Removes archived rows and outputs the number of rows deleted.
+
+## PARAMETERS
+
+### -Credential
+Credential for authentication.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the target database.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Provides parameters for the SQL command.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Password for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+The SQL command to execute.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Sets the command timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the PostgreSQL server.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+User name for authentication.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- [Npgsql provider on MS Learn](https://learn.microsoft.com/ef/core/providers/npgsql/)
+- [Project documentation](https://github.com/EvotecIT/DbaClientX)
+
+## NOTES
+
+### Note
+
+Use caution with destructive statements; the cmdlet respects -WhatIf and -Confirm.

--- a/Module/Docs/Invoke-DbaXPostgreSqlTransaction.md
+++ b/Module/Docs/Invoke-DbaXPostgreSqlTransaction.md
@@ -1,0 +1,188 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXPostgreSqlTransaction
+## SYNOPSIS
+Runs a script block inside a PostgreSQL transaction.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXPostgreSqlTransaction -Server <string> -Database <string> -ScriptBlock <scriptblock> [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-QueryTimeout <int>] [-IsolationLevel <IsolationLevel>] [-ArgumentList <Object[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a PostgreSQL client, begins a transaction, invokes the script block, and commits on success.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Invoke-DbaXPostgreSqlTransaction -Server 'pgsql01' -Database 'App' -Credential $credential -ArgumentList $credential -ScriptBlock { param($client, $login) $client.ExecuteNonQuery('pgsql01', 'App', $login.UserName, $login.GetNetworkCredential().Password, 'UPDATE Jobs SET Enabled = TRUE WHERE Id = 42', $null, $true) }
+```
+
+Use the same credential inside the transaction script block.
+
+## PARAMETERS
+
+### -ArgumentList
+Additional arguments passed to the script block after the transaction client.
+
+```yaml
+Type: Object[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+PostgreSQL credential.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the database name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsolationLevel
+Isolation level to use for the transaction.
+
+```yaml
+Type: IsolationLevel
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Chaos, ReadUncommitted, ReadCommitted, RepeatableRead, Serializable, Snapshot, Unspecified
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+PostgreSQL password.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Command timeout to assign to the transaction client.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScriptBlock
+Script block executed with the transaction client as the first argument.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the PostgreSQL server.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+PostgreSQL user name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DbaXQuery.md
+++ b/Module/Docs/Invoke-DbaXQuery.md
@@ -1,0 +1,268 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXQuery
+## SYNOPSIS
+Invokes a SQL Server query or stored procedure.
+
+## SYNTAX
+### Query (Default)
+```powershell
+Invoke-DbaXQuery -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-Stream] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### StoredProcedure
+```powershell
+Invoke-DbaXQuery -Server <string> -Database <string> -StoredProcedure <string> [-QueryTimeout <int>] [-Stream] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Connects to a SQL Server instance using integrated security or supplied credentials and executes the specified command.
+
+Supports streaming results and multiple return formats via the ReturnType parameter.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> $rows = Invoke-DbaXQuery -Server 'localhost' -Database 'master' -TrustServerCertificate -Query @'
+             SELECT
+                 name,
+                 database_id,
+                 create_date
+             FROM sys.databases
+             WHERE database_id > 4
+             ORDER BY name;
+             '@
+
+             $rows | Format-Table name, database_id, create_date
+```
+
+Executes a multi-line query against a local SQL Server instance and returns each row as a DataRow.
+
+### EXAMPLE 2
+```powershell
+PS> $credential = Get-Credential 'app_reader'
+Invoke-DbaXQuery -Server 'sql01' -Database 'app' -StoredProcedure 'dbo.usp_GetActiveUsers' -Credential $credential -ReturnType DataTable
+```
+
+Runs the stored procedure and outputs a DataTable.
+
+## PARAMETERS
+
+### -Credential
+Optional SQL authentication credential.
+
+```yaml
+Type: PSCredential
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the database name.
+
+```yaml
+Type: String
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Provides additional parameters for the query or procedure.
+
+```yaml
+Type: Hashtable
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Optional password for SQL authentication.
+
+```yaml
+Type: String
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+The SQL statement to execute.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Sets the command timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReturnType
+Selects the type of returned objects.
+
+```yaml
+Type: ReturnType
+Parameter Sets: Query, StoredProcedure
+Aliases: As
+Possible values: DataSet, DataTable, DataRow, PSObject
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the SQL Server instance.
+
+```yaml
+Type: String
+Parameter Sets: Query, StoredProcedure
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StoredProcedure
+Name of the stored procedure to run.
+
+```yaml
+Type: String
+Parameter Sets: StoredProcedure
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Stream
+Streams results instead of buffering them.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TrustServerCertificate
+Trusts the SQL Server TLS certificate without validating the certificate chain.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+Optional user name for SQL authentication.
+
+```yaml
+Type: String
+Parameter Sets: Query, StoredProcedure
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- [Using SqlClient](https://learn.microsoft.com/dotnet/framework/data/adonet/using-sqlclient)
+- [Project documentation](https://github.com/EvotecIT/DbaClientX)
+
+## NOTES
+
+### Note
+
+When -ErrorAction Stop is used, execution will terminate on the first error.

--- a/Module/Docs/Invoke-DbaXQueryStream.md
+++ b/Module/Docs/Invoke-DbaXQueryStream.md
@@ -1,0 +1,156 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXQueryStream
+## SYNOPSIS
+Streams query rows through a DbaClientX provider.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXQueryStream -Provider <DbaXProvider> -ConnectionString <string> -Query <string> [-Parameters <hashtable>] [-UseTransaction] [-ReturnType <ReturnType>] [-QueryTimeout <int>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Streams query rows through a DbaClientX provider.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Invoke-DbaXQueryStream -Provider SqlServer -ConnectionString $connectionString -Query 'SELECT name FROM sys.databases' -ReturnType PSObject
+```
+
+Streams query rows without buffering the full result set.
+
+## PARAMETERS
+
+### -ConnectionString
+Provider connection string, or SQLite database path.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Optional query parameters.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Provider
+Provider used to stream query rows.
+
+```yaml
+Type: DbaXProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+Query text to execute.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Optional command timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReturnType
+Controls the returned object format.
+
+```yaml
+Type: ReturnType
+Parameter Sets: __AllParameterSets
+Aliases: As
+Possible values: DataSet, DataTable, DataRow, PSObject
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseTransaction
+Executes through an active provider transaction when supported.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DbaXSQLite.md
+++ b/Module/Docs/Invoke-DbaXSQLite.md
@@ -1,0 +1,156 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXSQLite
+## SYNOPSIS
+Invokes a query against a SQLite database.
+
+## SYNTAX
+### Query (Default)
+```powershell
+Invoke-DbaXSQLite -Database <string> -Query <string> [-QueryTimeout <int>] [-Stream] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Executes SQL statements on a specified SQLite database and returns data in the format you choose.
+
+Supports streaming results for large data sets when the platform allows asynchronous enumeration.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Invoke-DbaXSQLite -Database 'app.db' -Query 'SELECT * FROM Users'
+```
+
+Executes the query and outputs each row as a DataRow.
+
+### EXAMPLE 2
+```powershell
+PS> Invoke-DbaXSQLite -Database 'app.db' -Query 'SELECT * FROM Logs' -Stream -ReturnType DataRow
+```
+
+Streams each row as it is received, which is useful for large result sets.
+
+## PARAMETERS
+
+### -Database
+Specifies the path to the SQLite database file.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Provides additional query parameters.
+
+```yaml
+Type: Hashtable
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Query
+Defines the SQL query to execute.
+
+```yaml
+Type: String
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Sets the command timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReturnType
+Selects the format of returned data.
+
+```yaml
+Type: ReturnType
+Parameter Sets: Query
+Aliases: As
+Possible values: DataSet, DataTable, DataRow, PSObject
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Stream
+Streams results instead of buffering them.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Query
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- [SQLite in .NET](https://learn.microsoft.com/dotnet/standard/data/sqlite/)
+- [Project documentation](https://github.com/EvotecIT/DbaClientX)
+
+## NOTES
+
+### Note
+
+When -Stream is used on platforms without streaming support, a NotSupportedException is thrown.

--- a/Module/Docs/Invoke-DbaXSQLiteMaintenance.md
+++ b/Module/Docs/Invoke-DbaXSQLiteMaintenance.md
@@ -1,0 +1,156 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXSQLiteMaintenance
+## SYNOPSIS
+Runs SQLite maintenance operations through the DbaClientX SQLite provider.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXSQLiteMaintenance [-Database] <string> [-Action] <DbaXSQLiteMaintenanceAction> [-Destination <string>] [-CheckpointMode <SqliteCheckpointMode>] [-BusyTimeoutMs <Int32>] [-SkipOptimize] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Runs SQLite maintenance operations through the DbaClientX SQLite provider.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Invoke-DbaXSQLiteMaintenance -Database .\app.db -Action PrepareForShutdown
+```
+
+Runs the provider shutdown maintenance sequence.
+
+## PARAMETERS
+
+### -Action
+Maintenance operation to execute.
+
+```yaml
+Type: DbaXSQLiteMaintenanceAction
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Backup, Checkpoint, Optimize, PrepareForShutdown
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BusyTimeoutMs
+Optional busy timeout in milliseconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CheckpointMode
+Checkpoint mode used by Checkpoint and PrepareForShutdown.
+
+```yaml
+Type: SqliteCheckpointMode
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Passive, Full, Restart, Truncate
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+SQLite database path or SQLite connection string.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: Path, ConnectionString
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Destination
+Destination database path for the Backup action.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+Returns a small completion object.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipOptimize
+Skips PRAGMA optimize after checkpointing during PrepareForShutdown.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DbaXSQLiteTransaction.md
+++ b/Module/Docs/Invoke-DbaXSQLiteTransaction.md
@@ -1,0 +1,124 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXSQLiteTransaction
+## SYNOPSIS
+Runs a script block inside a SQLite transaction.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXSQLiteTransaction -Database <string> -ScriptBlock <scriptblock> [-QueryTimeout <int>] [-IsolationLevel <IsolationLevel>] [-ArgumentList <Object[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a SQLite client, begins a transaction, invokes the script block, and commits on success.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Invoke-DbaXSQLiteTransaction -Database '.\app.db' -ScriptBlock { param($client) $client.ExecuteNonQuery('.\app.db', 'UPDATE Jobs SET Enabled = 1 WHERE Id = 42', $null, $true) }
+```
+
+Update a row in a SQLite transaction.
+
+## PARAMETERS
+
+### -ArgumentList
+Additional arguments passed to the script block after the transaction client.
+
+```yaml
+Type: Object[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the SQLite database path or connection target.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsolationLevel
+Isolation level to use for the transaction.
+
+```yaml
+Type: IsolationLevel
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Chaos, ReadUncommitted, ReadCommitted, RepeatableRead, Serializable, Snapshot, Unspecified
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Command timeout to assign to the transaction client.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScriptBlock
+Script block executed with the transaction client as the first argument.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DbaXStoredProcedure.md
+++ b/Module/Docs/Invoke-DbaXStoredProcedure.md
@@ -1,0 +1,172 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXStoredProcedure
+## SYNOPSIS
+Invokes a stored procedure through a DbaClientX provider.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXStoredProcedure -Provider <DbaXProvider> -ConnectionString <string> -Procedure <string> [-Parameters <hashtable>] [-UseTransaction] [-Stream] [-ReturnType <ReturnType>] [-QueryTimeout <int>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Invokes a stored procedure through a DbaClientX provider.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Invoke-DbaXStoredProcedure -Provider SqlServer -ConnectionString $connectionString -Procedure dbo.GetUsers -ReturnType PSObject
+```
+
+Executes the stored procedure and converts rows to PowerShell objects.
+
+## PARAMETERS
+
+### -ConnectionString
+Provider connection string.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Parameters
+Optional procedure parameters.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Procedure
+Stored procedure name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Provider
+Provider used to execute the stored procedure.
+
+```yaml
+Type: DbaXProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Optional command timeout in seconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReturnType
+Controls the returned object format.
+
+```yaml
+Type: ReturnType
+Parameter Sets: __AllParameterSets
+Aliases: As
+Possible values: DataSet, DataTable, DataRow, PSObject
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Stream
+Streams result rows instead of buffering the result.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseTransaction
+Executes through an active provider transaction when supported.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Invoke-DbaXTransaction.md
+++ b/Module/Docs/Invoke-DbaXTransaction.md
@@ -1,0 +1,188 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Invoke-DbaXTransaction
+## SYNOPSIS
+Runs a script block inside a SQL Server transaction.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Invoke-DbaXTransaction -Server <string> -Database <string> -ScriptBlock <scriptblock> [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-QueryTimeout <int>] [-IsolationLevel <IsolationLevel>] [-ArgumentList <Object[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a SQL Server client, begins a transaction, invokes the script block, and commits on success.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Invoke-DbaXTransaction -Server 'sql01' -Database 'App' -ScriptBlock { param($client) $client.ExecuteNonQuery('sql01', 'App', $true, 'UPDATE Jobs SET Enabled = 1 WHERE Id = 42', $null, $true) }
+```
+
+Update a row through the transaction client. The cmdlet commits after the script block succeeds.
+
+## PARAMETERS
+
+### -ArgumentList
+Additional arguments passed to the script block after the transaction client.
+
+```yaml
+Type: Object[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+Optional SQL authentication credential.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Defines the database name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsolationLevel
+Isolation level to use for the transaction.
+
+```yaml
+Type: IsolationLevel
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Chaos, ReadUncommitted, ReadCommitted, RepeatableRead, Serializable, Snapshot, Unspecified
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Optional SQL authentication password.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -QueryTimeout
+Command timeout to assign to the transaction client.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ScriptBlock
+Script block executed with the transaction client as the first argument.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Specifies the SQL Server instance.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: DBServer, SqlInstance, Instance
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+Optional SQL authentication user name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/New-DbaXConnectionString.md
+++ b/Module/Docs/New-DbaXConnectionString.md
@@ -1,0 +1,252 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# New-DbaXConnectionString
+## SYNOPSIS
+Builds a provider connection string using the matching DbaClientX C# provider.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-DbaXConnectionString [-Provider] <DbaXProvider> -Database <string> [-Server <string>] [-Port <Int32>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-Ssl] [-TrustServerCertificate] [-ReadOnly] [-BusyTimeoutMs <Int32>] [-ConnectTimeoutSeconds <Int32>] [-ApplicationName <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Builds a provider connection string using the matching DbaClientX C# provider.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> New-DbaXConnectionString -Provider SqlServer -Server . -Database master -TrustServerCertificate
+```
+
+Returns a SQL Server connection string using integrated security.
+
+## PARAMETERS
+
+### -ApplicationName
+Optional SQL Server application name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BusyTimeoutMs
+Optional SQLite busy timeout in milliseconds.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectTimeoutSeconds
+Optional connection timeout in seconds where supported.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+Optional credential used instead of Username and Password.
+
+```yaml
+Type: PSCredential
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Database
+Database name, Oracle service name, or SQLite database path.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Optional password.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Port
+Optional provider TCP port.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Provider
+Database provider whose connection-string builder should be used.
+
+```yaml
+Type: DbaXProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReadOnly
+Builds a read-only SQLite connection string.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Server
+Server, host, or SQL Server instance name. SQLite ignores this parameter.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Ssl
+Enables provider SSL or encryption when supported by the provider builder.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TrustServerCertificate
+Trusts the SQL Server certificate when SQL Server encryption is enabled.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Username
+Optional username. SQL Server uses integrated security when no credential or username/password is supplied.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/New-DbaXQuery.md
+++ b/Module/Docs/New-DbaXQuery.md
@@ -1,0 +1,335 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# New-DbaXQuery
+## SYNOPSIS
+Creates SQL query-builder objects using the DbaClientX core query builder.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-DbaXQuery [-TableName] <string> [-Action <DbaXQueryAction>] [-Columns <string[]>] [-Values <IDictionary>] [-Set <IDictionary>] [-Where <IDictionary>] [-ConflictColumns <string[]>] [-UpsertUpdateOnly <string[]>] [-OrderBy <string[]>] [-OrderByDescending <string[]>] [-Compile] [-CompileWithParameters] [-Dialect <SqlDialect>] [-Limit <Int32>] [-Offset <Int32>] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Builds SELECT, INSERT, UPDATE, DELETE, and UPSERT statements without duplicating SQL-generation logic in PowerShell.
+
+Use -Compile for literal SQL output or -CompileWithParameters to return SQL plus an ordered parameter map.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> New-DbaXQuery -TableName 'dbo.Users' -Columns Id,DisplayName
+```
+
+Returns a core query object targeting selected columns from dbo.Users.
+
+### EXAMPLE 2
+```powershell
+PS> New-DbaXQuery -TableName 'dbo.Users' -Columns Id,DisplayName -Where @{ IsActive = $true } -OrderBy DisplayName -Limit 10 -Offset 20 -Compile
+```
+
+Outputs a SQL Server SELECT statement with a WHERE clause and OFFSET/FETCH pagination.
+
+### EXAMPLE 3
+```powershell
+PS> New-DbaXQuery -Action Insert -TableName 'dbo.Users' -Values ([ordered]@{ Id = 42; DisplayName = 'Ada' }) -Compile
+```
+
+Outputs an INSERT statement using the DbaClientX core query compiler.
+
+### EXAMPLE 4
+```powershell
+PS> New-DbaXQuery -Action Update -TableName 'dbo.Users' -Set @{ DisplayName = 'Ada Lovelace' } -Where @{ Id = 42 } -Compile
+```
+
+Outputs an UPDATE statement with values supplied by PowerShell hashtables.
+
+### EXAMPLE 5
+```powershell
+PS> New-DbaXQuery -Action Delete -TableName 'dbo.Users' -Where @{ Id = 42 } -Compile
+```
+
+Outputs a DELETE statement scoped by the provided WHERE values.
+
+### EXAMPLE 6
+```powershell
+PS> New-DbaXQuery -Action Upsert -Dialect PostgreSql -TableName 'public.users' -Values ([ordered]@{ id = 42; display_name = 'Ada'; email = 'ada@example.test' }) -ConflictColumns id -UpsertUpdateOnly display_name,email -Compile
+```
+
+Outputs a PostgreSQL INSERT ... ON CONFLICT statement. Use another -Dialect value for SQL Server, MySQL, SQLite, or Oracle compiler behavior.
+
+### EXAMPLE 7
+```powershell
+PS> New-DbaXQuery -Action Update -Dialect PostgreSql -TableName 'public.users' -Set @{ display_name = 'Ada' } -Where @{ id = 42 } -CompileWithParameters
+```
+
+Returns an object with Sql, Parameters, and ParameterValues properties for callers that want to execute parameterized SQL later.
+
+## PARAMETERS
+
+### -Action
+The query-builder operation to create.
+
+```yaml
+Type: DbaXQueryAction
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Select, Insert, Update, Delete, Upsert
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Columns
+Columns to include in a SELECT statement. When omitted, the core builder emits *.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Compile
+Compiles the query to a SQL string.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CompileWithParameters
+Compiles the query to SQL text and returns ordered parameter values.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConflictColumns
+Columns used to detect UPSERT conflicts.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Dialect
+SQL dialect used when compiling the query.
+
+```yaml
+Type: SqlDialect
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, SQLite, Oracle
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Limit
+Limits the number of returned rows.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Offset
+Skips a number of rows before returning results.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OrderBy
+Columns to add to ORDER BY in ascending order.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OrderByDescending
+Columns to add to ORDER BY in descending order.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Set
+Column/value pairs for UPDATE SET clauses.
+
+```yaml
+Type: IDictionary
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TableName
+Name of the table targeted by the query.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UpsertUpdateOnly
+Columns updated during an UPSERT conflict. When omitted, the core builder updates all non-conflict insert columns.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Values
+Column/value pairs for INSERT or UPSERT statements.
+
+```yaml
+Type: IDictionary
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Where
+Column/value pairs added as equality predicates to the WHERE clause.
+
+```yaml
+Type: IDictionary
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- [SELECT statement (Transact-SQL)](https://learn.microsoft.com/sql/t-sql/queries/select-transact-sql)
+- [Project documentation](https://github.com/EvotecIT/DbaClientX)
+
+## NOTES
+
+### Note
+
+The cmdlet does not connect to the database or validate table existence; it only builds query objects or SQL text.

--- a/Module/Docs/New-DbaXTableCopyDefinition.md
+++ b/Module/Docs/New-DbaXTableCopyDefinition.md
@@ -1,0 +1,204 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# New-DbaXTableCopyDefinition
+## SYNOPSIS
+Creates a DbaClientX table-copy definition.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-DbaXTableCopyDefinition -SourceName <string> -DestinationName <string> [-LogicalName <string>] [-OrderByColumns <string[]>] [-ColumnMappings <hashtable>] [-ExcludedColumns <string[]>] [-ColumnTypeConversions <hashtable>] [-DeduplicateByColumns <string[]>] [-DeduplicateOrderByColumns <string[]>] [-DeduplicateCaseInsensitive] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Creates a DbaClientX table-copy definition.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> New-DbaXTableCopyDefinition -SourceName dbo.Users -DestinationName archive.Users -OrderByColumns Id
+```
+
+Returns a typed copy definition that can be passed to DbaClientX data movement APIs.
+
+## PARAMETERS
+
+### -ColumnMappings
+Optional source column to destination column mappings.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ColumnTypeConversions
+Optional destination column type conversions.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeduplicateByColumns
+Optional source columns used for source-side deduplication.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeduplicateCaseInsensitive
+Uses case-insensitive source-side deduplication.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DeduplicateOrderByColumns
+Optional source order columns used to choose rows during deduplication.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationName
+Destination table name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludedColumns
+Optional columns to exclude from copy pages.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LogicalName
+Optional logical display name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OrderByColumns
+Optional source-side order columns for paged reads.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceName
+Source table or view name.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/New-DbaXTableCopyPlan.md
+++ b/Module/Docs/New-DbaXTableCopyPlan.md
@@ -1,0 +1,300 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# New-DbaXTableCopyPlan
+## SYNOPSIS
+Builds a table-copy plan from supplied DbaClientX metadata objects.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+New-DbaXTableCopyPlan -SourceTables <DbaTableInfo[]> -SourceColumns <DbaColumnInfo[]> [-SourceIndexes <DbaIndexInfo[]>] [-DestinationColumns <DbaColumnInfo[]>] [-Provider <DbaXProvider>] [-SourceSchema <string>] [-DestinationSchema <string>] [-IncludeViews] [-TableMappings <hashtable>] [-ColumnMappings <hashtable>] [-ExcludedColumns <string[]>] [-ColumnTypeConversions <hashtable>] [-IncludeDestinationIdentityColumns] [-IncludeSourceGeneratedColumns] [-IncludeDestinationGeneratedColumns] [-SkipDestinationColumnMatch] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Builds a table-copy plan from supplied DbaClientX metadata objects.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> New-DbaXTableCopyPlan -SourceTables $tables -SourceColumns $columns -Provider SqlServer -DestinationSchema archive
+```
+
+Calls the shared DbaClientX table-copy planner.
+
+## PARAMETERS
+
+### -ColumnMappings
+Optional global source column to destination column mappings.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ColumnTypeConversions
+Optional global column type conversions.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationColumns
+Optional destination column metadata.
+
+```yaml
+Type: DbaColumnInfo[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationSchema
+Destination schema used for generated destination names.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludedColumns
+Optional global excluded columns.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeDestinationGeneratedColumns
+Includes destination generated columns in generated pages.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeDestinationIdentityColumns
+Includes destination identity columns in generated pages.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeSourceGeneratedColumns
+Includes source generated columns in generated pages.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeViews
+Includes views in generated copy definitions.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Provider
+Provider whose identifier folding rules should be used.
+
+```yaml
+Type: DbaXProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipDestinationColumnMatch
+Does not require source columns to exist in destination metadata.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceColumns
+Source column metadata.
+
+```yaml
+Type: DbaColumnInfo[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceIndexes
+Optional source index metadata.
+
+```yaml
+Type: DbaIndexInfo[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceSchema
+Restricts source tables to a schema.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SourceTables
+Source table metadata.
+
+```yaml
+Type: DbaTableInfo[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TableMappings
+Optional source table to destination table mappings.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -1,0 +1,122 @@
+---
+Module Name: DbaClientX
+Module Guid: c22cc272-c829-49e2-aaa1-58d3c36edb94
+Download Help Link: https://github.com/EvotecIT/DbaClientX
+Help Version: 1.0.6
+Locale: en-US
+---
+# DbaClientX Module
+## Description
+Simple project to query Sql Server and other databases using PowerShell
+
+## DbaClientX Cmdlets
+### [ConvertTo-DbaXParameterMap](ConvertTo-DbaXParameterMap.md)
+Converts objects into provider parameter dictionaries using the DbaClientX parameter mapper.
+
+### [Copy-DbaXAzureTableData](Copy-DbaXAzureTableData.md)
+Copies Azure Table data between storage accounts or Table API endpoints.
+
+### [Copy-DbaXTableData](Copy-DbaXTableData.md)
+Copies table data from one DbaClientX provider connection to another using paged reads and provider-native bulk writes.
+
+### [Get-DbaXAzureTableEntity](Get-DbaXAzureTableEntity.md)
+Reads Azure Table entities with native continuation-token paging.
+
+### [Get-DbaXMetadata](Get-DbaXMetadata.md)
+Gets database metadata without requiring SQL Server Management Objects.
+
+### [Get-DbaXProviderCapability](Get-DbaXProviderCapability.md)
+Gets the capabilities exposed by DbaClientX providers.
+
+### [Get-DbaXSQLiteDiagnostics](Get-DbaXSQLiteDiagnostics.md)
+Collects SQLite file and database diagnostics through the DbaClientX SQLite provider.
+
+### [Get-DbaXSqlServerManagement](Get-DbaXSqlServerManagement.md)
+Gets SQL Server-specific management metadata without requiring SQL Server Management Objects.
+
+### [Get-DbaXSqlServerMonitoring](Get-DbaXSqlServerMonitoring.md)
+Collects a SQL Server monitoring snapshot through the DbaClientX SQL Server provider.
+
+### [Get-DbaXTableCopyPlan](Get-DbaXTableCopyPlan.md)
+Discovers provider metadata and builds a DbaClientX table-copy plan.
+
+### [Invoke-DbaXBulkInsert](Invoke-DbaXBulkInsert.md)
+Invokes a provider-native DbaClientX bulk insert from tabular PowerShell input.
+
+### [Invoke-DbaXMySql](Invoke-DbaXMySql.md)
+Invokes commands against a MySQL database.
+
+### [Invoke-DbaXMySqlNonQuery](Invoke-DbaXMySqlNonQuery.md)
+Executes a non-query SQL command against MySQL.
+
+### [Invoke-DbaXMySqlScalar](Invoke-DbaXMySqlScalar.md)
+Executes a scalar SQL query against MySQL.
+
+### [Invoke-DbaXMySqlTransaction](Invoke-DbaXMySqlTransaction.md)
+Runs a script block inside a MySQL transaction.
+
+### [Invoke-DbaXNonQuery](Invoke-DbaXNonQuery.md)
+Executes a non-query SQL command against SQL Server.
+
+### [Invoke-DbaXOracle](Invoke-DbaXOracle.md)
+Invokes commands against an Oracle database.
+
+### [Invoke-DbaXOracleNonQuery](Invoke-DbaXOracleNonQuery.md)
+Executes a non-query SQL command against Oracle.
+
+### [Invoke-DbaXOracleScalar](Invoke-DbaXOracleScalar.md)
+Executes a scalar SQL query against Oracle.
+
+### [Invoke-DbaXOracleTransaction](Invoke-DbaXOracleTransaction.md)
+Runs a script block inside an Oracle transaction.
+
+### [Invoke-DbaXPostgreSql](Invoke-DbaXPostgreSql.md)
+Invokes commands against a PostgreSQL database.
+
+### [Invoke-DbaXPostgreSqlNonQuery](Invoke-DbaXPostgreSqlNonQuery.md)
+Executes a non-query SQL command against PostgreSQL.
+
+### [Invoke-DbaXPostgreSqlTransaction](Invoke-DbaXPostgreSqlTransaction.md)
+Runs a script block inside a PostgreSQL transaction.
+
+### [Invoke-DbaXQuery](Invoke-DbaXQuery.md)
+Invokes a SQL Server query or stored procedure.
+
+### [Invoke-DbaXQueryStream](Invoke-DbaXQueryStream.md)
+Streams query rows through a DbaClientX provider.
+
+### [Invoke-DbaXSQLite](Invoke-DbaXSQLite.md)
+Invokes a query against a SQLite database.
+
+### [Invoke-DbaXSQLiteMaintenance](Invoke-DbaXSQLiteMaintenance.md)
+Runs SQLite maintenance operations through the DbaClientX SQLite provider.
+
+### [Invoke-DbaXSQLiteTransaction](Invoke-DbaXSQLiteTransaction.md)
+Runs a script block inside a SQLite transaction.
+
+### [Invoke-DbaXStoredProcedure](Invoke-DbaXStoredProcedure.md)
+Invokes a stored procedure through a DbaClientX provider.
+
+### [Invoke-DbaXTransaction](Invoke-DbaXTransaction.md)
+Runs a script block inside a SQL Server transaction.
+
+### [New-DbaXConnectionString](New-DbaXConnectionString.md)
+Builds a provider connection string using the matching DbaClientX C# provider.
+
+### [New-DbaXQuery](New-DbaXQuery.md)
+Creates SQL query-builder objects using the DbaClientX core query builder.
+
+### [New-DbaXTableCopyDefinition](New-DbaXTableCopyDefinition.md)
+Creates a DbaClientX table-copy definition.
+
+### [New-DbaXTableCopyPlan](New-DbaXTableCopyPlan.md)
+Builds a table-copy plan from supplied DbaClientX metadata objects.
+
+### [Test-DbaXConnection](Test-DbaXConnection.md)
+Validates and optionally pings a DbaClientX provider connection string.
+
+### [Write-DbaXAzureTableEntity](Write-DbaXAzureTableEntity.md)
+Writes PowerShell pipeline objects to Azure Tables in partition-safe transactions.
+
+### [Write-DbaXTableData](Write-DbaXTableData.md)
+Writes tabular pipeline input to a database table using provider-native bulk insert APIs.

--- a/Module/Docs/Test-DbaXConnection.md
+++ b/Module/Docs/Test-DbaXConnection.md
@@ -1,0 +1,108 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Test-DbaXConnection
+## SYNOPSIS
+Validates and optionally pings a DbaClientX provider connection string.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Test-DbaXConnection [-Provider] <DbaXProvider> [-ConnectionString] <string> [-SkipPing] [-Detailed] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Validates and optionally pings a DbaClientX provider connection string.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Test-DbaXConnection -Provider SqlServer -ConnectionString 'Server=.;Database=master;Integrated Security=True;Encrypt=True;TrustServerCertificate=True' -Detailed
+```
+
+Returns validation and ping details for the supplied SQL Server connection string.
+
+## PARAMETERS
+
+### -ConnectionString
+Provider connection string, or a SQLite database path.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Detailed
+Return a detailed result object instead of a Boolean.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Provider
+Database provider used to validate the connection string.
+
+```yaml
+Type: DbaXProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SkipPing
+Only validate connection-string shape and skip opening a provider connection.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Write-DbaXAzureTableEntity.md
+++ b/Module/Docs/Write-DbaXAzureTableEntity.md
@@ -1,0 +1,156 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Write-DbaXAzureTableEntity
+## SYNOPSIS
+Writes PowerShell pipeline objects to Azure Tables in partition-safe transactions.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Write-DbaXAzureTableEntity -ConnectionString <string> -TableName <string> -InputObject <Object> [-WriteMode <DbaAzureTableWriteMode>] [-BatchSize <int>] [-NoCreateTable] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Input must expose PartitionKey and RowKey properties. Each Azure transaction contains at most 100 entities and stays inside one partition.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> $rows | Write-DbaXAzureTableEntity -ConnectionString $connectionString -TableName Reports -WriteMode UpsertReplace -PassThru
+```
+
+Creates the table when needed and replaces matching entities.
+
+## PARAMETERS
+
+### -BatchSize
+Maximum entities per same-partition transaction.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectionString
+Azure Storage or Cosmos DB Table API connection string.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+Objects containing PartitionKey, RowKey, and optional entity properties.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -NoCreateTable
+Do not create the destination table when it is missing.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+Return a summary after the write.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TableName
+Destination table.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WriteMode
+Azure entity write mode.
+
+```yaml
+Type: DbaAzureTableWriteMode
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: Add, UpsertMerge, UpsertReplace
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.Object`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/Docs/Write-DbaXTableData.md
+++ b/Module/Docs/Write-DbaXTableData.md
@@ -1,0 +1,298 @@
+---
+external help file: DbaClientX-help.xml
+Module Name: DbaClientX
+online version: https://github.com/EvotecIT/DbaClientX
+schema: 2.0.0
+---
+# Write-DbaXTableData
+## SYNOPSIS
+Writes tabular pipeline input to a database table using provider-native bulk insert APIs.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Write-DbaXTableData -Provider <DbaXBulkProvider> -ConnectionString <string> -DestinationTable <string> -InputObject <Object> [-BatchSize <Int32>] [-BulkCopyTimeout <Int32>] [-ColumnMap <hashtable>] [-TableLock] [-CheckConstraints] [-FireTriggers] [-KeepIdentity] [-KeepNulls] [-AutoCreateTable] [-NotifyAfter <Int32>] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Accepts a DataTable, DataView, IDataReader, DataRow pipeline, or regular PowerShell objects and routes the resulting table to the selected DbaClientX provider.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Import-OfficeExcel .\Data.xlsx -AsDataTable | Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=.;Database=App;Encrypt=True;TrustServerCertificate=True;Integrated Security=True' -DestinationTable dbo.Import
+```
+
+Loads the workbook rows as a DataTable and sends them through the SQL Server bulk-copy provider.
+
+### EXAMPLE 2
+```powershell
+PS> $rows | Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=.;Database=App;Encrypt=True;TrustServerCertificate=True;Integrated Security=True' -DestinationTable staging.Import -AutoCreateTable -TableLock
+```
+
+Creates the destination schema and table when needed, then writes the rows through SQL Server bulk copy.
+
+### EXAMPLE 3
+```powershell
+PS> $rows | Write-DbaXTableData -Provider PostgreSql -ConnectionString 'Host=localhost;Database=app;Username=user;Password=secret;SslMode=Require' -DestinationTable public.import_data -BatchSize 5000
+```
+
+Converts the objects to a DataTable and writes them with the PostgreSQL COPY-backed provider.
+
+## PARAMETERS
+
+### -AutoCreateTable
+SQL Server-only option to create the destination schema and table when they do not already exist.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BatchSize
+Optional number of rows per provider bulk batch.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BulkCopyTimeout
+Optional provider bulk-copy timeout in seconds. SQLite does not support this option.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CheckConstraints
+SQL Server-only option to check destination constraints during the copy.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ColumnMap
+SQL Server-only mapping from source column names to destination column names.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectionString
+Provider connection string used for the bulk insert.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DestinationTable
+Destination table name. Include schema or owner when required by the provider.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FireTriggers
+SQL Server-only option to fire insert triggers during the copy.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+Tabular input to write. Accepts DataTable, DataView, IDataReader, DataRow, hashtable, and object pipeline input.
+
+```yaml
+Type: Object
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -KeepIdentity
+SQL Server-only option to preserve identity values from the source data.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -KeepNulls
+SQL Server-only option to preserve null values from the source data.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NotifyAfter
+SQL Server-only number of rows copied between progress updates.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PassThru
+Writes a small result object with provider, destination table, and row count.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Provider
+Database provider that should receive the bulk insert.
+
+```yaml
+Type: DbaXBulkProvider
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: SqlServer, PostgreSql, MySql, Oracle, SQLite
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TableLock
+SQL Server-only option to acquire a bulk update lock for the duration of the copy.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.Object`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Module/en-US/DbaClientX-help.xml
+++ b/Module/en-US/DbaClientX-help.xml
@@ -1,0 +1,11587 @@
+<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>ConvertTo-DbaXParameterMap</command:name>
+      <command:verb>ConvertTo</command:verb>
+      <command:noun>DbaXParameterMap</command:noun>
+      <maml:description>
+        <maml:para>Converts objects into provider parameter dictionaries using the DbaClientX parameter mapper.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Converts objects into provider parameter dictionaries using the DbaClientX parameter mapper.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>ConvertTo-DbaXParameterMap</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Ambient</maml:name>
+          <maml:description>
+            <maml:para>Optional ambient values used when the input object does not contain a mapped property.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EnumsAsString</maml:name>
+          <maml:description>
+            <maml:para>Converts enum values to strings rather than their underlying numeric value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>InputObject</maml:name>
+          <maml:description>
+            <maml:para>Input object whose properties should be mapped to provider parameters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Map</maml:name>
+          <maml:description>
+            <maml:para>Logical property name to provider parameter name map.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PreserveDateTimeOffset</maml:name>
+          <maml:description>
+            <maml:para>Preserves DateTimeOffset values instead of converting them to UTC DateTime values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Ambient</maml:name>
+        <maml:description>
+          <maml:para>Optional ambient values used when the input object does not contain a mapped property.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>EnumsAsString</maml:name>
+        <maml:description>
+          <maml:para>Converts enum values to strings rather than their underlying numeric value.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>InputObject</maml:name>
+        <maml:description>
+          <maml:para>Input object whose properties should be mapped to provider parameters.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Map</maml:name>
+        <maml:description>
+          <maml:para>Logical property name to provider parameter name map.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PreserveDateTimeOffset</maml:name>
+        <maml:description>
+          <maml:para>Preserves DateTimeOffset values instead of converting them to UTC DateTime values.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Map object properties to SQL parameters.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>[pscustomobject]@{ UserName = 'Ada' } | ConvertTo-DbaXParameterMap -Map @{ UserName = '@UserName' }</dev:code>
+        <dev:remarks>
+          <maml:para>Returns a dictionary containing the provider parameter name and value.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Copy-DbaXAzureTableData</command:name>
+      <command:verb>Copy</command:verb>
+      <command:noun>DbaXAzureTableData</command:noun>
+      <maml:description>
+        <maml:para>Copies Azure Table data between storage accounts or Table API endpoints.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Copies Azure Table data between storage accounts or Table API endpoints.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Copy-DbaXAzureTableData</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Maximum entities per same-partition destination transaction.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClearDestination</maml:name>
+          <maml:description>
+            <maml:para>Clear existing destination entities before copying.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Destination Azure Storage or Cosmos DB Table API connection string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationTable</maml:name>
+          <maml:description>
+            <maml:para>Destination table.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>Optional source OData filter.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoCreateTable</maml:name>
+          <maml:description>
+            <maml:para>Do not create the destination table when it is missing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoVerify</maml:name>
+          <maml:description>
+            <maml:para>Skip source and destination row-count scans.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>Entities requested per source page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PassThru</maml:name>
+          <maml:description>
+            <maml:para>Return the copy result.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Select</maml:name>
+          <maml:description>
+            <maml:para>Optional source property projection. PartitionKey and RowKey are always copied.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Source Azure Storage or Cosmos DB Table API connection string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceTable</maml:name>
+          <maml:description>
+            <maml:para>Source table.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WriteMode</maml:name>
+          <maml:description>
+            <maml:para>Destination write behavior.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DbaAzureTableWriteMode</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Add</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UpsertMerge</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UpsertReplace</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaAzureTableWriteMode</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BatchSize</maml:name>
+        <maml:description>
+          <maml:para>Maximum entities per same-partition destination transaction.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ClearDestination</maml:name>
+        <maml:description>
+          <maml:para>Clear existing destination entities before copying.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Destination Azure Storage or Cosmos DB Table API connection string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationTable</maml:name>
+        <maml:description>
+          <maml:para>Destination table.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Filter</maml:name>
+        <maml:description>
+          <maml:para>Optional source OData filter.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoCreateTable</maml:name>
+        <maml:description>
+          <maml:para>Do not create the destination table when it is missing.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoVerify</maml:name>
+        <maml:description>
+          <maml:para>Skip source and destination row-count scans.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>Entities requested per source page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PassThru</maml:name>
+        <maml:description>
+          <maml:para>Return the copy result.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Select</maml:name>
+        <maml:description>
+          <maml:para>Optional source property projection. PartitionKey and RowKey are always copied.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Source Azure Storage or Cosmos DB Table API connection string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceTable</maml:name>
+        <maml:description>
+          <maml:para>Source table.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WriteMode</maml:name>
+        <maml:description>
+          <maml:para>Destination write behavior.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DbaAzureTableWriteMode</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Add</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">UpsertMerge</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">UpsertReplace</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaAzureTableWriteMode</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Copy a filtered table into an archive account.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Copy-DbaXAzureTableData -SourceConnectionString $source -DestinationConnectionString $destination -SourceTable Reports -DestinationTable ReportsArchive -Filter "PartitionKey eq 'daily'" -PassThru</dev:code>
+        <dev:remarks>
+          <maml:para>Streams pages through the provider-neutral DbaClientX copy engine and verifies row counts.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Copy-DbaXTableData</command:name>
+      <command:verb>Copy</command:verb>
+      <command:noun>DbaXTableData</command:noun>
+      <maml:description>
+        <maml:para>Copies table data from one DbaClientX provider connection to another using paged reads and provider-native bulk writes.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Use this cmdlet for table-to-table imports, exports, and migrations across SQL Server, PostgreSQL, MySQL, Oracle, and SQLite. The reusable copy orchestration lives in DbaClientX.Core while this cmdlet supplies PowerShell-friendly parameters and progress output.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Copy-DbaXTableData</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AllowSameTableCopy</maml:name>
+          <maml:description>
+            <maml:para>Allows copying from and to the same provider database table. Use only when intentionally owning the consequences.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AllowUnordered</maml:name>
+          <maml:description>
+            <maml:para>Allows paged copies without an explicit order. Use only for ad hoc copies where provider natural order is acceptable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Optional number of rows per provider bulk-write batch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BooleanColumn</maml:name>
+          <maml:description>
+            <maml:para>Column names converted to Boolean values before bulk writing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BulkCopyTimeout</maml:name>
+          <maml:description>
+            <maml:para>Optional provider bulk-copy timeout in seconds. SQLite destinations do not support this option.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckConstraints</maml:name>
+          <maml:description>
+            <maml:para>SQL Server destination option to check destination constraints during each bulk copy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClearDestination</maml:name>
+          <maml:description>
+            <maml:para>Deletes destination table rows before copying source rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ColumnMap</maml:name>
+          <maml:description>
+            <maml:para>Mapping from source column names to destination column names.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DateTimeColumn</maml:name>
+          <maml:description>
+            <maml:para>Column names converted to DateTime values before bulk writing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DecimalColumn</maml:name>
+          <maml:description>
+            <maml:para>Column names converted to Decimal values before bulk writing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DeduplicateSourceBy</maml:name>
+          <maml:description>
+            <maml:para>Source key columns used to keep one effective row per key before copying.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DeduplicateSourceCaseInsensitive</maml:name>
+          <maml:description>
+            <maml:para>Uses case-insensitive source keys when deduplicating source rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DeduplicateSourceOrderBy</maml:name>
+          <maml:description>
+            <maml:para>Source columns used to choose the winning row for each deduplicated source key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>Definition</maml:name>
+          <maml:description>
+            <maml:para>Reusable table copy definitions to execute. Use this for multi-table plans generated by DbaClientX.Core.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DbaTableCopyDefinition[]</command:parameterValue>
+          <dev:type>
+            <maml:name>DbaTableCopyDefinition[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Connection string used to write destination rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationFabricWarehouse</maml:name>
+          <maml:description>
+            <maml:para>Applies Microsoft Fabric Warehouse TDS and direct bulk-copy compatibility validation to a SQL Server destination.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationProvider</maml:name>
+          <maml:description>
+            <maml:para>Provider used to write destination rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXBulkProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXBulkProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationTable</maml:name>
+          <maml:description>
+            <maml:para>Destination table name. Include schema or owner when required by the provider.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExcludeColumn</maml:name>
+          <maml:description>
+            <maml:para>Source column names excluded from destination pages before bulk writing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FireTriggers</maml:name>
+          <maml:description>
+            <maml:para>SQL Server destination option to fire insert triggers during each bulk copy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Int32Column</maml:name>
+          <maml:description>
+            <maml:para>Column names converted to Int32 values before bulk writing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Int64Column</maml:name>
+          <maml:description>
+            <maml:para>Column names converted to Int64 values before bulk writing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>KeepIdentity</maml:name>
+          <maml:description>
+            <maml:para>SQL Server destination option to preserve identity values from the source data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>KeepNulls</maml:name>
+          <maml:description>
+            <maml:para>SQL Server destination option to preserve null values from the source data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoVerify</maml:name>
+          <maml:description>
+            <maml:para>Skips source and destination row-count verification after the copy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OperationId</maml:name>
+          <maml:description>
+            <maml:para>Optional non-zero 32-character W3C trace identifier used to correlate this copy with downstream workflows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OrderBy</maml:name>
+          <maml:description>
+            <maml:para>Column names used to order paged source reads. Provide stable key columns for deterministic copies.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>Number of rows read from the source per page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PassThru</maml:name>
+          <maml:description>
+            <maml:para>Writes a result object with copied table counts, verification state, and elapsed time.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Connection string used to read source rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceFabricWarehouse</maml:name>
+          <maml:description>
+            <maml:para>Applies Microsoft Fabric Warehouse TDS compatibility validation to a SQL Server source.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceProvider</maml:name>
+          <maml:description>
+            <maml:para>Provider used to read source rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXBulkProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXBulkProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceTable</maml:name>
+          <maml:description>
+            <maml:para>Source table name. Include schema or owner when required by the provider.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>StringColumn</maml:name>
+          <maml:description>
+            <maml:para>Column names converted to String values before bulk writing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TableLock</maml:name>
+          <maml:description>
+            <maml:para>SQL Server destination option to acquire a bulk update lock for the duration of each bulk copy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TreatMissingTablesAsEmpty</maml:name>
+          <maml:description>
+            <maml:para>Treats missing source or destination tables as empty during row counts and clear operations.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AllowSameTableCopy</maml:name>
+        <maml:description>
+          <maml:para>Allows copying from and to the same provider database table. Use only when intentionally owning the consequences.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AllowUnordered</maml:name>
+        <maml:description>
+          <maml:para>Allows paged copies without an explicit order. Use only for ad hoc copies where provider natural order is acceptable.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BatchSize</maml:name>
+        <maml:description>
+          <maml:para>Optional number of rows per provider bulk-write batch.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BooleanColumn</maml:name>
+        <maml:description>
+          <maml:para>Column names converted to Boolean values before bulk writing.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BulkCopyTimeout</maml:name>
+        <maml:description>
+          <maml:para>Optional provider bulk-copy timeout in seconds. SQLite destinations do not support this option.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CheckConstraints</maml:name>
+        <maml:description>
+          <maml:para>SQL Server destination option to check destination constraints during each bulk copy.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ClearDestination</maml:name>
+        <maml:description>
+          <maml:para>Deletes destination table rows before copying source rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ColumnMap</maml:name>
+        <maml:description>
+          <maml:para>Mapping from source column names to destination column names.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DateTimeColumn</maml:name>
+        <maml:description>
+          <maml:para>Column names converted to DateTime values before bulk writing.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DecimalColumn</maml:name>
+        <maml:description>
+          <maml:para>Column names converted to Decimal values before bulk writing.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DeduplicateSourceBy</maml:name>
+        <maml:description>
+          <maml:para>Source key columns used to keep one effective row per key before copying.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DeduplicateSourceCaseInsensitive</maml:name>
+        <maml:description>
+          <maml:para>Uses case-insensitive source keys when deduplicating source rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DeduplicateSourceOrderBy</maml:name>
+        <maml:description>
+          <maml:para>Source columns used to choose the winning row for each deduplicated source key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>Definition</maml:name>
+        <maml:description>
+          <maml:para>Reusable table copy definitions to execute. Use this for multi-table plans generated by DbaClientX.Core.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DbaTableCopyDefinition[]</command:parameterValue>
+        <dev:type>
+          <maml:name>DbaTableCopyDefinition[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Connection string used to write destination rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationFabricWarehouse</maml:name>
+        <maml:description>
+          <maml:para>Applies Microsoft Fabric Warehouse TDS and direct bulk-copy compatibility validation to a SQL Server destination.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationProvider</maml:name>
+        <maml:description>
+          <maml:para>Provider used to write destination rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXBulkProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXBulkProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationTable</maml:name>
+        <maml:description>
+          <maml:para>Destination table name. Include schema or owner when required by the provider.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExcludeColumn</maml:name>
+        <maml:description>
+          <maml:para>Source column names excluded from destination pages before bulk writing.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FireTriggers</maml:name>
+        <maml:description>
+          <maml:para>SQL Server destination option to fire insert triggers during each bulk copy.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Int32Column</maml:name>
+        <maml:description>
+          <maml:para>Column names converted to Int32 values before bulk writing.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Int64Column</maml:name>
+        <maml:description>
+          <maml:para>Column names converted to Int64 values before bulk writing.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>KeepIdentity</maml:name>
+        <maml:description>
+          <maml:para>SQL Server destination option to preserve identity values from the source data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>KeepNulls</maml:name>
+        <maml:description>
+          <maml:para>SQL Server destination option to preserve null values from the source data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoVerify</maml:name>
+        <maml:description>
+          <maml:para>Skips source and destination row-count verification after the copy.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OperationId</maml:name>
+        <maml:description>
+          <maml:para>Optional non-zero 32-character W3C trace identifier used to correlate this copy with downstream workflows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OrderBy</maml:name>
+        <maml:description>
+          <maml:para>Column names used to order paged source reads. Provide stable key columns for deterministic copies.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>Number of rows read from the source per page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PassThru</maml:name>
+        <maml:description>
+          <maml:para>Writes a result object with copied table counts, verification state, and elapsed time.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Connection string used to read source rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceFabricWarehouse</maml:name>
+        <maml:description>
+          <maml:para>Applies Microsoft Fabric Warehouse TDS compatibility validation to a SQL Server source.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceProvider</maml:name>
+        <maml:description>
+          <maml:para>Provider used to read source rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXBulkProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXBulkProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceTable</maml:name>
+        <maml:description>
+          <maml:para>Source table name. Include schema or owner when required by the provider.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>StringColumn</maml:name>
+        <maml:description>
+          <maml:para>Column names converted to String values before bulk writing.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TableLock</maml:name>
+        <maml:description>
+          <maml:para>SQL Server destination option to acquire a bulk update lock for the duration of each bulk copy.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TreatMissingTablesAsEmpty</maml:name>
+        <maml:description>
+          <maml:para>Treats missing source or destination tables as empty during row counts and clear operations.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>DBAClientX.DataMovement.DbaTableCopyDefinition[]</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Copy SQLite history rows into SQL Server.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Copy-DbaXTableData -SourceProvider SQLite -SourceConnectionString 'Data Source=C:\Data\history.db' -SourceTable ProbeResults -DestinationProvider SqlServer -DestinationConnectionString 'Server=.;Database=History;Encrypt=True;TrustServerCertificate=True;Integrated Security=True' -DestinationTable dbo.ProbeResults -OrderBy Id -PageSize 10000 -BatchSize 5000 -ClearDestination -PassThru</dev:code>
+        <dev:remarks>
+          <maml:para>Reads the SQLite table in deterministic pages and writes each page through SQL Server bulk copy.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Copy between same-shaped staging tables.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Copy-DbaXTableData -SourceProvider SqlServer -SourceConnectionString $source -SourceTable staging.Customers -DestinationProvider PostgreSql -DestinationConnectionString $dest -DestinationTable public.customers -OrderBy CustomerId -PageSize 25000 -PassThru</dev:code>
+        <dev:remarks>
+          <maml:para>Copies all rows from SQL Server into PostgreSQL using provider-native read and write paths.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Copy several planned tables.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$definitions | Copy-DbaXTableData -SourceProvider SQLite -SourceConnectionString $source -DestinationProvider SqlServer -DestinationConnectionString $dest -BatchSize 5000 -PassThru</dev:code>
+        <dev:remarks>
+          <maml:para>Runs reusable DbaTableCopyDefinition objects produced by .NET planning code or constructed directly in PowerShell.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-DbaXAzureTableEntity</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DbaXAzureTableEntity</command:noun>
+      <maml:description>
+        <maml:para>Reads Azure Table entities with native continuation-token paging.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Reads Azure Table entities with native continuation-token paging.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-DbaXAzureTableEntity</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AsPage</maml:name>
+          <maml:description>
+            <maml:para>Return page envelopes instead of enumerating individual entities.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Azure Storage or Cosmos DB Table API connection string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ContinuationToken</maml:name>
+          <maml:description>
+            <maml:para>Optional token at which to resume the query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Filter</maml:name>
+          <maml:description>
+            <maml:para>Optional OData filter.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>Maximum entities requested from Azure per page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Select</maml:name>
+          <maml:description>
+            <maml:para>Optional property projection. PartitionKey and RowKey are always included.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TableName</maml:name>
+          <maml:description>
+            <maml:para>Table to query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AsPage</maml:name>
+        <maml:description>
+          <maml:para>Return page envelopes instead of enumerating individual entities.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Azure Storage or Cosmos DB Table API connection string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ContinuationToken</maml:name>
+        <maml:description>
+          <maml:para>Optional token at which to resume the query.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Filter</maml:name>
+        <maml:description>
+          <maml:para>Optional OData filter.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>Maximum entities requested from Azure per page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Select</maml:name>
+        <maml:description>
+          <maml:para>Optional property projection. PartitionKey and RowKey are always included.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TableName</maml:name>
+        <maml:description>
+          <maml:para>Table to query.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>DBAClientX.AzureTables.DbaAzureTableEntity</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>DBAClientX.AzureTables.DbaAzureTablePage</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Read all entities in one partition.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-DbaXAzureTableEntity -ConnectionString $connectionString -TableName Reports -Filter "PartitionKey eq 'daily'"</dev:code>
+        <dev:remarks>
+          <maml:para>Streams matching entities while following Azure continuation tokens internally.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Return page envelopes for checkpointed processing.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-DbaXAzureTableEntity -ConnectionString $connectionString -TableName Reports -PageSize 500 -AsPage</dev:code>
+        <dev:remarks>
+          <maml:para>Returns each page with its opaque continuation token.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-DbaXMetadata</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DbaXMetadata</command:noun>
+      <maml:description>
+        <maml:para>Gets database metadata without requiring SQL Server Management Objects.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Returns provider-neutral metadata for databases, tables/views, columns, indexes, foreign keys, and routines using native catalog queries from the selected provider.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-DbaXMetadata</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="2" aliases="None">
+          <maml:name>ConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Specifies a provider connection string, or a SQLite database path when Provider is SQLite.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExcludeViews</maml:name>
+          <maml:description>
+            <maml:para>Excludes views when requesting table metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Provider</maml:name>
+          <maml:description>
+            <maml:para>Specifies the database provider.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Schema</maml:name>
+          <maml:description>
+            <maml:para>Optional schema or owner filter where the selected provider supports schemas.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Table</maml:name>
+          <maml:description>
+            <maml:para>Optional table filter for column, index, and foreign key metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Selects the metadata type to return.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXMetadataType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Database</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Table</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Column</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Index</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ForeignKey</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Routine</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXMetadataType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="2" aliases="None">
+        <maml:name>ConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Specifies a provider connection string, or a SQLite database path when Provider is SQLite.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExcludeViews</maml:name>
+        <maml:description>
+          <maml:para>Excludes views when requesting table metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Provider</maml:name>
+        <maml:description>
+          <maml:para>Specifies the database provider.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Schema</maml:name>
+        <maml:description>
+          <maml:para>Optional schema or owner filter where the selected provider supports schemas.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Table</maml:name>
+        <maml:description>
+          <maml:para>Optional table filter for column, index, and foreign key metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>Selects the metadata type to return.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXMetadataType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Database</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Table</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Column</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Index</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ForeignKey</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Routine</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXMetadataType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>List SQL Server tables.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-DbaXMetadata -Provider SqlServer -Type Table -ConnectionString 'Server=.;Database=master;Integrated Security=True;Encrypt=True;TrustServerCertificate=True'</dev:code>
+        <dev:remarks>
+          <maml:para>Lists tables and views visible through the supplied SQL Server connection.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>List SQLite columns for one table.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-DbaXMetadata -Provider SQLite -Type Column -ConnectionString '.\app.db' -Table Users</dev:code>
+        <dev:remarks>
+          <maml:para>Returns column metadata for the Users table in the SQLite database file.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-DbaXProviderCapability</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DbaXProviderCapability</command:noun>
+      <maml:description>
+        <maml:para>Gets the capabilities exposed by DbaClientX providers.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Gets the capabilities exposed by DbaClientX providers.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-DbaXProviderCapability</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Provider</maml:name>
+          <maml:description>
+            <maml:para>Optional provider filter.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DbaXProvider[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXProvider[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Provider</maml:name>
+        <maml:description>
+          <maml:para>Optional provider filter.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DbaXProvider[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXProvider[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>List all provider capabilities.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-DbaXProviderCapability</dev:code>
+        <dev:remarks>
+          <maml:para>Returns one object per supported provider.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-DbaXSQLiteDiagnostics</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DbaXSQLiteDiagnostics</command:noun>
+      <maml:description>
+        <maml:para>Collects SQLite file and database diagnostics through the DbaClientX SQLite provider.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Collects SQLite file and database diagnostics through the DbaClientX SQLite provider.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-DbaXSQLiteDiagnostics</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BusyTimeoutMs</maml:name>
+          <maml:description>
+            <maml:para>Optional busy timeout in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="Path,ConnectionString">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>SQLite database path or SQLite connection string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BusyTimeoutMs</maml:name>
+        <maml:description>
+          <maml:para>Optional busy timeout in milliseconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="Path,ConnectionString">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>SQLite database path or SQLite connection string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Inspect a SQLite database.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-DbaXSQLiteDiagnostics -Database .\app.db</dev:code>
+        <dev:remarks>
+          <maml:para>Returns file, integrity, journal, and SQLite version diagnostics.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-DbaXSqlServerManagement</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DbaXSqlServerManagement</command:noun>
+      <maml:description>
+        <maml:para>Gets SQL Server-specific management metadata without requiring SQL Server Management Objects.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Returns SQL Server Agent, security, dependency, scripting, copy-plan, inventory, instance property, and configuration metadata using native SQL Server catalog queries.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-DbaXSqlServerManagement</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>ConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Specifies a SQL Server connection string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationSchema</maml:name>
+          <maml:description>
+            <maml:para>Destination schema name for table copy plans.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationTable</maml:name>
+          <maml:description>
+            <maml:para>Destination table name for table copy plans.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeAdvanced</maml:name>
+          <maml:description>
+            <maml:para>Includes advanced SQL Server configuration values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeDisabled</maml:name>
+          <maml:description>
+            <maml:para>Includes disabled SQL Server Agent jobs or schedules where applicable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeSystem</maml:name>
+          <maml:description>
+            <maml:para>Includes system principals where applicable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MemberName</maml:name>
+          <maml:description>
+            <maml:para>Optional member name filter for role membership metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Name</maml:name>
+          <maml:description>
+            <maml:para>Optional name filter used by Agent jobs, principals, instance properties, and configurations.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PrincipalName</maml:name>
+          <maml:description>
+            <maml:para>Optional grantee principal name filter for permission metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>RoleName</maml:name>
+          <maml:description>
+            <maml:para>Optional role name filter for role membership metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Schema</maml:name>
+          <maml:description>
+            <maml:para>Optional schema filter used by dependency, scripting, and copy-plan metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Table</maml:name>
+          <maml:description>
+            <maml:para>Source table name for table copy plans.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Selects the SQL Server management metadata type to return.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXSqlServerManagementType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">AgentJob</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AgentJobStep</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AgentSchedule</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ServerPrincipal</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DatabasePrincipal</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RoleMembership</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Permission</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">InstanceProperty</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Configuration</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dependency</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ModuleScript</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TableScript</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TableCopyPlan</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Inventory</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXSqlServerManagementType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>ConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Specifies a SQL Server connection string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationSchema</maml:name>
+        <maml:description>
+          <maml:para>Destination schema name for table copy plans.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationTable</maml:name>
+        <maml:description>
+          <maml:para>Destination table name for table copy plans.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeAdvanced</maml:name>
+        <maml:description>
+          <maml:para>Includes advanced SQL Server configuration values.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeDisabled</maml:name>
+        <maml:description>
+          <maml:para>Includes disabled SQL Server Agent jobs or schedules where applicable.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeSystem</maml:name>
+        <maml:description>
+          <maml:para>Includes system principals where applicable.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MemberName</maml:name>
+        <maml:description>
+          <maml:para>Optional member name filter for role membership metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Name</maml:name>
+        <maml:description>
+          <maml:para>Optional name filter used by Agent jobs, principals, instance properties, and configurations.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PrincipalName</maml:name>
+        <maml:description>
+          <maml:para>Optional grantee principal name filter for permission metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>RoleName</maml:name>
+        <maml:description>
+          <maml:para>Optional role name filter for role membership metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Schema</maml:name>
+        <maml:description>
+          <maml:para>Optional schema filter used by dependency, scripting, and copy-plan metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Table</maml:name>
+        <maml:description>
+          <maml:para>Source table name for table copy plans.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>Selects the SQL Server management metadata type to return.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXSqlServerManagementType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">AgentJob</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AgentJobStep</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AgentSchedule</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ServerPrincipal</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DatabasePrincipal</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RoleMembership</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Permission</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">InstanceProperty</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Configuration</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Dependency</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ModuleScript</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TableScript</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TableCopyPlan</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Inventory</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXSqlServerManagementType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>List SQL Server Agent jobs.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-DbaXSqlServerManagement -Type AgentJob -ConnectionString 'Server=.;Database=msdb;Integrated Security=True;Encrypt=True;TrustServerCertificate=True'</dev:code>
+        <dev:remarks>
+          <maml:para>Lists SQL Server Agent jobs visible through the supplied connection.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>List database principals.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-DbaXSqlServerManagement -Type DatabasePrincipal -ConnectionString 'Server=.;Database=AppDb;Integrated Security=True;Encrypt=True;TrustServerCertificate=True'</dev:code>
+        <dev:remarks>
+          <maml:para>Lists database principals in the current database.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-DbaXSqlServerMonitoring</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DbaXSqlServerMonitoring</command:noun>
+      <maml:description>
+        <maml:para>Collects a SQL Server monitoring snapshot through the DbaClientX SQL Server provider.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Collects a SQL Server monitoring snapshot through the DbaClientX SQL Server provider.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-DbaXSqlServerMonitoring</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApplicationName</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL Server application name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectTimeoutSeconds</maml:name>
+          <maml:description>
+            <maml:para>Optional connection timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL credential.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Database used for connection-level checks.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeDisabledAgentJobs</maml:name>
+          <maml:description>
+            <maml:para>Includes disabled SQL Server Agent jobs.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeSystemDatabases</maml:name>
+          <maml:description>
+            <maml:para>Includes system databases in database-level collectors.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxCheckDbAgeDays</maml:name>
+          <maml:description>
+            <maml:para>Maximum age in days for last known good CHECKDB before status is considered overdue.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxDifferentialBackupAgeHours</maml:name>
+          <maml:description>
+            <maml:para>Maximum age in hours for differential backups before status is considered overdue.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxFullBackupAgeHours</maml:name>
+          <maml:description>
+            <maml:para>Maximum age in hours for full backups before status is considered overdue.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxLogBackupAgeMinutes</maml:name>
+          <maml:description>
+            <maml:para>Maximum age in minutes for log backups before status is considered overdue.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+          <dev:type>
+            <maml:name>Double</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL login password.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Port</maml:name>
+          <maml:description>
+            <maml:para>Optional TCP port.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Scope</maml:name>
+          <maml:description>
+            <maml:para>Monitoring areas to collect.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SqlServerMonitoringScope</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Connectivity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DatabaseState</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BackupFreshness</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CheckDbFreshness</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AgentJobs</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Baseline</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">WaitStatistics</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AvailabilityGroups</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">All</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>SqlServerMonitoringScope</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>SQL Server instance name or address.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TrustServerCertificate</maml:name>
+          <maml:description>
+            <maml:para>Trusts the SQL Server certificate while keeping encryption enabled.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL login name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WaitStatisticThresholdPercent</maml:name>
+          <maml:description>
+            <maml:para>Maximum cumulative wait percentage to include in wait statistics.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Decimal</command:parameterValue>
+          <dev:type>
+            <maml:name>Decimal</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ApplicationName</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL Server application name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectTimeoutSeconds</maml:name>
+        <maml:description>
+          <maml:para>Optional connection timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL credential.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Database used for connection-level checks.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeDisabledAgentJobs</maml:name>
+        <maml:description>
+          <maml:para>Includes disabled SQL Server Agent jobs.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeSystemDatabases</maml:name>
+        <maml:description>
+          <maml:para>Includes system databases in database-level collectors.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxCheckDbAgeDays</maml:name>
+        <maml:description>
+          <maml:para>Maximum age in days for last known good CHECKDB before status is considered overdue.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxDifferentialBackupAgeHours</maml:name>
+        <maml:description>
+          <maml:para>Maximum age in hours for differential backups before status is considered overdue.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxFullBackupAgeHours</maml:name>
+        <maml:description>
+          <maml:para>Maximum age in hours for full backups before status is considered overdue.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxLogBackupAgeMinutes</maml:name>
+        <maml:description>
+          <maml:para>Maximum age in minutes for log backups before status is considered overdue.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
+        <dev:type>
+          <maml:name>Double</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL login password.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Port</maml:name>
+        <maml:description>
+          <maml:para>Optional TCP port.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Scope</maml:name>
+        <maml:description>
+          <maml:para>Monitoring areas to collect.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SqlServerMonitoringScope</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">None</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Connectivity</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DatabaseState</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BackupFreshness</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CheckDbFreshness</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AgentJobs</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Baseline</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">WaitStatistics</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AvailabilityGroups</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">All</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>SqlServerMonitoringScope</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>SQL Server instance name or address.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TrustServerCertificate</maml:name>
+        <maml:description>
+          <maml:para>Trusts the SQL Server certificate while keeping encryption enabled.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL login name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WaitStatisticThresholdPercent</maml:name>
+        <maml:description>
+          <maml:para>Maximum cumulative wait percentage to include in wait statistics.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Decimal</command:parameterValue>
+        <dev:type>
+          <maml:name>Decimal</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Collect baseline monitoring data.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-DbaXSqlServerMonitoring -Server . -Database master -TrustServerCertificate</dev:code>
+        <dev:remarks>
+          <maml:para>Returns a typed monitoring snapshot for the local SQL Server instance.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-DbaXTableCopyPlan</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>DbaXTableCopyPlan</command:noun>
+      <maml:description>
+        <maml:para>Discovers provider metadata and builds a DbaClientX table-copy plan.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Discovers provider metadata and builds a DbaClientX table-copy plan.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-DbaXTableCopyPlan</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ColumnMappings</maml:name>
+          <maml:description>
+            <maml:para>Optional global source column to destination column mappings.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ColumnTypeConversions</maml:name>
+          <maml:description>
+            <maml:para>Optional global column type conversions.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Source provider connection string, or SQLite source database path.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Optional destination provider connection string, or SQLite destination database path.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationSchema</maml:name>
+          <maml:description>
+            <maml:para>Destination schema used for generated destination names.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExcludedColumns</maml:name>
+          <maml:description>
+            <maml:para>Optional global excluded columns.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeDestinationGeneratedColumns</maml:name>
+          <maml:description>
+            <maml:para>Includes destination generated columns in generated pages.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeDestinationIdentityColumns</maml:name>
+          <maml:description>
+            <maml:para>Includes destination identity columns in generated pages.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeSourceGeneratedColumns</maml:name>
+          <maml:description>
+            <maml:para>Includes source generated columns in generated pages.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeViews</maml:name>
+          <maml:description>
+            <maml:para>Includes views in generated copy definitions.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Provider</maml:name>
+          <maml:description>
+            <maml:para>Provider used to discover metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SkipDestinationColumnMatch</maml:name>
+          <maml:description>
+            <maml:para>Does not require source columns to exist in destination metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceSchema</maml:name>
+          <maml:description>
+            <maml:para>Restricts source metadata to a schema.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceTable</maml:name>
+          <maml:description>
+            <maml:para>Restricts source metadata to a table.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TableMappings</maml:name>
+          <maml:description>
+            <maml:para>Optional source table to destination table mappings.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ColumnMappings</maml:name>
+        <maml:description>
+          <maml:para>Optional global source column to destination column mappings.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ColumnTypeConversions</maml:name>
+        <maml:description>
+          <maml:para>Optional global column type conversions.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Source provider connection string, or SQLite source database path.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Optional destination provider connection string, or SQLite destination database path.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationSchema</maml:name>
+        <maml:description>
+          <maml:para>Destination schema used for generated destination names.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExcludedColumns</maml:name>
+        <maml:description>
+          <maml:para>Optional global excluded columns.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeDestinationGeneratedColumns</maml:name>
+        <maml:description>
+          <maml:para>Includes destination generated columns in generated pages.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeDestinationIdentityColumns</maml:name>
+        <maml:description>
+          <maml:para>Includes destination identity columns in generated pages.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeSourceGeneratedColumns</maml:name>
+        <maml:description>
+          <maml:para>Includes source generated columns in generated pages.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeViews</maml:name>
+        <maml:description>
+          <maml:para>Includes views in generated copy definitions.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Provider</maml:name>
+        <maml:description>
+          <maml:para>Provider used to discover metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SkipDestinationColumnMatch</maml:name>
+        <maml:description>
+          <maml:para>Does not require source columns to exist in destination metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceSchema</maml:name>
+        <maml:description>
+          <maml:para>Restricts source metadata to a schema.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceTable</maml:name>
+        <maml:description>
+          <maml:para>Restricts source metadata to a table.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TableMappings</maml:name>
+        <maml:description>
+          <maml:para>Optional source table to destination table mappings.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Build a SQL Server copy plan from live metadata.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Get-DbaXTableCopyPlan -Provider SqlServer -ConnectionString $source -DestinationConnectionString $destination -DestinationSchema archive</dev:code>
+        <dev:remarks>
+          <maml:para>Discovers source and destination metadata, then calls the shared DbaClientX planner.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXBulkInsert</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXBulkInsert</command:noun>
+      <maml:description>
+        <maml:para>Invokes a provider-native DbaClientX bulk insert from tabular PowerShell input.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Invokes a provider-native DbaClientX bulk insert from tabular PowerShell input.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXBulkInsert</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Optional rows per provider bulk batch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BulkCopyTimeout</maml:name>
+          <maml:description>
+            <maml:para>Optional provider bulk-copy timeout in seconds. SQLite does not support this option.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Provider connection string, or SQLite database path.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationTable</maml:name>
+          <maml:description>
+            <maml:para>Destination table name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>InputObject</maml:name>
+          <maml:description>
+            <maml:para>Tabular input to write. Accepts DataTable, DataView, IDataReader, DataRow, hashtable, and object pipeline input.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PassThru</maml:name>
+          <maml:description>
+            <maml:para>Returns a small result object with provider, destination table, and row count.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Provider</maml:name>
+          <maml:description>
+            <maml:para>Provider used for the bulk insert.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTransaction</maml:name>
+          <maml:description>
+            <maml:para>Executes the bulk insert inside a provider transaction where supported.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BatchSize</maml:name>
+        <maml:description>
+          <maml:para>Optional rows per provider bulk batch.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BulkCopyTimeout</maml:name>
+        <maml:description>
+          <maml:para>Optional provider bulk-copy timeout in seconds. SQLite does not support this option.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Provider connection string, or SQLite database path.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationTable</maml:name>
+        <maml:description>
+          <maml:para>Destination table name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>InputObject</maml:name>
+        <maml:description>
+          <maml:para>Tabular input to write. Accepts DataTable, DataView, IDataReader, DataRow, hashtable, and object pipeline input.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PassThru</maml:name>
+        <maml:description>
+          <maml:para>Returns a small result object with provider, destination table, and row count.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Provider</maml:name>
+        <maml:description>
+          <maml:para>Provider used for the bulk insert.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>UseTransaction</maml:name>
+        <maml:description>
+          <maml:para>Executes the bulk insert inside a provider transaction where supported.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Bulk insert object rows into SQL Server.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$rows | Invoke-DbaXBulkInsert -Provider SqlServer -ConnectionString $connectionString -DestinationTable dbo.Import -PassThru</dev:code>
+        <dev:remarks>
+          <maml:para>Converts pipeline input to a DataTable and writes it using the SQL Server bulk provider.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXMySql</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXMySql</command:noun>
+      <maml:description>
+        <maml:para>Invokes commands against a MySQL database.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Connects to a MySQL server using provided credentials and executes a SQL query.</maml:para>
+      <maml:para>Results can be streamed or returned in different formats based on the ReturnType.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="Query">
+        <maml:name>Invoke-DbaXMySql</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the name of the database.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides additional parameters for the query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>The SQL statement to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the timeout for the command in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+          <maml:name>ReturnType</maml:name>
+          <maml:description>
+            <maml:para>Selects the format of the returned data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReturnType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the MySQL server to connect to.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Stream</maml:name>
+          <maml:description>
+            <maml:para>Streams results without buffering.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>User name for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Credential for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the name of the database.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Provides additional parameters for the query.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Password for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>The SQL statement to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Sets the timeout for the command in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+        <maml:name>ReturnType</maml:name>
+        <maml:description>
+          <maml:para>Selects the format of the returned data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>ReturnType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the MySQL server to connect to.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Stream</maml:name>
+        <maml:description>
+          <maml:para>Streams results without buffering.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>User name for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Network operations may incur latency; consider using -Stream for large result sets.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Query MySQL with credentials.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$credential = Get-Credential 'app_reader'&#xD;
+            Invoke-DbaXMySql -Server 'mysql01' -Database 'app' -Credential $credential -Query @'&#xD;
+            SELECT&#xD;
+                id,&#xD;
+                email,&#xD;
+                created_at&#xD;
+            FROM users&#xD;
+            WHERE is_active = 1&#xD;
+            ORDER BY created_at DESC&#xD;
+            LIMIT 25;&#xD;
+            '@</dev:code>
+        <dev:remarks>
+          <maml:para>Returns recent active users as DataRow objects.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Stream results as they arrive.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$credential = Get-Credential 'app_reader'&#xD;
+            Invoke-DbaXMySql -Server 'mysql01' -Database 'app' -Credential $credential -Query @'&#xD;
+            SELECT id, message, created_at&#xD;
+            FROM audit_log&#xD;
+            ORDER BY created_at DESC&#xD;
+            LIMIT 1000;&#xD;
+            '@ -Stream</dev:code>
+        <dev:remarks>
+          <maml:para>Streams rows without buffering the entire result.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>MySQL provider on MS Learn</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/ef/core/providers/?tabs=dotnet-core-cli#mysql</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/DbaClientX</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXMySqlNonQuery</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXMySqlNonQuery</command:noun>
+      <maml:description>
+        <maml:para>Executes a non-query SQL command against MySQL.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Runs an SQL statement such as INSERT, UPDATE, or DELETE and returns the number of affected rows.</maml:para>
+      <maml:para>Requires explicit credentials for authentication.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXMySqlNonQuery</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the target database.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides parameters for the SQL command.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>The SQL command to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the MySQL server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>User name for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Credential for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the target database.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Provides parameters for the SQL command.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Password for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>The SQL command to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Sets the command timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the MySQL server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>User name for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Use caution with destructive statements; the cmdlet respects -WhatIf and -Confirm.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Delete rows from a table.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Invoke-DbaXMySqlNonQuery -Server 'mysqlsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'DELETE FROM Users WHERE Disabled = 1'</dev:code>
+        <dev:remarks>
+          <maml:para>Removes disabled users and outputs the number of rows deleted.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>MySQL provider on MS Learn</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/ef/core/providers/?tabs=dotnet-core-cli#mysql</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/DbaClientX</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXMySqlScalar</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXMySqlScalar</command:noun>
+      <maml:description>
+        <maml:para>Executes a scalar SQL query against MySQL.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Runs a SQL statement and returns a single value. Supports asynchronous execution and type conversion via ReturnType.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXMySqlScalar</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the target database.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides parameters for the SQL command.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>The SQL command to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+          <maml:name>ReturnType</maml:name>
+          <maml:description>
+            <maml:para>Selects the format of the returned value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReturnType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the MySQL server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>User name for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Credential for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the target database.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Provides parameters for the SQL command.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Password for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>The SQL command to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Sets the command timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+        <maml:name>ReturnType</maml:name>
+        <maml:description>
+          <maml:para>Selects the format of the returned value.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>ReturnType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the MySQL server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>User name for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get a single value.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$credential = Get-Credential 'app_reader'&#xD;
+            Invoke-DbaXMySqlScalar -Server 'mysql01' -Database 'app' -Credential $credential -Query @'&#xD;
+            SELECT COUNT(*)&#xD;
+            FROM users&#xD;
+            WHERE is_active = 1;&#xD;
+            '@</dev:code>
+        <dev:remarks>
+          <maml:para>Returns the number of users.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXMySqlTransaction</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXMySqlTransaction</command:noun>
+      <maml:description>
+        <maml:para>Runs a script block inside a MySQL transaction.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a MySQL client, begins a transaction, invokes the script block, and commits on success.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXMySqlTransaction</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ArgumentList</maml:name>
+          <maml:description>
+            <maml:para>Additional arguments passed to the script block after the transaction client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Object[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>MySQL credential.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the database name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IsolationLevel</maml:name>
+          <maml:description>
+            <maml:para>Isolation level to use for the transaction.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IsolationLevel</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Chaos</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ReadUncommitted</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ReadCommitted</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RepeatableRead</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Serializable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Snapshot</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Unspecified</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>IsolationLevel</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>MySQL password.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Command timeout to assign to the transaction client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ScriptBlock</maml:name>
+          <maml:description>
+            <maml:para>Script block executed with the transaction client as the first argument.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+          <dev:type>
+            <maml:name>ScriptBlock</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the MySQL server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>MySQL user name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ArgumentList</maml:name>
+        <maml:description>
+          <maml:para>Additional arguments passed to the script block after the transaction client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Object[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>MySQL credential.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the database name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IsolationLevel</maml:name>
+        <maml:description>
+          <maml:para>Isolation level to use for the transaction.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IsolationLevel</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Chaos</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ReadUncommitted</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ReadCommitted</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RepeatableRead</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Serializable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Snapshot</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Unspecified</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>IsolationLevel</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>MySQL password.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Command timeout to assign to the transaction client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ScriptBlock</maml:name>
+        <maml:description>
+          <maml:para>Script block executed with the transaction client as the first argument.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+        <dev:type>
+          <maml:name>ScriptBlock</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the MySQL server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>MySQL user name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Invoke-DbaXMySqlTransaction -Server 'mysql01' -Database 'App' -Credential $credential -ArgumentList $credential -ScriptBlock { param($client, $login) $client.ExecuteNonQuery('mysql01', 'App', $login.UserName, $login.GetNetworkCredential().Password, 'UPDATE Jobs SET Enabled = 1 WHERE Id = 42', $null, $true) }</dev:code>
+        <dev:remarks>
+          <maml:para>Use the same credential inside the transaction script block.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXNonQuery</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXNonQuery</command:noun>
+      <maml:description>
+        <maml:para>Executes a non-query SQL command against SQL Server.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Runs an SQL statement such as INSERT, UPDATE, or DELETE and returns the number of affected rows.</maml:para>
+      <maml:para>Supports SQL authentication or integrated security based on provided credentials.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="DefaultCredentials">
+        <maml:name>Invoke-DbaXNonQuery</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL authentication credential.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the target database.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides parameters for the SQL command.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Optional password for SQL authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>The SQL command to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the SQL Server instance.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TrustServerCertificate</maml:name>
+          <maml:description>
+            <maml:para>Trusts the SQL Server TLS certificate without validating the certificate chain.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>Optional user name for SQL authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL authentication credential.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the target database.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Provides parameters for the SQL command.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Optional password for SQL authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>The SQL command to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Sets the command timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the SQL Server instance.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TrustServerCertificate</maml:name>
+        <maml:description>
+          <maml:para>Trusts the SQL Server TLS certificate without validating the certificate chain.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>Optional user name for SQL authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Use caution with destructive statements; the cmdlet respects -WhatIf and -Confirm.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Create and populate a local temporary table.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$sql = @'&#xD;
+             CREATE TABLE #DbaClientXDemo&#xD;
+             (&#xD;
+                 Id int NOT NULL,&#xD;
+                 Name nvarchar(50) NOT NULL&#xD;
+             );&#xD;
+            &#xD;
+             INSERT INTO #DbaClientXDemo (Id, Name)&#xD;
+             VALUES (1, N'Alpha'), (2, N'Beta');&#xD;
+             '@&#xD;
+            &#xD;
+             Invoke-DbaXNonQuery -Server 'localhost' -Database 'master' -TrustServerCertificate -Query $sql</dev:code>
+        <dev:remarks>
+          <maml:para>Executes a multi-line command and returns the number of affected rows.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Run a command with SQL authentication.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$credential = Get-Credential 'app_writer'&#xD;
+             Invoke-DbaXNonQuery -Server 'sql01' -Database 'app' -Query 'UPDATE dbo.Users SET LastSeenUtc = SYSUTCDATETIME() WHERE Id = @Id' -Credential $credential -Parameters @{ Id = 42 }</dev:code>
+        <dev:remarks>
+          <maml:para>Executes the statement using the supplied credentials.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Using SqlClient</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/dotnet/framework/data/adonet/using-sqlclient</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/DbaClientX</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXOracle</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXOracle</command:noun>
+      <maml:description>
+        <maml:para>Invokes commands against an Oracle database.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Connects to an Oracle server using provided credentials and executes a SQL query.</maml:para>
+      <maml:para>Results can be returned in different formats based on the ReturnType.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXOracle</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the name of the database.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides additional parameters for the query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>The SQL statement to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the timeout for the command in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+          <maml:name>ReturnType</maml:name>
+          <maml:description>
+            <maml:para>Selects the format of the returned data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReturnType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Oracle server to connect to.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Stream</maml:name>
+          <maml:description>
+            <maml:para>Streams results without buffering.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>User name for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Credential for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the name of the database.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Provides additional parameters for the query.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Password for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>The SQL statement to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Sets the timeout for the command in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+        <maml:name>ReturnType</maml:name>
+        <maml:description>
+          <maml:para>Selects the format of the returned data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>ReturnType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the Oracle server to connect to.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Stream</maml:name>
+        <maml:description>
+          <maml:para>Streams results without buffering.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>User name for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Network operations may incur latency; consider using -Stream for large result sets.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Query Oracle with credentials.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$credential = Get-Credential 'app_reader'&#xD;
+            Invoke-DbaXOracle -Server 'oracle01' -Database 'ORCLPDB1' -Credential $credential -Query @'&#xD;
+            SELECT&#xD;
+                USER AS ConnectedUser,&#xD;
+                SYS_CONTEXT('USERENV', 'SERVICE_NAME') AS ServiceName&#xD;
+            FROM dual&#xD;
+            '@</dev:code>
+        <dev:remarks>
+          <maml:para>Returns Oracle session context as DataRow objects.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Stream results as they arrive.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$credential = Get-Credential 'app_reader'&#xD;
+            Invoke-DbaXOracle -Server 'oracle01' -Database 'ORCLPDB1' -Credential $credential -Query @'&#xD;
+            SELECT owner, table_name&#xD;
+            FROM all_tables&#xD;
+            WHERE owner = USER&#xD;
+            ORDER BY table_name&#xD;
+            '@ -Stream</dev:code>
+        <dev:remarks>
+          <maml:para>Streams rows without buffering the entire result.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Oracle provider documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/dotnet/standard/data/sqlite/?tabs=netcore-cli</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/DbaClientX</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXOracleNonQuery</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXOracleNonQuery</command:noun>
+      <maml:description>
+        <maml:para>Executes a non-query SQL command against Oracle.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Runs an SQL statement such as INSERT, UPDATE, or DELETE and returns the number of affected rows.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXOracleNonQuery</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the target database.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides parameters for the SQL command.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>The SQL command to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Oracle server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>User name for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Credential for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the target database.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Provides parameters for the SQL command.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Password for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>The SQL command to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Sets the command timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the Oracle server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>User name for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Use caution with destructive statements; the cmdlet respects -WhatIf and -Confirm.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Delete rows from a table.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Invoke-DbaXOracleNonQuery -Server 'oraclesrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'DELETE FROM Users WHERE Disabled = 1'</dev:code>
+        <dev:remarks>
+          <maml:para>Removes disabled users and outputs the number of rows deleted.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/DbaClientX</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXOracleScalar</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXOracleScalar</command:noun>
+      <maml:description>
+        <maml:para>Executes a scalar SQL query against Oracle.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Runs a SQL statement and returns a single value. Supports type conversion via ReturnType.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXOracleScalar</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the target database.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides parameters for the SQL command.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>The SQL command to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+          <maml:name>ReturnType</maml:name>
+          <maml:description>
+            <maml:para>Selects the format of the returned value.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReturnType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Oracle server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>User name for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Credential for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the target database.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Provides parameters for the SQL command.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Password for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>The SQL command to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Sets the command timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+        <maml:name>ReturnType</maml:name>
+        <maml:description>
+          <maml:para>Selects the format of the returned value.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>ReturnType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the Oracle server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>User name for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get a single value.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Invoke-DbaXOracleScalar -Server 'oraclesrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'SELECT COUNT(*) FROM Users'</dev:code>
+        <dev:remarks>
+          <maml:para>Returns the number of users.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXOracleTransaction</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXOracleTransaction</command:noun>
+      <maml:description>
+        <maml:para>Runs a script block inside an Oracle transaction.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates an Oracle client, begins a transaction, invokes the script block, and commits on success.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXOracleTransaction</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ArgumentList</maml:name>
+          <maml:description>
+            <maml:para>Additional arguments passed to the script block after the transaction client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Object[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Oracle credential.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ServiceName">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the Oracle service name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IsolationLevel</maml:name>
+          <maml:description>
+            <maml:para>Isolation level to use for the transaction.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IsolationLevel</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Chaos</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ReadUncommitted</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ReadCommitted</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RepeatableRead</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Serializable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Snapshot</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Unspecified</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>IsolationLevel</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Oracle password.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Command timeout to assign to the transaction client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ScriptBlock</maml:name>
+          <maml:description>
+            <maml:para>Script block executed with the transaction client as the first argument.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+          <dev:type>
+            <maml:name>ScriptBlock</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the Oracle server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>Oracle user name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ArgumentList</maml:name>
+        <maml:description>
+          <maml:para>Additional arguments passed to the script block after the transaction client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Object[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Oracle credential.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ServiceName">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the Oracle service name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IsolationLevel</maml:name>
+        <maml:description>
+          <maml:para>Isolation level to use for the transaction.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IsolationLevel</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Chaos</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ReadUncommitted</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ReadCommitted</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RepeatableRead</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Serializable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Snapshot</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Unspecified</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>IsolationLevel</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Oracle password.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Command timeout to assign to the transaction client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ScriptBlock</maml:name>
+        <maml:description>
+          <maml:para>Script block executed with the transaction client as the first argument.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+        <dev:type>
+          <maml:name>ScriptBlock</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the Oracle server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>Oracle user name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Invoke-DbaXOracleTransaction -Server 'oracle01' -Database 'FREEPDB1' -Credential $credential -ArgumentList $credential -ScriptBlock { param($client, $login) $client.ExecuteNonQuery('oracle01', 'FREEPDB1', $login.UserName, $login.GetNetworkCredential().Password, 'UPDATE Jobs SET Enabled = 1 WHERE Id = 42', $null, $true) }</dev:code>
+        <dev:remarks>
+          <maml:para>Use the same credential inside the transaction script block.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXPostgreSql</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXPostgreSql</command:noun>
+      <maml:description>
+        <maml:para>Invokes commands against a PostgreSQL database.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Connects to a PostgreSQL server and executes a query or stored procedure with optional parameters.</maml:para>
+      <maml:para>Results can be streamed or returned in DataRow, DataTable, DataSet or PSObject formats.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="Query">
+        <maml:name>Invoke-DbaXPostgreSql</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>The credential for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the database name on the server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Supplies parameters for the query or stored procedure.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>The password for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>Provides the SQL query text to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+          <maml:name>ReturnType</maml:name>
+          <maml:description>
+            <maml:para>Selects the format of returned data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReturnType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the PostgreSQL server to connect to.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Stream</maml:name>
+          <maml:description>
+            <maml:para>Streams results instead of buffering them.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>The user name for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="StoredProcedure">
+        <maml:name>Invoke-DbaXPostgreSql</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>The credential for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the database name on the server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Supplies parameters for the query or stored procedure.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>The password for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+          <maml:name>ReturnType</maml:name>
+          <maml:description>
+            <maml:para>Selects the format of returned data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReturnType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the PostgreSQL server to connect to.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>StoredProcedure</maml:name>
+          <maml:description>
+            <maml:para>Names the stored procedure to invoke.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>The user name for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>The credential for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the database name on the server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Supplies parameters for the query or stored procedure.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>The password for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>Provides the SQL query text to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Sets the command timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+        <maml:name>ReturnType</maml:name>
+        <maml:description>
+          <maml:para>Selects the format of returned data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>ReturnType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the PostgreSQL server to connect to.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>StoredProcedure</maml:name>
+        <maml:description>
+          <maml:para>Names the stored procedure to invoke.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Stream</maml:name>
+        <maml:description>
+          <maml:para>Streams results instead of buffering them.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>The user name for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Credentials are transmitted to the server; ensure secure channels when running over a network.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Run a query using explicit credentials.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$credential = Get-Credential 'app_reader'&#xD;
+            Invoke-DbaXPostgreSql -Server 'pg01' -Database 'app' -Credential $credential -Query @'&#xD;
+            SELECT&#xD;
+                current_database() AS database_name,&#xD;
+                current_user AS connected_as,&#xD;
+                version() AS server_version;&#xD;
+            '@</dev:code>
+        <dev:remarks>
+          <maml:para>Executes the query and returns each row as a DataRow.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Execute a stored procedure and get a DataTable.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$credential = Get-Credential 'app_writer'&#xD;
+            Invoke-DbaXPostgreSql -Server 'pg01' -Database 'app' -Credential $credential -StoredProcedure 'refresh_stats' -ReturnType DataTable</dev:code>
+        <dev:remarks>
+          <maml:para>Runs the stored procedure and outputs a DataTable.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Npgsql provider on MS Learn</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/ef/core/providers/npgsql/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/DbaClientX</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXPostgreSqlNonQuery</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXPostgreSqlNonQuery</command:noun>
+      <maml:description>
+        <maml:para>Executes a non-query SQL command against PostgreSQL.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Runs statements like INSERT, UPDATE, or DELETE and returns the number of affected rows.</maml:para>
+      <maml:para>Requires explicit credentials for authentication.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXPostgreSqlNonQuery</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the target database.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides parameters for the SQL command.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>The SQL command to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the PostgreSQL server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>User name for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Credential for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the target database.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Provides parameters for the SQL command.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Password for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>The SQL command to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Sets the command timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the PostgreSQL server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>User name for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>Use caution with destructive statements; the cmdlet respects -WhatIf and -Confirm.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Delete rows from a table.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Invoke-DbaXPostgreSqlNonQuery -Server 'pgsrv' -Database 'app' -Username 'user' -Password 'p@ss' -Query 'DELETE FROM data WHERE Archived = 1'</dev:code>
+        <dev:remarks>
+          <maml:para>Removes archived rows and outputs the number of rows deleted.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Npgsql provider on MS Learn</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/ef/core/providers/npgsql/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/DbaClientX</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXPostgreSqlTransaction</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXPostgreSqlTransaction</command:noun>
+      <maml:description>
+        <maml:para>Runs a script block inside a PostgreSQL transaction.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a PostgreSQL client, begins a transaction, invokes the script block, and commits on success.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXPostgreSqlTransaction</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ArgumentList</maml:name>
+          <maml:description>
+            <maml:para>Additional arguments passed to the script block after the transaction client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Object[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>PostgreSQL credential.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the database name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IsolationLevel</maml:name>
+          <maml:description>
+            <maml:para>Isolation level to use for the transaction.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IsolationLevel</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Chaos</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ReadUncommitted</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ReadCommitted</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RepeatableRead</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Serializable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Snapshot</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Unspecified</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>IsolationLevel</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>PostgreSQL password.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Command timeout to assign to the transaction client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ScriptBlock</maml:name>
+          <maml:description>
+            <maml:para>Script block executed with the transaction client as the first argument.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+          <dev:type>
+            <maml:name>ScriptBlock</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the PostgreSQL server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>PostgreSQL user name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ArgumentList</maml:name>
+        <maml:description>
+          <maml:para>Additional arguments passed to the script block after the transaction client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Object[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>PostgreSQL credential.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the database name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IsolationLevel</maml:name>
+        <maml:description>
+          <maml:para>Isolation level to use for the transaction.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IsolationLevel</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Chaos</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ReadUncommitted</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ReadCommitted</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RepeatableRead</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Serializable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Snapshot</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Unspecified</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>IsolationLevel</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>PostgreSQL password.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Command timeout to assign to the transaction client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ScriptBlock</maml:name>
+        <maml:description>
+          <maml:para>Script block executed with the transaction client as the first argument.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+        <dev:type>
+          <maml:name>ScriptBlock</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the PostgreSQL server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>PostgreSQL user name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Invoke-DbaXPostgreSqlTransaction -Server 'pgsql01' -Database 'App' -Credential $credential -ArgumentList $credential -ScriptBlock { param($client, $login) $client.ExecuteNonQuery('pgsql01', 'App', $login.UserName, $login.GetNetworkCredential().Password, 'UPDATE Jobs SET Enabled = TRUE WHERE Id = 42', $null, $true) }</dev:code>
+        <dev:remarks>
+          <maml:para>Use the same credential inside the transaction script block.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXQuery</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXQuery</command:noun>
+      <maml:description>
+        <maml:para>Invokes a SQL Server query or stored procedure.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Connects to a SQL Server instance using integrated security or supplied credentials and executes the specified command.</maml:para>
+      <maml:para>Supports streaming results and multiple return formats via the ReturnType parameter.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="Query">
+        <maml:name>Invoke-DbaXQuery</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL authentication credential.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the database name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides additional parameters for the query or procedure.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Optional password for SQL authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>The SQL statement to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+          <maml:name>ReturnType</maml:name>
+          <maml:description>
+            <maml:para>Selects the type of returned objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReturnType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the SQL Server instance.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Stream</maml:name>
+          <maml:description>
+            <maml:para>Streams results instead of buffering them.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TrustServerCertificate</maml:name>
+          <maml:description>
+            <maml:para>Trusts the SQL Server TLS certificate without validating the certificate chain.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>Optional user name for SQL authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="StoredProcedure">
+        <maml:name>Invoke-DbaXQuery</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL authentication credential.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the database name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides additional parameters for the query or procedure.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Optional password for SQL authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+          <maml:name>ReturnType</maml:name>
+          <maml:description>
+            <maml:para>Selects the type of returned objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReturnType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the SQL Server instance.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>StoredProcedure</maml:name>
+          <maml:description>
+            <maml:para>Name of the stored procedure to run.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Stream</maml:name>
+          <maml:description>
+            <maml:para>Streams results instead of buffering them.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TrustServerCertificate</maml:name>
+          <maml:description>
+            <maml:para>Trusts the SQL Server TLS certificate without validating the certificate chain.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>Optional user name for SQL authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL authentication credential.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the database name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Provides additional parameters for the query or procedure.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Optional password for SQL authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>The SQL statement to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Sets the command timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+        <maml:name>ReturnType</maml:name>
+        <maml:description>
+          <maml:para>Selects the type of returned objects.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>ReturnType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the SQL Server instance.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>StoredProcedure</maml:name>
+        <maml:description>
+          <maml:para>Name of the stored procedure to run.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Stream</maml:name>
+        <maml:description>
+          <maml:para>Streams results instead of buffering them.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TrustServerCertificate</maml:name>
+        <maml:description>
+          <maml:para>Trusts the SQL Server TLS certificate without validating the certificate chain.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>Optional user name for SQL authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>When -ErrorAction Stop is used, execution will terminate on the first error.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Run a query with integrated security.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$rows = Invoke-DbaXQuery -Server 'localhost' -Database 'master' -TrustServerCertificate -Query @'&#xD;
+             SELECT&#xD;
+                 name,&#xD;
+                 database_id,&#xD;
+                 create_date&#xD;
+             FROM sys.databases&#xD;
+             WHERE database_id &gt; 4&#xD;
+             ORDER BY name;&#xD;
+             '@&#xD;
+            &#xD;
+             $rows | Format-Table name, database_id, create_date</dev:code>
+        <dev:remarks>
+          <maml:para>Executes a multi-line query against a local SQL Server instance and returns each row as a DataRow.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Execute a stored procedure using credentials.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$credential = Get-Credential 'app_reader'&#xD;
+             Invoke-DbaXQuery -Server 'sql01' -Database 'app' -StoredProcedure 'dbo.usp_GetActiveUsers' -Credential $credential -ReturnType DataTable</dev:code>
+        <dev:remarks>
+          <maml:para>Runs the stored procedure and outputs a DataTable.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Using SqlClient</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/dotnet/framework/data/adonet/using-sqlclient</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/DbaClientX</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXQueryStream</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXQueryStream</command:noun>
+      <maml:description>
+        <maml:para>Streams query rows through a DbaClientX provider.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Streams query rows through a DbaClientX provider.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXQueryStream</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Provider connection string, or SQLite database path.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Optional query parameters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Provider</maml:name>
+          <maml:description>
+            <maml:para>Provider used to stream query rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>Query text to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Optional command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+          <maml:name>ReturnType</maml:name>
+          <maml:description>
+            <maml:para>Controls the returned object format.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReturnType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTransaction</maml:name>
+          <maml:description>
+            <maml:para>Executes through an active provider transaction when supported.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Provider connection string, or SQLite database path.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Optional query parameters.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Provider</maml:name>
+        <maml:description>
+          <maml:para>Provider used to stream query rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>Query text to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Optional command timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+        <maml:name>ReturnType</maml:name>
+        <maml:description>
+          <maml:para>Controls the returned object format.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>ReturnType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>UseTransaction</maml:name>
+        <maml:description>
+          <maml:para>Executes through an active provider transaction when supported.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Stream SQL Server rows.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Invoke-DbaXQueryStream -Provider SqlServer -ConnectionString $connectionString -Query 'SELECT name FROM sys.databases' -ReturnType PSObject</dev:code>
+        <dev:remarks>
+          <maml:para>Streams query rows without buffering the full result set.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXSQLite</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXSQLite</command:noun>
+      <maml:description>
+        <maml:para>Invokes a query against a SQLite database.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Executes SQL statements on a specified SQLite database and returns data in the format you choose.</maml:para>
+      <maml:para>Supports streaming results for large data sets when the platform allows asynchronous enumeration.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="Query">
+        <maml:name>Invoke-DbaXSQLite</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Specifies the path to the SQLite database file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides additional query parameters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>Defines the SQL query to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+          <maml:name>ReturnType</maml:name>
+          <maml:description>
+            <maml:para>Selects the format of returned data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReturnType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Stream</maml:name>
+          <maml:description>
+            <maml:para>Streams results instead of buffering them.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Specifies the path to the SQLite database file.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Provides additional query parameters.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Query</maml:name>
+        <maml:description>
+          <maml:para>Defines the SQL query to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Sets the command timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+        <maml:name>ReturnType</maml:name>
+        <maml:description>
+          <maml:para>Selects the format of returned data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>ReturnType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Stream</maml:name>
+        <maml:description>
+          <maml:para>Streams results instead of buffering them.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>When -Stream is used on platforms without streaming support, a NotSupportedException is thrown.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Run a query and return rows.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Invoke-DbaXSQLite -Database 'app.db' -Query 'SELECT * FROM Users'</dev:code>
+        <dev:remarks>
+          <maml:para>Executes the query and outputs each row as a DataRow.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Stream results from a large query.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Invoke-DbaXSQLite -Database 'app.db' -Query 'SELECT * FROM Logs' -Stream -ReturnType DataRow</dev:code>
+        <dev:remarks>
+          <maml:para>Streams each row as it is received, which is useful for large result sets.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>SQLite in .NET</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/dotnet/standard/data/sqlite/</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/DbaClientX</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXSQLiteMaintenance</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXSQLiteMaintenance</command:noun>
+      <maml:description>
+        <maml:para>Runs SQLite maintenance operations through the DbaClientX SQLite provider.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Runs SQLite maintenance operations through the DbaClientX SQLite provider.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXSQLiteMaintenance</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>Action</maml:name>
+          <maml:description>
+            <maml:para>Maintenance operation to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXSQLiteMaintenanceAction</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Backup</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Checkpoint</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Optimize</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PrepareForShutdown</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXSQLiteMaintenanceAction</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BusyTimeoutMs</maml:name>
+          <maml:description>
+            <maml:para>Optional busy timeout in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckpointMode</maml:name>
+          <maml:description>
+            <maml:para>Checkpoint mode used by Checkpoint and PrepareForShutdown.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SqliteCheckpointMode</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Passive</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Full</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Restart</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Truncate</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>SqliteCheckpointMode</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="Path,ConnectionString">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>SQLite database path or SQLite connection string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Destination</maml:name>
+          <maml:description>
+            <maml:para>Destination database path for the Backup action.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PassThru</maml:name>
+          <maml:description>
+            <maml:para>Returns a small completion object.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SkipOptimize</maml:name>
+          <maml:description>
+            <maml:para>Skips PRAGMA optimize after checkpointing during PrepareForShutdown.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>Action</maml:name>
+        <maml:description>
+          <maml:para>Maintenance operation to execute.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXSQLiteMaintenanceAction</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Backup</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Checkpoint</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Optimize</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PrepareForShutdown</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXSQLiteMaintenanceAction</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BusyTimeoutMs</maml:name>
+        <maml:description>
+          <maml:para>Optional busy timeout in milliseconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CheckpointMode</maml:name>
+        <maml:description>
+          <maml:para>Checkpoint mode used by Checkpoint and PrepareForShutdown.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SqliteCheckpointMode</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Passive</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Full</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Restart</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Truncate</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>SqliteCheckpointMode</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="Path,ConnectionString">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>SQLite database path or SQLite connection string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Destination</maml:name>
+        <maml:description>
+          <maml:para>Destination database path for the Backup action.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PassThru</maml:name>
+        <maml:description>
+          <maml:para>Returns a small completion object.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SkipOptimize</maml:name>
+        <maml:description>
+          <maml:para>Skips PRAGMA optimize after checkpointing during PrepareForShutdown.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Prepare a SQLite database for shutdown.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Invoke-DbaXSQLiteMaintenance -Database .\app.db -Action PrepareForShutdown</dev:code>
+        <dev:remarks>
+          <maml:para>Runs the provider shutdown maintenance sequence.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXSQLiteTransaction</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXSQLiteTransaction</command:noun>
+      <maml:description>
+        <maml:para>Runs a script block inside a SQLite transaction.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a SQLite client, begins a transaction, invokes the script block, and commits on success.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXSQLiteTransaction</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ArgumentList</maml:name>
+          <maml:description>
+            <maml:para>Additional arguments passed to the script block after the transaction client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Object[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the SQLite database path or connection target.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IsolationLevel</maml:name>
+          <maml:description>
+            <maml:para>Isolation level to use for the transaction.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IsolationLevel</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Chaos</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ReadUncommitted</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ReadCommitted</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RepeatableRead</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Serializable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Snapshot</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Unspecified</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>IsolationLevel</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Command timeout to assign to the transaction client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ScriptBlock</maml:name>
+          <maml:description>
+            <maml:para>Script block executed with the transaction client as the first argument.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+          <dev:type>
+            <maml:name>ScriptBlock</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ArgumentList</maml:name>
+        <maml:description>
+          <maml:para>Additional arguments passed to the script block after the transaction client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Object[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the SQLite database path or connection target.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IsolationLevel</maml:name>
+        <maml:description>
+          <maml:para>Isolation level to use for the transaction.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IsolationLevel</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Chaos</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ReadUncommitted</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ReadCommitted</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RepeatableRead</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Serializable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Snapshot</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Unspecified</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>IsolationLevel</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Command timeout to assign to the transaction client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ScriptBlock</maml:name>
+        <maml:description>
+          <maml:para>Script block executed with the transaction client as the first argument.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+        <dev:type>
+          <maml:name>ScriptBlock</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Invoke-DbaXSQLiteTransaction -Database '.\app.db' -ScriptBlock { param($client) $client.ExecuteNonQuery('.\app.db', 'UPDATE Jobs SET Enabled = 1 WHERE Id = 42', $null, $true) }</dev:code>
+        <dev:remarks>
+          <maml:para>Update a row in a SQLite transaction.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXStoredProcedure</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXStoredProcedure</command:noun>
+      <maml:description>
+        <maml:para>Invokes a stored procedure through a DbaClientX provider.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Invokes a stored procedure through a DbaClientX provider.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXStoredProcedure</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Provider connection string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Optional procedure parameters.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Procedure</maml:name>
+          <maml:description>
+            <maml:para>Stored procedure name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Provider</maml:name>
+          <maml:description>
+            <maml:para>Provider used to execute the stored procedure.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Optional command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+          <maml:name>ReturnType</maml:name>
+          <maml:description>
+            <maml:para>Controls the returned object format.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReturnType</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Stream</maml:name>
+          <maml:description>
+            <maml:para>Streams result rows instead of buffering the result.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UseTransaction</maml:name>
+          <maml:description>
+            <maml:para>Executes through an active provider transaction when supported.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Provider connection string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Parameters</maml:name>
+        <maml:description>
+          <maml:para>Optional procedure parameters.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Procedure</maml:name>
+        <maml:description>
+          <maml:para>Stored procedure name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Provider</maml:name>
+        <maml:description>
+          <maml:para>Provider used to execute the stored procedure.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Optional command timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
+        <maml:name>ReturnType</maml:name>
+        <maml:description>
+          <maml:para>Controls the returned object format.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">DataSet</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataTable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DataRow</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PSObject</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>ReturnType</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Stream</maml:name>
+        <maml:description>
+          <maml:para>Streams result rows instead of buffering the result.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>UseTransaction</maml:name>
+        <maml:description>
+          <maml:para>Executes through an active provider transaction when supported.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Execute a SQL Server stored procedure.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Invoke-DbaXStoredProcedure -Provider SqlServer -ConnectionString $connectionString -Procedure dbo.GetUsers -ReturnType PSObject</dev:code>
+        <dev:remarks>
+          <maml:para>Executes the stored procedure and converts rows to PowerShell objects.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Invoke-DbaXTransaction</command:name>
+      <command:verb>Invoke</command:verb>
+      <command:noun>DbaXTransaction</command:noun>
+      <maml:description>
+        <maml:para>Runs a script block inside a SQL Server transaction.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a SQL Server client, begins a transaction, invokes the script block, and commits on success.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Invoke-DbaXTransaction</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ArgumentList</maml:name>
+          <maml:description>
+            <maml:para>Additional arguments passed to the script block after the transaction client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Object[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL authentication credential.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the database name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IsolationLevel</maml:name>
+          <maml:description>
+            <maml:para>Isolation level to use for the transaction.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IsolationLevel</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Chaos</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ReadUncommitted</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ReadCommitted</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RepeatableRead</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Serializable</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Snapshot</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Unspecified</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>IsolationLevel</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL authentication password.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Command timeout to assign to the transaction client.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ScriptBlock</maml:name>
+          <maml:description>
+            <maml:para>Script block executed with the transaction client as the first argument.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+          <dev:type>
+            <maml:name>ScriptBlock</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the SQL Server instance.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL authentication user name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ArgumentList</maml:name>
+        <maml:description>
+          <maml:para>Additional arguments passed to the script block after the transaction client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Object[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Object[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL authentication credential.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Defines the database name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IsolationLevel</maml:name>
+        <maml:description>
+          <maml:para>Isolation level to use for the transaction.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IsolationLevel</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Chaos</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ReadUncommitted</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ReadCommitted</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RepeatableRead</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Serializable</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Snapshot</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Unspecified</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>IsolationLevel</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL authentication password.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>QueryTimeout</maml:name>
+        <maml:description>
+          <maml:para>Command timeout to assign to the transaction client.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ScriptBlock</maml:name>
+        <maml:description>
+          <maml:para>Script block executed with the transaction client as the first argument.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">ScriptBlock</command:parameterValue>
+        <dev:type>
+          <maml:name>ScriptBlock</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Specifies the SQL Server instance.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL authentication user name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Invoke-DbaXTransaction -Server 'sql01' -Database 'App' -ScriptBlock { param($client) $client.ExecuteNonQuery('sql01', 'App', $true, 'UPDATE Jobs SET Enabled = 1 WHERE Id = 42', $null, $true) }</dev:code>
+        <dev:remarks>
+          <maml:para>Update a row through the transaction client. The cmdlet commits after the script block succeeds.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-DbaXConnectionString</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>DbaXConnectionString</command:noun>
+      <maml:description>
+        <maml:para>Builds a provider connection string using the matching DbaClientX C# provider.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Builds a provider connection string using the matching DbaClientX C# provider.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-DbaXConnectionString</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ApplicationName</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL Server application name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BusyTimeoutMs</maml:name>
+          <maml:description>
+            <maml:para>Optional SQLite busy timeout in milliseconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectTimeoutSeconds</maml:name>
+          <maml:description>
+            <maml:para>Optional connection timeout in seconds where supported.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Optional credential used instead of Username and Password.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Database name, Oracle service name, or SQLite database path.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Optional password.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Port</maml:name>
+          <maml:description>
+            <maml:para>Optional provider TCP port.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Provider</maml:name>
+          <maml:description>
+            <maml:para>Database provider whose connection-string builder should be used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ReadOnly</maml:name>
+          <maml:description>
+            <maml:para>Builds a read-only SQLite connection string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Server, host, or SQL Server instance name. SQLite ignores this parameter.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Ssl</maml:name>
+          <maml:description>
+            <maml:para>Enables provider SSL or encryption when supported by the provider builder.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TrustServerCertificate</maml:name>
+          <maml:description>
+            <maml:para>Trusts the SQL Server certificate when SQL Server encryption is enabled.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>Optional username. SQL Server uses integrated security when no credential or username/password is supplied.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ApplicationName</maml:name>
+        <maml:description>
+          <maml:para>Optional SQL Server application name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BusyTimeoutMs</maml:name>
+        <maml:description>
+          <maml:para>Optional SQLite busy timeout in milliseconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectTimeoutSeconds</maml:name>
+        <maml:description>
+          <maml:para>Optional connection timeout in seconds where supported.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Optional credential used instead of Username and Password.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Database</maml:name>
+        <maml:description>
+          <maml:para>Database name, Oracle service name, or SQLite database path.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Optional password.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Port</maml:name>
+        <maml:description>
+          <maml:para>Optional provider TCP port.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Provider</maml:name>
+        <maml:description>
+          <maml:para>Database provider whose connection-string builder should be used.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ReadOnly</maml:name>
+        <maml:description>
+          <maml:para>Builds a read-only SQLite connection string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Server</maml:name>
+        <maml:description>
+          <maml:para>Server, host, or SQL Server instance name. SQLite ignores this parameter.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Ssl</maml:name>
+        <maml:description>
+          <maml:para>Enables provider SSL or encryption when supported by the provider builder.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TrustServerCertificate</maml:name>
+        <maml:description>
+          <maml:para>Trusts the SQL Server certificate when SQL Server encryption is enabled.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Username</maml:name>
+        <maml:description>
+          <maml:para>Optional username. SQL Server uses integrated security when no credential or username/password is supplied.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Create a SQL Server connection string.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>New-DbaXConnectionString -Provider SqlServer -Server . -Database master -TrustServerCertificate</dev:code>
+        <dev:remarks>
+          <maml:para>Returns a SQL Server connection string using integrated security.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-DbaXQuery</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>DbaXQuery</command:noun>
+      <maml:description>
+        <maml:para>Creates SQL query-builder objects using the DbaClientX core query builder.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Builds SELECT, INSERT, UPDATE, DELETE, and UPSERT statements without duplicating SQL-generation logic in PowerShell.</maml:para>
+      <maml:para>Use -Compile for literal SQL output or -CompileWithParameters to return SQL plus an ordered parameter map.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-DbaXQuery</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Action</maml:name>
+          <maml:description>
+            <maml:para>The query-builder operation to create.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DbaXQueryAction</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Select</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Insert</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Update</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Delete</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Upsert</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXQueryAction</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Columns</maml:name>
+          <maml:description>
+            <maml:para>Columns to include in a SELECT statement. When omitted, the core builder emits *.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Compile</maml:name>
+          <maml:description>
+            <maml:para>Compiles the query to a SQL string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompileWithParameters</maml:name>
+          <maml:description>
+            <maml:para>Compiles the query to SQL text and returns ordered parameter values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConflictColumns</maml:name>
+          <maml:description>
+            <maml:para>Columns used to detect UPSERT conflicts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Dialect</maml:name>
+          <maml:description>
+            <maml:para>SQL dialect used when compiling the query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SqlDialect</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>SqlDialect</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Limit</maml:name>
+          <maml:description>
+            <maml:para>Limits the number of returned rows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Offset</maml:name>
+          <maml:description>
+            <maml:para>Skips a number of rows before returning results.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OrderBy</maml:name>
+          <maml:description>
+            <maml:para>Columns to add to ORDER BY in ascending order.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OrderByDescending</maml:name>
+          <maml:description>
+            <maml:para>Columns to add to ORDER BY in descending order.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Set</maml:name>
+          <maml:description>
+            <maml:para>Column/value pairs for UPDATE SET clauses.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IDictionary</command:parameterValue>
+          <dev:type>
+            <maml:name>IDictionary</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>TableName</maml:name>
+          <maml:description>
+            <maml:para>Name of the table targeted by the query.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UpsertUpdateOnly</maml:name>
+          <maml:description>
+            <maml:para>Columns updated during an UPSERT conflict. When omitted, the core builder updates all non-conflict insert columns.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Values</maml:name>
+          <maml:description>
+            <maml:para>Column/value pairs for INSERT or UPSERT statements.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IDictionary</command:parameterValue>
+          <dev:type>
+            <maml:name>IDictionary</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Where</maml:name>
+          <maml:description>
+            <maml:para>Column/value pairs added as equality predicates to the WHERE clause.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IDictionary</command:parameterValue>
+          <dev:type>
+            <maml:name>IDictionary</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Action</maml:name>
+        <maml:description>
+          <maml:para>The query-builder operation to create.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DbaXQueryAction</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Select</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Insert</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Update</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Delete</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Upsert</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXQueryAction</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Columns</maml:name>
+        <maml:description>
+          <maml:para>Columns to include in a SELECT statement. When omitted, the core builder emits *.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Compile</maml:name>
+        <maml:description>
+          <maml:para>Compiles the query to a SQL string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CompileWithParameters</maml:name>
+        <maml:description>
+          <maml:para>Compiles the query to SQL text and returns ordered parameter values.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConflictColumns</maml:name>
+        <maml:description>
+          <maml:para>Columns used to detect UPSERT conflicts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Dialect</maml:name>
+        <maml:description>
+          <maml:para>SQL dialect used when compiling the query.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SqlDialect</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>SqlDialect</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Limit</maml:name>
+        <maml:description>
+          <maml:para>Limits the number of returned rows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Offset</maml:name>
+        <maml:description>
+          <maml:para>Skips a number of rows before returning results.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OrderBy</maml:name>
+        <maml:description>
+          <maml:para>Columns to add to ORDER BY in ascending order.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OrderByDescending</maml:name>
+        <maml:description>
+          <maml:para>Columns to add to ORDER BY in descending order.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Set</maml:name>
+        <maml:description>
+          <maml:para>Column/value pairs for UPDATE SET clauses.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IDictionary</command:parameterValue>
+        <dev:type>
+          <maml:name>IDictionary</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>TableName</maml:name>
+        <maml:description>
+          <maml:para>Name of the table targeted by the query.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>UpsertUpdateOnly</maml:name>
+        <maml:description>
+          <maml:para>Columns updated during an UPSERT conflict. When omitted, the core builder updates all non-conflict insert columns.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Values</maml:name>
+        <maml:description>
+          <maml:para>Column/value pairs for INSERT or UPSERT statements.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IDictionary</command:parameterValue>
+        <dev:type>
+          <maml:name>IDictionary</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Where</maml:name>
+        <maml:description>
+          <maml:para>Column/value pairs added as equality predicates to the WHERE clause.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IDictionary</command:parameterValue>
+        <dev:type>
+          <maml:name>IDictionary</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Note</maml:para>
+        <maml:para>The cmdlet does not connect to the database or validate table existence; it only builds query objects or SQL text.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Create a SELECT query object.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>New-DbaXQuery -TableName 'dbo.Users' -Columns Id,DisplayName</dev:code>
+        <dev:remarks>
+          <maml:para>Returns a core query object targeting selected columns from dbo.Users.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Compile a paged SELECT query.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>New-DbaXQuery -TableName 'dbo.Users' -Columns Id,DisplayName -Where @{ IsActive = $true } -OrderBy DisplayName -Limit 10 -Offset 20 -Compile</dev:code>
+        <dev:remarks>
+          <maml:para>Outputs a SQL Server SELECT statement with a WHERE clause and OFFSET/FETCH pagination.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Compile an INSERT statement.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>New-DbaXQuery -Action Insert -TableName 'dbo.Users' -Values ([ordered]@{ Id = 42; DisplayName = 'Ada' }) -Compile</dev:code>
+        <dev:remarks>
+          <maml:para>Outputs an INSERT statement using the DbaClientX core query compiler.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Compile an UPDATE statement.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>New-DbaXQuery -Action Update -TableName 'dbo.Users' -Set @{ DisplayName = 'Ada Lovelace' } -Where @{ Id = 42 } -Compile</dev:code>
+        <dev:remarks>
+          <maml:para>Outputs an UPDATE statement with values supplied by PowerShell hashtables.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Compile a DELETE statement.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>New-DbaXQuery -Action Delete -TableName 'dbo.Users' -Where @{ Id = 42 } -Compile</dev:code>
+        <dev:remarks>
+          <maml:para>Outputs a DELETE statement scoped by the provided WHERE values.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Compile a provider-specific UPSERT statement.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>New-DbaXQuery -Action Upsert -Dialect PostgreSql -TableName 'public.users' -Values ([ordered]@{ id = 42; display_name = 'Ada'; email = 'ada@example.test' }) -ConflictColumns id -UpsertUpdateOnly display_name,email -Compile</dev:code>
+        <dev:remarks>
+          <maml:para>Outputs a PostgreSQL INSERT ... ON CONFLICT statement. Use another -Dialect value for SQL Server, MySQL, SQLite, or Oracle compiler behavior.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Compile SQL with ordered parameters.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>New-DbaXQuery -Action Update -Dialect PostgreSql -TableName 'public.users' -Set @{ display_name = 'Ada' } -Where @{ id = 42 } -CompileWithParameters</dev:code>
+        <dev:remarks>
+          <maml:para>Returns an object with Sql, Parameters, and ParameterValues properties for callers that want to execute parameterized SQL later.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>SELECT statement (Transact-SQL)</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/sql/t-sql/queries/select-transact-sql</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/DbaClientX</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-DbaXTableCopyDefinition</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>DbaXTableCopyDefinition</command:noun>
+      <maml:description>
+        <maml:para>Creates a DbaClientX table-copy definition.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Creates a DbaClientX table-copy definition.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-DbaXTableCopyDefinition</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ColumnMappings</maml:name>
+          <maml:description>
+            <maml:para>Optional source column to destination column mappings.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ColumnTypeConversions</maml:name>
+          <maml:description>
+            <maml:para>Optional destination column type conversions.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DeduplicateByColumns</maml:name>
+          <maml:description>
+            <maml:para>Optional source columns used for source-side deduplication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DeduplicateCaseInsensitive</maml:name>
+          <maml:description>
+            <maml:para>Uses case-insensitive source-side deduplication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DeduplicateOrderByColumns</maml:name>
+          <maml:description>
+            <maml:para>Optional source order columns used to choose rows during deduplication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationName</maml:name>
+          <maml:description>
+            <maml:para>Destination table name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExcludedColumns</maml:name>
+          <maml:description>
+            <maml:para>Optional columns to exclude from copy pages.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>LogicalName</maml:name>
+          <maml:description>
+            <maml:para>Optional logical display name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OrderByColumns</maml:name>
+          <maml:description>
+            <maml:para>Optional source-side order columns for paged reads.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceName</maml:name>
+          <maml:description>
+            <maml:para>Source table or view name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ColumnMappings</maml:name>
+        <maml:description>
+          <maml:para>Optional source column to destination column mappings.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ColumnTypeConversions</maml:name>
+        <maml:description>
+          <maml:para>Optional destination column type conversions.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DeduplicateByColumns</maml:name>
+        <maml:description>
+          <maml:para>Optional source columns used for source-side deduplication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DeduplicateCaseInsensitive</maml:name>
+        <maml:description>
+          <maml:para>Uses case-insensitive source-side deduplication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DeduplicateOrderByColumns</maml:name>
+        <maml:description>
+          <maml:para>Optional source order columns used to choose rows during deduplication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationName</maml:name>
+        <maml:description>
+          <maml:para>Destination table name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExcludedColumns</maml:name>
+        <maml:description>
+          <maml:para>Optional columns to exclude from copy pages.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>LogicalName</maml:name>
+        <maml:description>
+          <maml:para>Optional logical display name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OrderByColumns</maml:name>
+        <maml:description>
+          <maml:para>Optional source-side order columns for paged reads.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceName</maml:name>
+        <maml:description>
+          <maml:para>Source table or view name.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Create a copy definition.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>New-DbaXTableCopyDefinition -SourceName dbo.Users -DestinationName archive.Users -OrderByColumns Id</dev:code>
+        <dev:remarks>
+          <maml:para>Returns a typed copy definition that can be passed to DbaClientX data movement APIs.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-DbaXTableCopyPlan</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>DbaXTableCopyPlan</command:noun>
+      <maml:description>
+        <maml:para>Builds a table-copy plan from supplied DbaClientX metadata objects.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Builds a table-copy plan from supplied DbaClientX metadata objects.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>New-DbaXTableCopyPlan</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ColumnMappings</maml:name>
+          <maml:description>
+            <maml:para>Optional global source column to destination column mappings.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ColumnTypeConversions</maml:name>
+          <maml:description>
+            <maml:para>Optional global column type conversions.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationColumns</maml:name>
+          <maml:description>
+            <maml:para>Optional destination column metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DbaColumnInfo[]</command:parameterValue>
+          <dev:type>
+            <maml:name>DbaColumnInfo[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationSchema</maml:name>
+          <maml:description>
+            <maml:para>Destination schema used for generated destination names.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExcludedColumns</maml:name>
+          <maml:description>
+            <maml:para>Optional global excluded columns.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeDestinationGeneratedColumns</maml:name>
+          <maml:description>
+            <maml:para>Includes destination generated columns in generated pages.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeDestinationIdentityColumns</maml:name>
+          <maml:description>
+            <maml:para>Includes destination identity columns in generated pages.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeSourceGeneratedColumns</maml:name>
+          <maml:description>
+            <maml:para>Includes source generated columns in generated pages.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IncludeViews</maml:name>
+          <maml:description>
+            <maml:para>Includes views in generated copy definitions.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Provider</maml:name>
+          <maml:description>
+            <maml:para>Provider whose identifier folding rules should be used.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DbaXProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SkipDestinationColumnMatch</maml:name>
+          <maml:description>
+            <maml:para>Does not require source columns to exist in destination metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceColumns</maml:name>
+          <maml:description>
+            <maml:para>Source column metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaColumnInfo[]</command:parameterValue>
+          <dev:type>
+            <maml:name>DbaColumnInfo[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceIndexes</maml:name>
+          <maml:description>
+            <maml:para>Optional source index metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DbaIndexInfo[]</command:parameterValue>
+          <dev:type>
+            <maml:name>DbaIndexInfo[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceSchema</maml:name>
+          <maml:description>
+            <maml:para>Restricts source tables to a schema.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SourceTables</maml:name>
+          <maml:description>
+            <maml:para>Source table metadata.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaTableInfo[]</command:parameterValue>
+          <dev:type>
+            <maml:name>DbaTableInfo[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TableMappings</maml:name>
+          <maml:description>
+            <maml:para>Optional source table to destination table mappings.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ColumnMappings</maml:name>
+        <maml:description>
+          <maml:para>Optional global source column to destination column mappings.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ColumnTypeConversions</maml:name>
+        <maml:description>
+          <maml:para>Optional global column type conversions.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationColumns</maml:name>
+        <maml:description>
+          <maml:para>Optional destination column metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DbaColumnInfo[]</command:parameterValue>
+        <dev:type>
+          <maml:name>DbaColumnInfo[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationSchema</maml:name>
+        <maml:description>
+          <maml:para>Destination schema used for generated destination names.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExcludedColumns</maml:name>
+        <maml:description>
+          <maml:para>Optional global excluded columns.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeDestinationGeneratedColumns</maml:name>
+        <maml:description>
+          <maml:para>Includes destination generated columns in generated pages.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeDestinationIdentityColumns</maml:name>
+        <maml:description>
+          <maml:para>Includes destination identity columns in generated pages.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeSourceGeneratedColumns</maml:name>
+        <maml:description>
+          <maml:para>Includes source generated columns in generated pages.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IncludeViews</maml:name>
+        <maml:description>
+          <maml:para>Includes views in generated copy definitions.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Provider</maml:name>
+        <maml:description>
+          <maml:para>Provider whose identifier folding rules should be used.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DbaXProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SkipDestinationColumnMatch</maml:name>
+        <maml:description>
+          <maml:para>Does not require source columns to exist in destination metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceColumns</maml:name>
+        <maml:description>
+          <maml:para>Source column metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaColumnInfo[]</command:parameterValue>
+        <dev:type>
+          <maml:name>DbaColumnInfo[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceIndexes</maml:name>
+        <maml:description>
+          <maml:para>Optional source index metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DbaIndexInfo[]</command:parameterValue>
+        <dev:type>
+          <maml:name>DbaIndexInfo[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceSchema</maml:name>
+        <maml:description>
+          <maml:para>Restricts source tables to a schema.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SourceTables</maml:name>
+        <maml:description>
+          <maml:para>Source table metadata.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaTableInfo[]</command:parameterValue>
+        <dev:type>
+          <maml:name>DbaTableInfo[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TableMappings</maml:name>
+        <maml:description>
+          <maml:para>Optional source table to destination table mappings.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Build a copy plan from metadata.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>New-DbaXTableCopyPlan -SourceTables $tables -SourceColumns $columns -Provider SqlServer -DestinationSchema archive</dev:code>
+        <dev:remarks>
+          <maml:para>Calls the shared DbaClientX table-copy planner.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Test-DbaXConnection</command:name>
+      <command:verb>Test</command:verb>
+      <command:noun>DbaXConnection</command:noun>
+      <maml:description>
+        <maml:para>Validates and optionally pings a DbaClientX provider connection string.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Validates and optionally pings a DbaClientX provider connection string.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Test-DbaXConnection</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>ConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Provider connection string, or a SQLite database path.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Detailed</maml:name>
+          <maml:description>
+            <maml:para>Return a detailed result object instead of a Boolean.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Provider</maml:name>
+          <maml:description>
+            <maml:para>Database provider used to validate the connection string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SkipPing</maml:name>
+          <maml:description>
+            <maml:para>Only validate connection-string shape and skip opening a provider connection.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+        <maml:name>ConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Provider connection string, or a SQLite database path.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Detailed</maml:name>
+        <maml:description>
+          <maml:para>Return a detailed result object instead of a Boolean.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Provider</maml:name>
+        <maml:description>
+          <maml:para>Database provider used to validate the connection string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SkipPing</maml:name>
+        <maml:description>
+          <maml:para>Only validate connection-string shape and skip opening a provider connection.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Test a SQL Server connection string.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Test-DbaXConnection -Provider SqlServer -ConnectionString 'Server=.;Database=master;Integrated Security=True;Encrypt=True;TrustServerCertificate=True' -Detailed</dev:code>
+        <dev:remarks>
+          <maml:para>Returns validation and ping details for the supplied SQL Server connection string.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Write-DbaXAzureTableEntity</command:name>
+      <command:verb>Write</command:verb>
+      <command:noun>DbaXAzureTableEntity</command:noun>
+      <maml:description>
+        <maml:para>Writes PowerShell pipeline objects to Azure Tables in partition-safe transactions.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Input must expose PartitionKey and RowKey properties. Each Azure transaction contains at most 100 entities and stays inside one partition.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Write-DbaXAzureTableEntity</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Maximum entities per same-partition transaction.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Azure Storage or Cosmos DB Table API connection string.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>InputObject</maml:name>
+          <maml:description>
+            <maml:para>Objects containing PartitionKey, RowKey, and optional entity properties.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NoCreateTable</maml:name>
+          <maml:description>
+            <maml:para>Do not create the destination table when it is missing.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PassThru</maml:name>
+          <maml:description>
+            <maml:para>Return a summary after the write.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TableName</maml:name>
+          <maml:description>
+            <maml:para>Destination table.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WriteMode</maml:name>
+          <maml:description>
+            <maml:para>Azure entity write mode.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DbaAzureTableWriteMode</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Add</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UpsertMerge</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UpsertReplace</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaAzureTableWriteMode</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BatchSize</maml:name>
+        <maml:description>
+          <maml:para>Maximum entities per same-partition transaction.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Azure Storage or Cosmos DB Table API connection string.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>InputObject</maml:name>
+        <maml:description>
+          <maml:para>Objects containing PartitionKey, RowKey, and optional entity properties.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NoCreateTable</maml:name>
+        <maml:description>
+          <maml:para>Do not create the destination table when it is missing.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PassThru</maml:name>
+        <maml:description>
+          <maml:para>Return a summary after the write.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TableName</maml:name>
+        <maml:description>
+          <maml:para>Destination table.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WriteMode</maml:name>
+        <maml:description>
+          <maml:para>Azure entity write mode.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">DbaAzureTableWriteMode</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Add</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">UpsertMerge</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">UpsertReplace</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaAzureTableWriteMode</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Upsert report rows.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$rows | Write-DbaXAzureTableEntity -ConnectionString $connectionString -TableName Reports -WriteMode UpsertReplace -PassThru</dev:code>
+        <dev:remarks>
+          <maml:para>Creates the table when needed and replaces matching entities.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Write-DbaXTableData</command:name>
+      <command:verb>Write</command:verb>
+      <command:noun>DbaXTableData</command:noun>
+      <maml:description>
+        <maml:para>Writes tabular pipeline input to a database table using provider-native bulk insert APIs.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Accepts a DataTable, DataView, IDataReader, DataRow pipeline, or regular PowerShell objects and routes the resulting table to the selected DbaClientX provider.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Write-DbaXTableData</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AutoCreateTable</maml:name>
+          <maml:description>
+            <maml:para>SQL Server-only option to create the destination schema and table when they do not already exist.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BatchSize</maml:name>
+          <maml:description>
+            <maml:para>Optional number of rows per provider bulk batch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>BulkCopyTimeout</maml:name>
+          <maml:description>
+            <maml:para>Optional provider bulk-copy timeout in seconds. SQLite does not support this option.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CheckConstraints</maml:name>
+          <maml:description>
+            <maml:para>SQL Server-only option to check destination constraints during the copy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ColumnMap</maml:name>
+          <maml:description>
+            <maml:para>SQL Server-only mapping from source column names to destination column names.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectionString</maml:name>
+          <maml:description>
+            <maml:para>Provider connection string used for the bulk insert.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DestinationTable</maml:name>
+          <maml:description>
+            <maml:para>Destination table name. Include schema or owner when required by the provider.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FireTriggers</maml:name>
+          <maml:description>
+            <maml:para>SQL Server-only option to fire insert triggers during the copy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+          <maml:name>InputObject</maml:name>
+          <maml:description>
+            <maml:para>Tabular input to write. Accepts DataTable, DataView, IDataReader, DataRow, hashtable, and object pipeline input.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+          <dev:type>
+            <maml:name>Object</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>KeepIdentity</maml:name>
+          <maml:description>
+            <maml:para>SQL Server-only option to preserve identity values from the source data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>KeepNulls</maml:name>
+          <maml:description>
+            <maml:para>SQL Server-only option to preserve null values from the source data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>NotifyAfter</maml:name>
+          <maml:description>
+            <maml:para>SQL Server-only number of rows copied between progress updates.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PassThru</maml:name>
+          <maml:description>
+            <maml:para>Writes a small result object with provider, destination table, and row count.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Provider</maml:name>
+          <maml:description>
+            <maml:para>Database provider that should receive the bulk insert.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">DbaXBulkProvider</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DbaXBulkProvider</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TableLock</maml:name>
+          <maml:description>
+            <maml:para>SQL Server-only option to acquire a bulk update lock for the duration of the copy.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AutoCreateTable</maml:name>
+        <maml:description>
+          <maml:para>SQL Server-only option to create the destination schema and table when they do not already exist.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BatchSize</maml:name>
+        <maml:description>
+          <maml:para>Optional number of rows per provider bulk batch.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>BulkCopyTimeout</maml:name>
+        <maml:description>
+          <maml:para>Optional provider bulk-copy timeout in seconds. SQLite does not support this option.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CheckConstraints</maml:name>
+        <maml:description>
+          <maml:para>SQL Server-only option to check destination constraints during the copy.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ColumnMap</maml:name>
+        <maml:description>
+          <maml:para>SQL Server-only mapping from source column names to destination column names.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectionString</maml:name>
+        <maml:description>
+          <maml:para>Provider connection string used for the bulk insert.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DestinationTable</maml:name>
+        <maml:description>
+          <maml:para>Destination table name. Include schema or owner when required by the provider.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FireTriggers</maml:name>
+        <maml:description>
+          <maml:para>SQL Server-only option to fire insert triggers during the copy.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="True (ByValue)" position="named" aliases="None">
+        <maml:name>InputObject</maml:name>
+        <maml:description>
+          <maml:para>Tabular input to write. Accepts DataTable, DataView, IDataReader, DataRow, hashtable, and object pipeline input.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Object</command:parameterValue>
+        <dev:type>
+          <maml:name>Object</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>KeepIdentity</maml:name>
+        <maml:description>
+          <maml:para>SQL Server-only option to preserve identity values from the source data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>KeepNulls</maml:name>
+        <maml:description>
+          <maml:para>SQL Server-only option to preserve null values from the source data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>NotifyAfter</maml:name>
+        <maml:description>
+          <maml:para>SQL Server-only number of rows copied between progress updates.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PassThru</maml:name>
+        <maml:description>
+          <maml:para>Writes a small result object with provider, destination table, and row count.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Provider</maml:name>
+        <maml:description>
+          <maml:para>Database provider that should receive the bulk insert.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">DbaXBulkProvider</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">SqlServer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PostgreSql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MySql</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Oracle</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SQLite</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>DbaXBulkProvider</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TableLock</maml:name>
+        <maml:description>
+          <maml:para>SQL Server-only option to acquire a bulk update lock for the duration of the copy.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.Object</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Write an Excel-imported DataTable to SQL Server.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>Import-OfficeExcel .\Data.xlsx -AsDataTable | Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=.;Database=App;Encrypt=True;TrustServerCertificate=True;Integrated Security=True' -DestinationTable dbo.Import</dev:code>
+        <dev:remarks>
+          <maml:para>Loads the workbook rows as a DataTable and sends them through the SQL Server bulk-copy provider.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Create a SQL Server staging table from incoming columns.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$rows | Write-DbaXTableData -Provider SqlServer -ConnectionString 'Server=.;Database=App;Encrypt=True;TrustServerCertificate=True;Integrated Security=True' -DestinationTable staging.Import -AutoCreateTable -TableLock</dev:code>
+        <dev:remarks>
+          <maml:para>Creates the destination schema and table when needed, then writes the rows through SQL Server bulk copy.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Write object pipeline data to PostgreSQL.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$rows | Write-DbaXTableData -Provider PostgreSql -ConnectionString 'Host=localhost;Database=app;Username=user;Password=secret;SslMode=Require' -DestinationTable public.import_data -BatchSize 5000</dev:code>
+        <dev:remarks>
+          <maml:para>Converts the objects to a DataTable and writes them with the PostgreSQL COPY-backed provider.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+</helpItems>


### PR DESCRIPTION
## Summary

- remove MatejKafka.XmlDoc2CmdletDoc from the DbaClientX and FabricClientX binary modules
- generate Markdown and external MAML through PSPublishModule 3.0.88
- package both module-named and assembly-named external help
- update CI to use the corrected shared documentation owner

## Validation

- exact public PSPublishModule 3.0.88 builds completed for both modules
- generated Markdown/MAML parity: DbaClientX 37/37; FabricClientX 8/8
- package ZIPs contain both module and assembly help aliases
- representative Get-Help synopsis matches generated MAML in PowerShell 7 and Windows PowerShell 5.1
- no XmlDoc2CmdletDoc package, target, or argument remains

This PR is intentionally limited to dependency removal and functional build/package/Get-Help preservation.