### PR TITLE
Stream SQL results into CSV and Excel exports

### DIFF
--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -153,7 +153,8 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
     /// Processes input and performs the cmdlet's primary work.
     /// </summary>
     protected override async Task ProcessRecordAsync() {
-        var returnDataReader = string.Equals(ParameterSetName, "QueryReader", StringComparison.Ordinal);
+        await Task.Yield();
+        var returnDataReader = AsDataReader.IsPresent;
         var action = !string.IsNullOrEmpty(StoredProcedure) ? "Execute SQL Server stored procedure" : "Execute SQL Server query";
         if (!ShouldProcess($"{Server}/{Database}", action)) {
             return;

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -5,7 +5,7 @@ namespace DBAClientX.PowerShell;
 
 /// <summary>Invokes a SQL Server query or stored procedure.</summary>
 /// <para>Connects to a SQL Server instance using integrated security or supplied credentials and executes the specified command.</para>
-/// <para>Supports streaming results and multiple return formats via the <see cref="ReturnType"/> parameter.</para>
+/// <para>Supports streaming results, multiple buffered return formats, and transferring an owned data reader to a consuming API.</para>
 /// <list type="alertSet">
 /// <item>
 /// <term>Note</term>
@@ -35,6 +35,17 @@ namespace DBAClientX.PowerShell;
 /// Invoke-DbaXQuery -Server 'sql01' -Database 'app' -StoredProcedure 'dbo.usp_GetActiveUsers' -Credential $credential -ReturnType DataTable</code>
 /// <para>Runs the stored procedure and outputs a <see cref="DataTable"/>.</para>
 /// </example>
+/// <example>
+/// <summary>Stream query rows into a file writer.</summary>
+/// <prefix>PS&gt; </prefix>
+/// <code>$reader = Invoke-DbaXQuery -Server 'sql01' -Database 'app' -Query 'SELECT * FROM dbo.Users' -AsDataReader
+/// try {
+///     Export-OfficeCsv -InputObject $reader -Path .\Users.csv
+/// } finally {
+///     $reader.Dispose()
+/// }</code>
+/// <para>Returns one live <see cref="DbDataReader"/>. The caller must dispose it after the consuming API finishes reading.</para>
+/// </example>
 /// <seealso href="https://learn.microsoft.com/dotnet/framework/data/adonet/using-sqlclient">Using SqlClient</seealso>
 /// <seealso href="https://github.com/EvotecIT/DbaClientX">Project documentation</seealso>
 [Cmdlet(VerbsLifecycle.Invoke, "DbaXQuery", DefaultParameterSetName = "Query", SupportsShouldProcess = true)]
@@ -48,6 +59,7 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
 
     /// <summary>Specifies the SQL Server instance.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
+    [Parameter(Mandatory = true, ParameterSetName = "QueryReader")]
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [Alias("DBServer", "SqlInstance", "Instance")]
     [ValidateNotNullOrEmpty]
@@ -55,12 +67,14 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
 
     /// <summary>Defines the database name.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
+    [Parameter(Mandatory = true, ParameterSetName = "QueryReader")]
     [Parameter(Mandatory = true, ParameterSetName = "StoredProcedure")]
     [ValidateNotNullOrEmpty]
     public string Database { get; set; } = string.Empty;
 
     /// <summary>The SQL statement to execute.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Query")]
+    [Parameter(Mandatory = true, ParameterSetName = "QueryReader")]
     [ValidateNotNullOrEmpty]
     public string Query { get; set; } = string.Empty;
 
@@ -71,6 +85,7 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
 
     /// <summary>Sets the command timeout in seconds.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    [Parameter(Mandatory = false, ParameterSetName = "QueryReader")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public int QueryTimeout { get; set; }
 
@@ -85,29 +100,38 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
     [Alias("As")]
     public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
 
+    /// <summary>Returns one live reader that owns its command and connection until the caller disposes it.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = "QueryReader")]
+    public SwitchParameter AsDataReader { get; set; }
+
     /// <summary>Provides additional parameters for the query or procedure.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    [Parameter(Mandatory = false, ParameterSetName = "QueryReader")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public Hashtable? Parameters { get; set; }
 
     /// <summary>Optional user name for SQL authentication.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    [Parameter(Mandatory = false, ParameterSetName = "QueryReader")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public string Username { get; set; } = string.Empty;
 
     /// <summary>Optional password for SQL authentication.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    [Parameter(Mandatory = false, ParameterSetName = "QueryReader")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public string Password { get; set; } = string.Empty;
 
     /// <summary>Optional SQL authentication credential.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    [Parameter(Mandatory = false, ParameterSetName = "QueryReader")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     [Credential]
     public PSCredential? Credential { get; set; }
 
     /// <summary>Trusts the SQL Server TLS certificate without validating the certificate chain.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
+    [Parameter(Mandatory = false, ParameterSetName = "QueryReader")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public SwitchParameter TrustServerCertificate { get; set; }
 
@@ -129,7 +153,7 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
     /// Processes input and performs the cmdlet's primary work.
     /// </summary>
     protected override async Task ProcessRecordAsync() {
-        await Task.Yield();
+        var returnDataReader = string.Equals(ParameterSetName, "QueryReader", StringComparison.Ordinal);
         var action = !string.IsNullOrEmpty(StoredProcedure) ? "Execute SQL Server stored procedure" : "Execute SQL Server query";
         if (!ShouldProcess($"{Server}/{Database}", action)) {
             return;
@@ -212,6 +236,12 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
                 resolvedUsername,
                 resolvedPassword,
                 trustServerCertificate: TrustServerCertificate.IsPresent);
+            if (returnDataReader)
+            {
+                await WriteDataReaderAsync(connectionString, parameters).ConfigureAwait(false);
+                return;
+            }
+
             if (!PowerShellHelpers.TryValidateConnection(this, "sqlserver", connectionString, ErrorAction))
             {
                 return;
@@ -323,6 +353,29 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
         sqlServer.ReturnType = ReturnType;
         sqlServer.CommandTimeout = QueryTimeout;
         return sqlServer;
+    }
+
+    private async Task WriteDataReaderAsync(string connectionString, IDictionary<string, object?>? parameters)
+    {
+        using var sqlServer = CreateSqlServer();
+        DbaDataReader? reader = null;
+        try
+        {
+            reader = await sqlServer.QueryReaderAsync(
+                connectionString,
+                Query,
+                parameters,
+                cancellationToken: CancelToken).ConfigureAwait(false);
+            WriteObjectAndWait(reader, enumerateCollection: false);
+            reader = null;
+        }
+        finally
+        {
+            if (reader != null)
+            {
+                await reader.DisposeAsync().ConfigureAwait(false);
+            }
+        }
     }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -100,7 +100,11 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
     [Alias("As")]
     public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
 
-    /// <summary>Returns one live reader that owns its command and connection until the caller disposes it.</summary>
+    /// <summary>
+    /// When enabled, returns one live reader that owns its command and connection until the caller disposes it.
+    /// A disabled switch remains compatible with ordinary buffered query options.
+    /// </summary>
+    [Parameter(Mandatory = false, ParameterSetName = "Query")]
     [Parameter(Mandatory = true, ParameterSetName = "QueryReader")]
     public SwitchParameter AsDataReader { get; set; }
 
@@ -155,6 +159,12 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
     protected override async Task ProcessRecordAsync() {
         await Task.Yield();
         var returnDataReader = AsDataReader.IsPresent;
+        if (returnDataReader &&
+            (Stream.IsPresent || MyInvocation.BoundParameters.ContainsKey(nameof(ReturnType)))) {
+            throw new ArgumentException(
+                "AsDataReader cannot be combined with Stream or ReturnType when enabled.",
+                nameof(AsDataReader));
+        }
         var action = !string.IsNullOrEmpty(StoredProcedure) ? "Execute SQL Server stored procedure" : "Execute SQL Server query";
         if (!ShouldProcess($"{Server}/{Database}", action)) {
             return;

--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -217,6 +217,61 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
                 return;
             }
 
+            if (ReturnType == ReturnType.PSObject && string.IsNullOrEmpty(StoredProcedure))
+            {
+                using var psObjectSqlServer = CreateSqlServer();
+                string[] columnNames = Array.Empty<string>();
+                object[] values = Array.Empty<object>();
+                void Initialize(IDataRecord record)
+                {
+                    columnNames = PSObjectConverter.GetUniqueColumnNames(record);
+                    values = new object[columnNames.Length];
+                }
+
+                PSObject Map(IDataRecord record) =>
+                    PSObjectConverter.DataRecordToPSObject(record, columnNames, values);
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+                if (Stream.IsPresent)
+                {
+                    await WritePSObjectsAsync(psObjectSqlServer.QueryStreamAsync(
+                        connectionString,
+                        Query,
+                        Map,
+                        parameters,
+                        cancellationToken: CancelToken,
+                        initialize: Initialize)).ConfigureAwait(false);
+                }
+                else
+                {
+                    var rows = await psObjectSqlServer.QueryAsListAsync(
+                        connectionString,
+                        Query,
+                        Map,
+                        parameters,
+                        cancellationToken: CancelToken,
+                        initialize: Initialize).ConfigureAwait(false);
+                    foreach (var row in rows)
+                    {
+                        WriteObject(row);
+                    }
+                }
+#else
+                var rows = await psObjectSqlServer.QueryAsListAsync(
+                    connectionString,
+                    Query,
+                    Map,
+                    parameters,
+                    cancellationToken: CancelToken,
+                    initialize: Initialize).ConfigureAwait(false);
+                foreach (var row in rows)
+                {
+                    WriteObject(row);
+                }
+#endif
+                return;
+            }
+
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
             if (Stream.IsPresent)
             {
@@ -269,6 +324,16 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
         sqlServer.CommandTimeout = QueryTimeout;
         return sqlServer;
     }
+
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER
+    private async Task WritePSObjectsAsync(IAsyncEnumerable<PSObject> rows)
+    {
+        await foreach (var row in rows.ConfigureAwait(false))
+        {
+            WriteObject(row);
+        }
+    }
+#endif
 
     private void WriteRows(IEnumerable<DataRow> rows)
     {

--- a/DbaClientX.PowerShell/PSObjectConverter.cs
+++ b/DbaClientX.PowerShell/PSObjectConverter.cs
@@ -7,7 +7,7 @@ namespace DBAClientX.PowerShell;
 /// </summary>
 public static class PSObjectConverter
 {
-    private static readonly ConditionalWeakTable<DataTable, PSNoteProperty[]> _psNotePropertyCache = new();
+    private static readonly ConditionalWeakTable<DataTable, string[]> _columnNameCache = new();
 
     /// <summary>
     /// Converts a <see cref="DataRow"/> into a PowerShell <see cref="PSObject"/> with note properties matching the row's columns.
@@ -16,33 +16,85 @@ public static class PSObjectConverter
     /// <returns>A <see cref="PSObject"/> representing the provided data row.</returns>
     public static PSObject DataRowToPSObject(DataRow row)
     {
-        PSObject psObject = new PSObject();
+        PSObject psObject = new PSObject(row?.Table.Columns.Count ?? 0);
 
         if (row != null)
         {
             var table = row.Table;
-            if (!_psNotePropertyCache.TryGetValue(table, out var propertyTemplates))
+            if (!_columnNameCache.TryGetValue(table, out var columnNames))
             {
-                propertyTemplates = new PSNoteProperty[table.Columns.Count];
+                columnNames = new string[table.Columns.Count];
                 for (int i = 0; i < table.Columns.Count; i++)
                 {
-                    propertyTemplates[i] = new PSNoteProperty(table.Columns[i].ColumnName, null);
+                    columnNames[i] = table.Columns[i].ColumnName;
                 }
-                _psNotePropertyCache.Add(table, propertyTemplates);
+                _columnNameCache.Add(table, columnNames);
             }
 
-            for (int i = 0; i < propertyTemplates.Length; i++)
+            for (int i = 0; i < columnNames.Length; i++)
             {
-                var prop = (PSNoteProperty)propertyTemplates[i].Copy();
-                if (!row.IsNull(i))
-                {
-                    prop.Value = row[i];
-                }
-                psObject.Properties.Add(prop);
+                object? value = row.IsNull(i) ? null : row[i];
+                AddNoteProperty(psObject, columnNames[i], value);
             }
         }
 
         return psObject;
+    }
+
+    internal static string[] GetUniqueColumnNames(IDataRecord record)
+    {
+        var names = new string[record.FieldCount];
+        var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (int ordinal = 0; ordinal < names.Length; ordinal++)
+        {
+            string baseName = record.GetName(ordinal);
+            if (string.IsNullOrEmpty(baseName))
+            {
+                baseName = $"Column{ordinal + 1}";
+            }
+
+            string name = baseName;
+            for (int suffix = 1; !usedNames.Add(name); suffix++)
+            {
+                name = baseName + suffix.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            }
+
+            names[ordinal] = name;
+        }
+
+        return names;
+    }
+
+    internal static PSObject DataRecordToPSObject(IDataRecord record, string[] columnNames, object[] values)
+    {
+        if (record.FieldCount != columnNames.Length || values.Length < columnNames.Length)
+        {
+            throw new ArgumentException("Column names and value storage must match the data record field count.");
+        }
+
+        record.GetValues(values);
+        var psObject = new PSObject(columnNames.Length);
+        for (int ordinal = 0; ordinal < columnNames.Length; ordinal++)
+        {
+            object? value = values[ordinal] is DBNull ? null : values[ordinal];
+            AddNoteProperty(psObject, columnNames[ordinal], value);
+        }
+
+        return psObject;
+    }
+
+    private static void AddNoteProperty(PSObject psObject, string name, object? value)
+    {
+        var property = new PSNoteProperty(name, value);
+        if (name.StartsWith("PS", StringComparison.OrdinalIgnoreCase))
+        {
+            // PowerShell reserves the PS* namespace for adapted and extended members.
+            // Preserve its validation and exception behavior for those names.
+            psObject.Properties.Add(property);
+            return;
+        }
+
+        psObject.Properties.Add(property, preValidated: true);
     }
 }
 

--- a/DbaClientX.PowerShell/PSObjectConverter.cs
+++ b/DbaClientX.PowerShell/PSObjectConverter.cs
@@ -16,7 +16,7 @@ public static class PSObjectConverter
     /// <returns>A <see cref="PSObject"/> representing the provided data row.</returns>
     public static PSObject DataRowToPSObject(DataRow row)
     {
-        PSObject psObject = new PSObject(row?.Table.Columns.Count ?? 0);
+        PSObject psObject = new PSObject();
 
         if (row != null)
         {
@@ -73,7 +73,7 @@ public static class PSObjectConverter
         }
 
         record.GetValues(values);
-        var psObject = new PSObject(columnNames.Length);
+        var psObject = new PSObject();
         for (int ordinal = 0; ordinal < columnNames.Length; ordinal++)
         {
             object? value = values[ordinal] is DBNull ? null : values[ordinal];

--- a/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
+++ b/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
@@ -85,7 +85,7 @@ public class InvokeDbaXQueryCmdletTests
     }
 
     [Fact]
-    public void AsDataReader_UsesAnExclusiveQueryReaderParameterSet()
+    public void AsDataReader_IsBindableInBufferedQueriesWhileRetainingTheReaderSet()
     {
         var readerParameterSets = typeof(CmdletIInvokeDbaXQuery)
             .GetProperty(nameof(CmdletIInvokeDbaXQuery.AsDataReader))!
@@ -106,7 +106,8 @@ public class InvokeDbaXQueryCmdletTests
             .Select(attribute => attribute.ParameterSetName)
             .ToArray();
 
-        Assert.Equal(new[] { "QueryReader" }, readerParameterSets);
+        Assert.Contains("Query", readerParameterSets);
+        Assert.Contains("QueryReader", readerParameterSets);
         Assert.DoesNotContain("QueryReader", streamParameterSets);
         Assert.DoesNotContain("QueryReader", returnTypeParameterSets);
     }
@@ -131,13 +132,48 @@ public class InvokeDbaXQueryCmdletTests
                 .AddParameter("Server", "localhost")
                 .AddParameter("Database", "tempdb")
                 .AddParameter("Query", "SELECT 1")
+                .AddParameter("ReturnType", ReturnType.DataTable)
+                .AddParameter("Stream", false)
                 .AddParameter("AsDataReader", false);
 
             Collection<PSObject> results = powerShell.Invoke();
 
-            Assert.Equal(2, results.Count);
-            Assert.All(results, result => Assert.IsType<DataRow>(result.BaseObject));
+            var result = Assert.Single(results);
+            Assert.IsType<DataTable>(result.BaseObject);
             Assert.Empty(powerShell.Streams.Warning);
+        }
+        finally
+        {
+            CmdletIInvokeDbaXQuery.SqlServerFactory = () => new SqlServer();
+        }
+    }
+
+    [Fact]
+    public void EnabledAsDataReader_RejectsBufferedReturnOptionsBeforeQuerying()
+    {
+        using var table = CreateTable();
+        CmdletIInvokeDbaXQuery.SqlServerFactory = () => new DataTableSqlServer(table);
+
+        try
+        {
+            var state = InitialSessionState.CreateDefault();
+            state.Commands.Add(new SessionStateCmdletEntry(
+                "Invoke-DbaXQuery",
+                typeof(CmdletIInvokeDbaXQuery),
+                helpFileName: null));
+
+            using var powerShell = PowerShell.Create(state);
+            powerShell
+                .AddCommand("Invoke-DbaXQuery")
+                .AddParameter("Server", "localhost")
+                .AddParameter("Database", "tempdb")
+                .AddParameter("Query", "SELECT 1")
+                .AddParameter("ReturnType", ReturnType.DataTable)
+                .AddParameter("AsDataReader", true);
+
+            RuntimeException exception = Assert.ThrowsAny<RuntimeException>(() => powerShell.Invoke());
+
+            Assert.Contains("AsDataReader cannot be combined", exception.Message, StringComparison.Ordinal);
         }
         finally
         {

--- a/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
+++ b/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
@@ -130,6 +130,9 @@ public class InvokeDbaXQueryCmdletTests
                 "The reader query did not start in time.");
 
             var stopTask = Task.Run(powerShell.Stop);
+            Assert.True(
+                sqlServer.CancellationRequested.Wait(TimeSpan.FromSeconds(5)),
+                "The reader query did not observe pipeline cancellation in time.");
             sqlServer.ReleaseReader();
 
             await stopTask.WaitAsync(TimeSpan.FromSeconds(5));
@@ -140,6 +143,7 @@ public class InvokeDbaXQueryCmdletTests
         {
             CmdletIInvokeDbaXQuery.SqlServerFactory = () => new SqlServer();
             sqlServer.QueryStarted.Dispose();
+            sqlServer.CancellationRequested.Dispose();
             ownedReader.Dispose();
         }
     }
@@ -210,6 +214,8 @@ public class InvokeDbaXQueryCmdletTests
 
         public ManualResetEventSlim QueryStarted { get; } = new();
 
+        public ManualResetEventSlim CancellationRequested { get; } = new();
+
         public void ReleaseReader()
             => _releaseReader.TrySetResult();
 
@@ -223,6 +229,7 @@ public class InvokeDbaXQueryCmdletTests
             IDictionary<string, ParameterDirection>? parameterDirections = null)
         {
             QueryStarted.Set();
+            using var cancellationRegistration = cancellationToken.Register(CancellationRequested.Set);
             await _releaseReader.Task.ConfigureAwait(false);
             return _reader;
         }

--- a/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
+++ b/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Collections;
 using System.Collections.ObjectModel;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
@@ -49,6 +50,100 @@ public class InvokeDbaXQueryCmdletTests
         }
     }
 
+    [Fact]
+    public void AsDataReader_EmitsSingleLiveReaderWithoutEnumeratingIt()
+    {
+        using var table = CreateTable();
+        var ownedReader = new DbaDataReader(table.CreateDataReader());
+        var sqlServer = new DataReaderSqlServer(ownedReader);
+        CmdletIInvokeDbaXQuery.SqlServerFactory = () => sqlServer;
+
+        try
+        {
+            var results = InvokeReader(queryTimeout: 11, parameters: new Hashtable { ["MinimumId"] = 1 });
+
+            var result = Assert.Single(results);
+            var reader = Assert.IsType<DbaDataReader>(result.BaseObject);
+            Assert.Same(ownedReader, reader);
+            Assert.False(reader.IsClosed);
+            Assert.True(reader.Read());
+            Assert.Equal(1, reader.GetInt32(0));
+            Assert.Equal(1, sqlServer.QueryReaderCalls);
+            Assert.Equal(11, sqlServer.CommandTimeout);
+            Assert.Equal(1, sqlServer.ReceivedParameters!["MinimumId"]);
+            Assert.True(sqlServer.ReceivedCancellationToken.CanBeCanceled);
+            Assert.True(new SqlConnectionStringBuilder(sqlServer.ReceivedConnectionString).TrustServerCertificate);
+
+            reader.Dispose();
+            Assert.True(reader.IsClosed);
+        }
+        finally
+        {
+            CmdletIInvokeDbaXQuery.SqlServerFactory = () => new SqlServer();
+            ownedReader.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AsDataReader_UsesAnExclusiveQueryReaderParameterSet()
+    {
+        var readerParameterSets = typeof(CmdletIInvokeDbaXQuery)
+            .GetProperty(nameof(CmdletIInvokeDbaXQuery.AsDataReader))!
+            .GetCustomAttributes(typeof(ParameterAttribute), inherit: false)
+            .Cast<ParameterAttribute>()
+            .Select(attribute => attribute.ParameterSetName)
+            .ToArray();
+        var streamParameterSets = typeof(CmdletIInvokeDbaXQuery)
+            .GetProperty(nameof(CmdletIInvokeDbaXQuery.Stream))!
+            .GetCustomAttributes(typeof(ParameterAttribute), inherit: false)
+            .Cast<ParameterAttribute>()
+            .Select(attribute => attribute.ParameterSetName)
+            .ToArray();
+        var returnTypeParameterSets = typeof(CmdletIInvokeDbaXQuery)
+            .GetProperty(nameof(CmdletIInvokeDbaXQuery.ReturnType))!
+            .GetCustomAttributes(typeof(ParameterAttribute), inherit: false)
+            .Cast<ParameterAttribute>()
+            .Select(attribute => attribute.ParameterSetName)
+            .ToArray();
+
+        Assert.Equal(new[] { "QueryReader" }, readerParameterSets);
+        Assert.DoesNotContain("QueryReader", streamParameterSets);
+        Assert.DoesNotContain("QueryReader", returnTypeParameterSets);
+    }
+
+    [Fact]
+    public async Task AsDataReader_DisposesReaderWhenPipelineStopsBeforeDelivery()
+    {
+        using var table = CreateTable();
+        var ownedReader = new DbaDataReader(table.CreateDataReader());
+        var sqlServer = new DelayedDataReaderSqlServer(ownedReader);
+        CmdletIInvokeDbaXQuery.SqlServerFactory = () => sqlServer;
+
+        try
+        {
+            using var powerShell = CreateReaderPowerShell(
+                queryTimeout: 30,
+                parameters: new Hashtable());
+            var invocation = powerShell.BeginInvoke();
+            Assert.True(
+                sqlServer.QueryStarted.Wait(TimeSpan.FromSeconds(5)),
+                "The reader query did not start in time.");
+
+            var stopTask = Task.Run(powerShell.Stop);
+            sqlServer.ReleaseReader();
+
+            await stopTask.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Throws<PipelineStoppedException>(() => powerShell.EndInvoke(invocation));
+            Assert.True(ownedReader.IsClosed);
+        }
+        finally
+        {
+            CmdletIInvokeDbaXQuery.SqlServerFactory = () => new SqlServer();
+            sqlServer.QueryStarted.Dispose();
+            ownedReader.Dispose();
+        }
+    }
+
     private sealed class DataTableSqlServer : SqlServer
     {
         private readonly DataTable _table;
@@ -66,6 +161,71 @@ public class InvokeDbaXQueryCmdletTests
             IDictionary<string, SqlDbType>? parameterTypes = null,
             IDictionary<string, ParameterDirection>? parameterDirections = null)
             => ReturnType == ReturnType.DataRow ? _table.Rows : _table;
+    }
+
+    private sealed class DataReaderSqlServer : SqlServer
+    {
+        private readonly DbaDataReader _reader;
+
+        public DataReaderSqlServer(DbaDataReader reader)
+        {
+            _reader = reader;
+        }
+
+        public int QueryReaderCalls { get; private set; }
+
+        public string ReceivedConnectionString { get; private set; } = string.Empty;
+
+        public IDictionary<string, object?>? ReceivedParameters { get; private set; }
+
+        public CancellationToken ReceivedCancellationToken { get; private set; }
+
+        public override Task<DbaDataReader> QueryReaderAsync(
+            string connectionString,
+            string query,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, SqlDbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            QueryReaderCalls++;
+            ReceivedConnectionString = connectionString;
+            ReceivedParameters = parameters;
+            ReceivedCancellationToken = cancellationToken;
+            return Task.FromResult(_reader);
+        }
+    }
+
+    private sealed class DelayedDataReaderSqlServer : SqlServer
+    {
+        private readonly DbaDataReader _reader;
+        private readonly TaskCompletionSource _releaseReader =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public DelayedDataReaderSqlServer(DbaDataReader reader)
+        {
+            _reader = reader;
+        }
+
+        public ManualResetEventSlim QueryStarted { get; } = new();
+
+        public void ReleaseReader()
+            => _releaseReader.TrySetResult();
+
+        public override async Task<DbaDataReader> QueryReaderAsync(
+            string connectionString,
+            string query,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, SqlDbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+        {
+            QueryStarted.Set();
+            await _releaseReader.Task.ConfigureAwait(false);
+            return _reader;
+        }
     }
 
     private static DataTable CreateTable()
@@ -91,5 +251,30 @@ public class InvokeDbaXQueryCmdletTests
             .AddParameter("ReturnType", returnType);
 
         return powerShell.Invoke();
+    }
+
+    private static Collection<PSObject> InvokeReader(int queryTimeout, Hashtable parameters)
+    {
+        using var powerShell = CreateReaderPowerShell(queryTimeout, parameters);
+
+        return powerShell.Invoke();
+    }
+
+    private static PowerShell CreateReaderPowerShell(int queryTimeout, Hashtable parameters)
+    {
+        var state = InitialSessionState.CreateDefault();
+        state.Commands.Add(new SessionStateCmdletEntry("Invoke-DbaXQuery", typeof(CmdletIInvokeDbaXQuery), helpFileName: null));
+
+        var powerShell = PowerShell.Create(state);
+        powerShell
+            .AddCommand("Invoke-DbaXQuery")
+            .AddParameter("Server", "localhost")
+            .AddParameter("Database", "tempdb")
+            .AddParameter("Query", "SELECT Id FROM dbo.Rows WHERE Id >= @MinimumId")
+            .AddParameter("QueryTimeout", queryTimeout)
+            .AddParameter("Parameters", parameters)
+            .AddParameter("TrustServerCertificate")
+            .AddParameter("AsDataReader");
+        return powerShell;
     }
 }

--- a/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
+++ b/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
@@ -112,6 +112,40 @@ public class InvokeDbaXQueryCmdletTests
     }
 
     [Fact]
+    public void ExplicitFalseAsDataReader_UsesTheBufferedQueryContract()
+    {
+        using var table = CreateTable();
+        CmdletIInvokeDbaXQuery.SqlServerFactory = () => new DataTableSqlServer(table);
+
+        try
+        {
+            var state = InitialSessionState.CreateDefault();
+            state.Commands.Add(new SessionStateCmdletEntry(
+                "Invoke-DbaXQuery",
+                typeof(CmdletIInvokeDbaXQuery),
+                helpFileName: null));
+
+            using var powerShell = PowerShell.Create(state);
+            powerShell
+                .AddCommand("Invoke-DbaXQuery")
+                .AddParameter("Server", "localhost")
+                .AddParameter("Database", "tempdb")
+                .AddParameter("Query", "SELECT 1")
+                .AddParameter("AsDataReader", false);
+
+            Collection<PSObject> results = powerShell.Invoke();
+
+            Assert.Equal(2, results.Count);
+            Assert.All(results, result => Assert.IsType<DataRow>(result.BaseObject));
+            Assert.Empty(powerShell.Streams.Warning);
+        }
+        finally
+        {
+            CmdletIInvokeDbaXQuery.SqlServerFactory = () => new SqlServer();
+        }
+    }
+
+    [Fact]
     public async Task AsDataReader_DisposesReaderWhenPipelineStopsBeforeDelivery()
     {
         using var table = CreateTable();
@@ -167,6 +201,16 @@ public class InvokeDbaXQueryCmdletTests
             IDictionary<string, SqlDbType>? parameterTypes = null,
             IDictionary<string, ParameterDirection>? parameterDirections = null)
             => ReturnType == ReturnType.DataRow ? _table.Rows : _table;
+
+        public override Task<DbaDataReader> QueryReaderAsync(
+            string connectionString,
+            string query,
+            IDictionary<string, object?>? parameters = null,
+            bool useTransaction = false,
+            CancellationToken cancellationToken = default,
+            IDictionary<string, SqlDbType>? parameterTypes = null,
+            IDictionary<string, ParameterDirection>? parameterDirections = null)
+            => throw new InvalidOperationException("The buffered query contract must not request a data reader.");
     }
 
     private sealed class DataReaderSqlServer : SqlServer

--- a/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
+++ b/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
@@ -137,7 +137,9 @@ public class InvokeDbaXQueryCmdletTests
 
             await stopTask.WaitAsync(TimeSpan.FromSeconds(5));
             Assert.Throws<PipelineStoppedException>(() => powerShell.EndInvoke(invocation));
-            Assert.True(ownedReader.IsClosed);
+            Assert.True(
+                SpinWait.SpinUntil(() => ownedReader.IsClosed, TimeSpan.FromSeconds(5)),
+                "The canceled query reader was not disposed in time.");
         }
         finally
         {

--- a/DbaClientX.Tests/PSObjectConverterTests.cs
+++ b/DbaClientX.Tests/PSObjectConverterTests.cs
@@ -28,4 +28,42 @@ public class PSObjectConverterTests
         Assert.Equal(2, ps2.Properties["Id"].Value);
         Assert.Equal("Bob", ps2.Properties["Name"].Value);
     }
+
+    [Fact]
+    public void DataRecordToPSObjectPreservesValuesAndConvertsDbNullToNull()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Columns.Add("Name", typeof(string));
+        table.Rows.Add(7, DBNull.Value);
+
+        using var reader = table.CreateDataReader();
+        Assert.True(reader.Read());
+        string[] columnNames = PSObjectConverter.GetUniqueColumnNames(reader);
+        var converted = PSObjectConverter.DataRecordToPSObject(reader, columnNames, new object[reader.FieldCount]);
+
+        Assert.Equal(7, converted.Properties["Id"].Value);
+        Assert.Null(converted.Properties["Name"].Value);
+    }
+
+    [Fact]
+    public void GetUniqueColumnNamesPreservesWhitespaceAliases()
+    {
+        var table = new DataTable();
+        table.Columns.Add(" ", typeof(int));
+        table.Rows.Add(1);
+
+        using var reader = table.CreateDataReader();
+        Assert.Equal(new[] { " " }, PSObjectConverter.GetUniqueColumnNames(reader));
+    }
+
+    [Fact]
+    public void DataRowToPSObjectRejectsReservedPowerShellMemberNames()
+    {
+        var table = new DataTable();
+        table.Columns.Add("PSObject", typeof(int));
+        table.Rows.Add(1);
+
+        Assert.Throws<ExtendedTypeSystemException>(() => PSObjectConverter.DataRowToPSObject(table.Rows[0]));
+    }
 }

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -131,8 +131,10 @@ Build-Module -ModuleName 'DbaClientX' -NoInteractive {
 
     New-ConfigurationBuild @newConfigurationBuildSplat
 
-    New-ConfigurationProjectBuild -Name 'DbaClientX' -ConfigPath '..\Build\project.build.json' -Enabled:$true -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget
-    New-ConfigurationRelease -StageRoot 'Artefacts\UploadReady' -VersionSource ProjectBuild -PrimaryProject 'DbaClientX.Core' -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
+    # NuGet packages keep independent 0.x versions; build them as module dependencies,
+    # not as members of the PowerShell module's coordinated 1.0.x release line.
+    New-ConfigurationProjectBuild -Name 'DbaClientX' -ConfigPath '..\Build\project.build.json' -Enabled:$false -BuildBeforeModule -ProvideLocalNuGetFeed -PublishNuget
+    New-ConfigurationRelease -StageRoot 'Artefacts\UploadReady' -VersionSource Module -BuildOrder 'Module' -PublishOrder 'PowerShellGallery', 'GitHub'
 
     New-ConfigurationArtefact -Type Unpacked -Enable -Path 'Artefacts\Unpacked' #-RequiredModulesPath "$PSScriptRoot\..\Artefacts\Modules"
     New-ConfigurationArtefact -Type Packed -Enable -Path 'Artefacts\Packed' -IncludeTagName

--- a/Module/Docs/Invoke-DbaXQuery.md
+++ b/Module/Docs/Invoke-DbaXQuery.md
@@ -11,7 +11,7 @@ Invokes a SQL Server query or stored procedure.
 ## SYNTAX
 ### Query (Default)
 ```powershell
-Invoke-DbaXQuery -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-Stream] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
+Invoke-DbaXQuery -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-Stream] [-ReturnType <ReturnType>] [-AsDataReader] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### QueryReader
@@ -71,11 +71,12 @@ Returns one live DbDataReader. The caller must dispose it after the consuming AP
 ## PARAMETERS
 
 ### -AsDataReader
-Returns one live reader that owns its command and connection until the caller disposes it.
+When enabled, returns one live reader that owns its command and connection until the caller disposes it.
+A disabled switch remains compatible with ordinary buffered query options.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: QueryReader
+Parameter Sets: Query, QueryReader
 Aliases: None
 Possible values:
 

--- a/Module/Docs/Invoke-DbaXQuery.md
+++ b/Module/Docs/Invoke-DbaXQuery.md
@@ -14,6 +14,11 @@ Invokes a SQL Server query or stored procedure.
 Invoke-DbaXQuery -Server <string> -Database <string> -Query <string> [-QueryTimeout <int>] [-Stream] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
+### QueryReader
+```powershell
+Invoke-DbaXQuery -Server <string> -Database <string> -Query <string> -AsDataReader [-QueryTimeout <int>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
 ### StoredProcedure
 ```powershell
 Invoke-DbaXQuery -Server <string> -Database <string> -StoredProcedure <string> [-QueryTimeout <int>] [-Stream] [-ReturnType <ReturnType>] [-Parameters <hashtable>] [-Username <string>] [-Password <string>] [-Credential <pscredential>] [-TrustServerCertificate] [-WhatIf] [-Confirm] [<CommonParameters>]
@@ -22,7 +27,7 @@ Invoke-DbaXQuery -Server <string> -Database <string> -StoredProcedure <string> [
 ## DESCRIPTION
 Connects to a SQL Server instance using integrated security or supplied credentials and executes the specified command.
 
-Supports streaming results and multiple return formats via the ReturnType parameter.
+Supports streaming results, multiple buffered return formats, and transferring an owned data reader to a consuming API.
 
 ## EXAMPLES
 
@@ -51,14 +56,42 @@ Invoke-DbaXQuery -Server 'sql01' -Database 'app' -StoredProcedure 'dbo.usp_GetAc
 
 Runs the stored procedure and outputs a DataTable.
 
+### EXAMPLE 3
+```powershell
+PS> $reader = Invoke-DbaXQuery -Server 'sql01' -Database 'app' -Query 'SELECT * FROM dbo.Users' -AsDataReader
+try {
+    Export-OfficeCsv -InputObject $reader -Path .\Users.csv
+} finally {
+    $reader.Dispose()
+}
+```
+
+Returns one live DbDataReader. The caller must dispose it after the consuming API finishes reading.
+
 ## PARAMETERS
+
+### -AsDataReader
+Returns one live reader that owns its command and connection until the caller disposes it.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: QueryReader
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -Credential
 Optional SQL authentication credential.
 
 ```yaml
 Type: PSCredential
-Parameter Sets: Query, StoredProcedure
+Parameter Sets: Query, QueryReader, StoredProcedure
 Aliases: None
 Possible values:
 
@@ -74,7 +107,7 @@ Defines the database name.
 
 ```yaml
 Type: String
-Parameter Sets: Query, StoredProcedure
+Parameter Sets: Query, QueryReader, StoredProcedure
 Aliases: None
 Possible values:
 
@@ -90,7 +123,7 @@ Provides additional parameters for the query or procedure.
 
 ```yaml
 Type: Hashtable
-Parameter Sets: Query, StoredProcedure
+Parameter Sets: Query, QueryReader, StoredProcedure
 Aliases: None
 Possible values:
 
@@ -106,7 +139,7 @@ Optional password for SQL authentication.
 
 ```yaml
 Type: String
-Parameter Sets: Query, StoredProcedure
+Parameter Sets: Query, QueryReader, StoredProcedure
 Aliases: None
 Possible values:
 
@@ -122,7 +155,7 @@ The SQL statement to execute.
 
 ```yaml
 Type: String
-Parameter Sets: Query
+Parameter Sets: Query, QueryReader
 Aliases: None
 Possible values:
 
@@ -138,7 +171,7 @@ Sets the command timeout in seconds.
 
 ```yaml
 Type: Int32
-Parameter Sets: Query, StoredProcedure
+Parameter Sets: Query, QueryReader, StoredProcedure
 Aliases: None
 Possible values:
 
@@ -170,7 +203,7 @@ Specifies the SQL Server instance.
 
 ```yaml
 Type: String
-Parameter Sets: Query, StoredProcedure
+Parameter Sets: Query, QueryReader, StoredProcedure
 Aliases: DBServer, SqlInstance, Instance
 Possible values:
 
@@ -218,7 +251,7 @@ Trusts the SQL Server TLS certificate without validating the certificate chain.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: Query, StoredProcedure
+Parameter Sets: Query, QueryReader, StoredProcedure
 Aliases: None
 Possible values:
 
@@ -234,7 +267,7 @@ Optional user name for SQL authentication.
 
 ```yaml
 Type: String
-Parameter Sets: Query, StoredProcedure
+Parameter Sets: Query, QueryReader, StoredProcedure
 Aliases: None
 Possible values:
 

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -19,6 +19,7 @@ param(
     ),
     [string] $PSWriteOfficeModulePath = $(if ($env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH) { $env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH } else { 'PSWriteOffice' }),
     [string] $ImportExcelModulePath = $(if ($env:IMPORTEXCEL_BENCHMARK_MODULE_PATH) { $env:IMPORTEXCEL_BENCHMARK_MODULE_PATH } else { 'ImportExcel' }),
+    [version] $ImportExcelVersion = $(if ($env:IMPORTEXCEL_BENCHMARK_VERSION) { [version] $env:IMPORTEXCEL_BENCHMARK_VERSION } else { $null }),
     [string] $ImportExcelModuleCachePath,
     [switch] $SkipImportExcelInstall,
     [string] $ProcessorAffinity,
@@ -33,6 +34,19 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 . (Join-Path $PSScriptRoot 'DbaClientX.Benchmark.Process.ps1')
+$officeRoundTripSupportPath = Join-Path $PSScriptRoot 'DbaClientX.Benchmark.OfficeRoundTrip.ps1'
+. $officeRoundTripSupportPath
+$officeRoundTripHelpers = @{
+    ImportExcel = ${function:Import-DbaClientXBenchmarkImportExcel}
+    TestImportExcel = ${function:Test-ImportExcelCommandAvailability}
+    GetModuleIdentity = ${function:Get-DbaClientXBenchmarkModuleIdentity}
+    GetAssemblyIdentity = ${function:Get-DbaClientXBenchmarkAssemblyIdentity}
+    GetCreateTableQuery = ${function:Get-DbaClientXOfficeBenchmarkCreateTableQuery}
+    GetSeedQuery = ${function:Get-DbaClientXOfficeBenchmarkSeedQuery}
+    GetExpectedIntegrity = ${function:Get-DbaClientXOfficeBenchmarkExpectedIntegrity}
+    AssertIntegrity = ${function:Assert-DbaClientXOfficeBenchmarkIntegrity}
+    AssertTypedSchema = ${function:Assert-DbaClientXOfficeBenchmarkTypedSchema}
+}
 
 function Convert-DbaClientXBenchmarkList {
     param([object[]] $Value)
@@ -105,6 +119,8 @@ if ($Engine -contains 'NativePowerShell' -and -not $nativePowerShellCsvAvailable
 Import-Module PSPublishModule -MinimumVersion 3.0.64 -ErrorAction Stop
 
 $benchmarkScriptRoot = $PSScriptRoot
+$benchmarkScriptIdentity = "Path=$PSCommandPath; SHA256=$((Get-FileHash -LiteralPath $PSCommandPath -Algorithm SHA256).Hash)"
+$benchmarkSupportIdentity = "Path=$officeRoundTripSupportPath; SHA256=$((Get-FileHash -LiteralPath $officeRoundTripSupportPath -Algorithm SHA256).Hash)"
 $benchmarkRunToken = [guid]::NewGuid().ToString('N').Substring(0, 8)
 $benchmarkProcess = Set-DbaClientXBenchmarkProcess -ProcessorAffinity $ProcessorAffinity -ProcessPriority $ProcessPriority
 try {
@@ -123,6 +139,7 @@ $settings = {
     $modulePath = $ModulePath
     $psWriteOfficeModulePath = $PSWriteOfficeModulePath
     $importExcelModulePath = $ImportExcelModulePath
+    $importExcelVersion = $ImportExcelVersion
     $importExcelModuleCachePath = if ([string]::IsNullOrWhiteSpace($ImportExcelModuleCachePath)) {
         Join-Path $defaultOutputRoot 'Modules'
     } else {
@@ -132,6 +149,8 @@ $settings = {
     $supportsNativePowerShellCsv = $nativePowerShellCsvAvailable
     $appliedProcessorAffinity = $benchmarkProcess.ProcessorAffinity
     $appliedProcessPriority = $benchmarkProcess.ProcessPriority
+    $benchmarkScript = $benchmarkScriptIdentity
+    $benchmarkSupport = $benchmarkSupportIdentity
     $updateReadme = $UpdateReadme.IsPresent
     $keepArtifacts = $KeepArtifacts.IsPresent
     $rowCounts = $RowCount
@@ -145,174 +164,67 @@ $settings = {
 
     $engineComparisonBaseline = if ($selectedEngines -contains 'DbaClientX') { 'DbaClientX' } else { $selectedEngines[0] }
 
-    function Import-DbaClientXBenchmarkImportExcel {
-        param(
-            [string] $ModulePath,
-            [string] $ModuleCachePath,
-            [switch] $SkipInstall
-        )
-
-        if ($ModulePath -eq 'ImportExcel' -and -not (Get-Module -ListAvailable -Name ImportExcel)) {
-            if ($SkipInstall.IsPresent) {
-                throw 'ImportExcel is not installed and automatic benchmark dependency preparation is disabled.'
-            }
-
-            New-Item -ItemType Directory -Force -Path $ModuleCachePath | Out-Null
-            $modulePaths = @($env:PSModulePath -split [System.IO.Path]::PathSeparator | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-            if ($ModuleCachePath -notin $modulePaths) {
-                $env:PSModulePath = (@($ModuleCachePath) + $modulePaths) -join [System.IO.Path]::PathSeparator
-            }
-
-            if (-not (Get-Module -ListAvailable -Name ImportExcel | Where-Object { $_.Path -like "$ModuleCachePath*" })) {
-                Save-Module -Name ImportExcel -Repository PSGallery -Path $ModuleCachePath -Force -ErrorAction Stop
-            }
-        }
-
-        Import-Module $ModulePath -Global -Force -PassThru -ErrorAction Stop
+    $getCreateTableQuery = $officeRoundTripHelpers.GetCreateTableQuery
+    $getSeedQuery = $officeRoundTripHelpers.GetSeedQuery
+    $getExpectedIntegrity = $officeRoundTripHelpers.GetExpectedIntegrity
+    $assertIntegrity = $officeRoundTripHelpers.AssertIntegrity
+    $assertTypedSchema = $officeRoundTripHelpers.AssertTypedSchema
+    $importImportExcelModule = $officeRoundTripHelpers.ImportExcel
+    $testImportExcelCommands = $officeRoundTripHelpers.TestImportExcel
+    $getModuleIdentity = $officeRoundTripHelpers.GetModuleIdentity
+    $getAssemblyIdentity = $officeRoundTripHelpers.GetAssemblyIdentity
+    $resolvedDbaClientXModule = Import-Module $modulePath -Global -Force -PassThru -ErrorAction Stop
+    $resolvedPSWriteOfficeModule = if ($selectedEngines -contains 'DbaClientX') {
+        Import-Module $psWriteOfficeModulePath -Global -Force -PassThru -ErrorAction Stop
+    } else {
+        $null
     }
-
-    function Test-ImportExcelCommandAvailability {
-        param(
-            [string] $ModulePath,
-            [string] $ModuleCachePath,
-            [switch] $SkipInstall,
-            [scriptblock] $ImportModuleCommand
-        )
-
+    $resolvedImportExcelModule = if ($selectedEngines -contains 'ImportExcel') {
         try {
-            $importedModule = & $ImportModuleCommand -ModulePath $ModulePath -ModuleCachePath $ModuleCachePath -SkipInstall:$SkipInstall.IsPresent
+            & $importImportExcelModule -ModulePath $importExcelModulePath -ModuleCachePath $importExcelModuleCachePath -RequiredVersion $importExcelVersion -SkipInstall:$skipImportExcelInstall
         } catch {
-            Write-Warning "Skipping ImportExcel benchmark lane because ImportExcel could not be imported from '$ModulePath': $($_.Exception.Message)"
-            return $false
+            $null
         }
-
-        $moduleNames = @($importedModule | ForEach-Object { $_.Name })
-        $exportCommand = Get-Command Export-Excel -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
-        $importCommand = Get-Command Import-Excel -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
-        if (-not $exportCommand -or -not $importCommand) {
-            Write-Warning 'Skipping ImportExcel benchmark lane because the imported module does not expose Export-Excel and Import-Excel.'
-            return $false
-        }
-
-        return $true
+    } else {
+        $null
     }
-
-    function Get-DbaClientXOfficeBenchmarkCreateTableQuery {
-        param([string] $TableName)
-
-        @"
-IF OBJECT_ID(N'dbo.$TableName', N'U') IS NOT NULL DROP TABLE dbo.$TableName;
-CREATE TABLE dbo.$TableName
-(
-    Id int NOT NULL CONSTRAINT PK_${TableName}_Id PRIMARY KEY CLUSTERED,
-    DisplayName nvarchar(100) NOT NULL,
-    Score decimal(18,2) NOT NULL,
-    CreatedUtc datetime2 NOT NULL
-);
-"@
+    $sqlServerIdentity = if ($Plan.IsPresent) {
+        'Plan mode; not queried'
+    } else {
+        $serverProperties = Invoke-DbaXQuery `
+            -Server $server `
+            -Database $database `
+            -TrustServerCertificate `
+            -Query "SELECT CONVERT(nvarchar(128), SERVERPROPERTY('ProductVersion')) AS ProductVersion, CONVERT(nvarchar(128), SERVERPROPERTY('Edition')) AS Edition, CONVERT(nvarchar(128), SERVERPROPERTY('ProductLevel')) AS ProductLevel, CONVERT(nvarchar(128), DATABASEPROPERTYEX(DB_NAME(), 'Collation')) AS Collation;" `
+            -QueryTimeout 30 `
+            -ReturnType PSObject `
+            -ErrorAction Stop
+        "Server=$server; Database=$database; ProductVersion=$($serverProperties.ProductVersion); ProductLevel=$($serverProperties.ProductLevel); Edition=$($serverProperties.Edition); Collation=$($serverProperties.Collation)"
     }
-
-    function Get-DbaClientXOfficeBenchmarkSeedQuery {
-        param(
-            [string] $TableName,
-            [int] $RowCount
-        )
-
-        @"
-WITH numbers AS
-(
-    SELECT TOP ($RowCount)
-        ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS Id
-    FROM sys.all_objects AS a
-    CROSS JOIN sys.all_objects AS b
-)
-INSERT INTO dbo.$TableName (Id, DisplayName, Score, CreatedUtc)
-SELECT
-    Id,
-    CONCAT(N'Row ', Id),
-    CONVERT(decimal(18,2), Id * 1.25),
-    DATEADD(second, Id, CONVERT(datetime2, '2026-01-01T00:00:00'))
-FROM numbers;
-"@
-    }
-
-    function Get-DbaClientXOfficeBenchmarkExpectedIntegrity {
-        param([int] $RowCount)
-
-        $expectedIdSum = [long] ([int64] $RowCount * ([int64] $RowCount + 1) / 2)
-        [pscustomobject]@{
-            Rows = $RowCount
-            MinId = 1
-            MaxId = $RowCount
-            IdSum = $expectedIdSum
-            ScoreSum = [decimal] $expectedIdSum * 1.25
-        }
-    }
-
-    function Assert-DbaClientXOfficeBenchmarkIntegrity {
-        param(
-            [string] $FileKind,
-            [string] $TableName,
-            [object] $Actual,
-            [object] $Expected
-        )
-
-        if ($Actual.Rows -ne $Expected.Rows) {
-            throw "$FileKind round trip processed $($Actual.Rows) of $($Expected.Rows) expected row(s) for dbo.$TableName."
-        }
-
-        if ($Actual.MinId -ne $Expected.MinId -or
-            $Actual.MaxId -ne $Expected.MaxId -or
-            $Actual.IdSum -ne $Expected.IdSum -or
-            $Actual.ScoreSum -ne $Expected.ScoreSum -or
-            $Actual.ExactMismatchCount -ne 0) {
-            throw "$FileKind round trip produced unexpected data for dbo.${TableName}: MinId=$($Actual.MinId), MaxId=$($Actual.MaxId), IdSum=$($Actual.IdSum), ScoreSum=$($Actual.ScoreSum), ExactMismatchCount=$($Actual.ExactMismatchCount)."
-        }
-    }
-
-    function Assert-DbaClientXOfficeBenchmarkTypedSchema {
-        param(
-            [string] $FileKind,
-            [string] $TableName,
-            [object[]] $Columns
-        )
-
-        $actualTypes = @{}
-        foreach ($column in @($Columns)) {
-            $actualTypes[[string] $column.ColumnName] = [string] $column.TypeName
-        }
-
-        $excelNumericTypes = $FileKind -in @('Excel', 'ExcelReader', 'ExcelReaderMapped')
-        $expectedTypes = [ordered] @{
-            Id = if ($excelNumericTypes) { @('float') } else { @('int') }
-            DisplayName = @('nvarchar', 'varchar')
-            Score = if ($excelNumericTypes) { @('float') } else { @('decimal', 'numeric') }
-            CreatedUtc = @('datetime2', 'datetime', 'datetimeoffset')
-        }
-
-        foreach ($entry in $expectedTypes.GetEnumerator()) {
-            if (-not $actualTypes.ContainsKey($entry.Key)) {
-                throw "$FileKind typed round trip did not create expected column '$($entry.Key)' in dbo.$TableName."
-            }
-
-            if ($actualTypes[$entry.Key] -notin $entry.Value) {
-                throw "$FileKind typed round trip created dbo.$TableName.$($entry.Key) as $($actualTypes[$entry.Key]); expected one of: $($entry.Value -join ', ')."
-            }
-        }
-    }
-
-    $getCreateTableQuery = ${function:Get-DbaClientXOfficeBenchmarkCreateTableQuery}
-    $getSeedQuery = ${function:Get-DbaClientXOfficeBenchmarkSeedQuery}
-    $getExpectedIntegrity = ${function:Get-DbaClientXOfficeBenchmarkExpectedIntegrity}
-    $assertIntegrity = ${function:Assert-DbaClientXOfficeBenchmarkIntegrity}
-    $assertTypedSchema = ${function:Assert-DbaClientXOfficeBenchmarkTypedSchema}
-    $importImportExcelModule = ${function:Import-DbaClientXBenchmarkImportExcel}
-    $testImportExcelCommands = ${function:Test-ImportExcelCommandAvailability}
+    $dbaClientXModuleIdentity = & $getModuleIdentity -Module $resolvedDbaClientXModule -Label 'DbaClientX'
+    $psWriteOfficeModuleIdentity = & $getModuleIdentity -Module $resolvedPSWriteOfficeModule -Label 'PSWriteOffice'
+    $importExcelModuleIdentity = & $getModuleIdentity -Module $resolvedImportExcelModule -Label 'ImportExcel'
+    $dbaClientXAssemblyIdentity = & $getAssemblyIdentity -SimpleName 'DbaClientX.PowerShell'
+    $psWriteOfficeAssemblyIdentity = & $getAssemblyIdentity -SimpleName 'PSWriteOffice'
+    $officeIMOExcelAssemblyIdentity = & $getAssemblyIdentity -SimpleName 'OfficeIMO.Excel'
+    $officeIMOCsvAssemblyIdentity = & $getAssemblyIdentity -SimpleName 'OfficeIMO.CSV'
+    $epplusAssemblyIdentity = & $getAssemblyIdentity -SimpleName 'EPPlus'
     benchmark 'office-file-roundtrip' -out $outputRootBase {
         policy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
         profile Current -Cleanup KeepOnFailure
         metadata ProcessorAffinity $appliedProcessorAffinity
         metadata ProcessPriority $appliedProcessPriority
+        metadata BenchmarkScript $benchmarkScript
+        metadata BenchmarkSupport $benchmarkSupport
+        metadata SqlServer $sqlServerIdentity
+        metadata DbaClientXModule $dbaClientXModuleIdentity
+        metadata DbaClientXAssembly $dbaClientXAssemblyIdentity
+        metadata PSWriteOfficeModule $psWriteOfficeModuleIdentity
+        metadata PSWriteOfficeAssembly $psWriteOfficeAssemblyIdentity
+        metadata OfficeIMOExcelAssembly $officeIMOExcelAssemblyIdentity
+        metadata OfficeIMOCsvAssembly $officeIMOCsvAssemblyIdentity
+        metadata ImportExcelModule $importExcelModuleIdentity
+        metadata EPPlusAssembly $epplusAssemblyIdentity
 
         caseSource {
             foreach ($rowCount in $rowCounts) {
@@ -344,6 +256,7 @@ FROM numbers;
             $run.KeepArtifacts = $keepArtifacts
             $run.ExportMs = 0.0
             $run.LoadMs = 0.0
+            $run.ExactMismatchCount = 0L
             $run.ConnectionString = "Server=$($run.Server);Database=$($run.Database);Encrypt=True;TrustServerCertificate=True;Integrated Security=True"
             $laneToken = '{0}_{1}_{2}_{3}_{4}' -f $benchmarkRunToken, $case.Engine, $case.FileKind, $case.ColumnShape, $case.RowCount
             $run.SourceTable = 'DbaClientXBench_FileSource_{0}' -f $laneToken
@@ -381,7 +294,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             }
 
             if ($case.Engine -eq 'ImportExcel') {
-                & $importImportExcelModule -ModulePath $importExcelModulePath -ModuleCachePath $importExcelModuleCachePath -SkipInstall:$skipImportExcelInstall | Out-Null
+                & $importImportExcelModule -ModulePath $importExcelModulePath -ModuleCachePath $importExcelModuleCachePath -RequiredVersion $importExcelVersion -SkipInstall:$skipImportExcelInstall | Out-Null
             }
 
             Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropQuery -QueryTimeout 120 -ErrorAction Stop | Out-Null
@@ -419,7 +332,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                     return $true
                 }
 
-                return -not (& $testImportExcelCommands -ModulePath $importExcelModulePath -ModuleCachePath $importExcelModuleCachePath -SkipInstall:$skipImportExcelInstall -ImportModuleCommand $importImportExcelModule)
+                return -not (& $testImportExcelCommands -ModulePath $importExcelModulePath -ModuleCachePath $importExcelModuleCachePath -RequiredVersion $importExcelVersion -SkipInstall:$skipImportExcelInstall -ImportModuleCommand $importImportExcelModule)
             }
 
             return $false
@@ -691,16 +604,17 @@ SELECT
     SUM(CASE
         WHEN source.Id IS NULL OR destination.Id IS NULL
           OR destination.DisplayName IS NULL
-          OR CONVERT(nvarchar(100), destination.DisplayName) <> source.DisplayName
-          OR TRY_CONVERT(decimal(18,2), destination.Score) IS NULL
-          OR TRY_CONVERT(decimal(18,2), destination.Score) <> source.Score
-          OR TRY_CONVERT(datetime2, destination.CreatedUtc) IS NULL
-          OR TRY_CONVERT(datetime2, destination.CreatedUtc) <> source.CreatedUtc
+          OR DATALENGTH(CONVERT(nvarchar(100), destination.DisplayName)) <> DATALENGTH(source.DisplayName)
+          OR CONVERT(nvarchar(100), destination.DisplayName) COLLATE Latin1_General_100_BIN2 <> source.DisplayName COLLATE Latin1_General_100_BIN2
+          OR TRY_CONVERT(decimal(38,10), destination.Score) IS NULL
+          OR TRY_CONVERT(decimal(38,10), destination.Score) <> CONVERT(decimal(38,10), source.Score)
+          OR TRY_CONVERT(datetime2(7), destination.CreatedUtc) IS NULL
+          OR TRY_CONVERT(datetime2(7), destination.CreatedUtc) <> CONVERT(datetime2(7), source.CreatedUtc)
         THEN CONVERT(bigint, 1) ELSE CONVERT(bigint, 0)
     END) AS [ExactMismatchCount]
 FROM dbo.$($run.DestinationTable) AS destination
 FULL OUTER JOIN dbo.$($run.SourceTable) AS source
-    ON TRY_CONVERT(int, destination.Id) = source.Id;
+    ON TRY_CONVERT(decimal(38,10), destination.Id) = CONVERT(decimal(38,10), source.Id);
 "@ `
                 -QueryTimeout 120 `
                 -ReturnType PSObject `
@@ -732,6 +646,7 @@ FULL OUTER JOIN dbo.$($run.SourceTable) AS source
             $run.RowsProcessed = $actual.Rows
             $run.IdSum = $actual.IdSum
             $run.ScoreSum = $actual.ScoreSum
+            $run.ExactMismatchCount = $actual.ExactMismatchCount
 
             if (-not $run.KeepArtifacts) {
                 Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropQuery -QueryTimeout 120 -ErrorAction Stop | Out-Null
@@ -769,6 +684,12 @@ FULL OUTER JOIN dbo.$($run.SourceTable) AS source
             param($case, $run)
 
             $run.ScoreSum
+        }
+
+        metric ExactMismatchCount {
+            param($case, $run)
+
+            $run.ExactMismatchCount
         }
 
         metric RowsPerSecond {

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -472,18 +472,21 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                         }
                     }
 
-                    $client = [DBAClientX.SqlServer]::new()
                     $reader = $null
                     try {
-                        $client.CommandTimeout = 120
-                        $reader = $client.QueryReader($run.ConnectionString, $query)
+                        $reader = Invoke-DbaXQuery `
+                            -Server $run.Server `
+                            -Database $run.Database `
+                            -TrustServerCertificate `
+                            -Query $query `
+                            -QueryTimeout 120 `
+                            -AsDataReader `
+                            -ErrorAction Stop
                         Export-OfficeCsv -InputObject $reader @csvExportParameters
                     } finally {
                         if ($null -ne $reader) {
                             $reader.Dispose()
                         }
-
-                        $client.Dispose()
                     }
                     $exportTimer.Stop()
                     $run.ExportMs = $exportTimer.Elapsed.TotalMilliseconds
@@ -492,30 +495,21 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                     $imported = Import-OfficeCsv @csvImportParameters
                 } elseif ($case.FileKind -in @('ExcelReader', 'ExcelReaderMapped')) {
                     $exportTimer = [System.Diagnostics.Stopwatch]::StartNew()
-                    $connectionString = [DBAClientX.SqlServer]::BuildConnectionString(
-                        $run.Server,
-                        $run.Database,
-                        $true,
-                        $null,
-                        $null,
-                        $null,
-                        $null,
-                        $true,
-                        $null,
-                        $null)
-
-                    $client = [DBAClientX.SqlServer]::new()
                     $reader = $null
                     try {
-                        $client.CommandTimeout = 120
-                        $reader = $client.QueryReader($connectionString, $query)
+                        $reader = Invoke-DbaXQuery `
+                            -Server $run.Server `
+                            -Database $run.Database `
+                            -TrustServerCertificate `
+                            -Query $query `
+                            -QueryTimeout 120 `
+                            -AsDataReader `
+                            -ErrorAction Stop
                         Export-OfficeExcel -InputObject $reader -Path $run.FilePath -WorksheetName Data -TableName Data -ErrorAction Stop
                     } finally {
                         if ($null -ne $reader) {
                             $reader.Dispose()
                         }
-
-                        $client.Dispose()
                     }
                     $exportTimer.Stop()
                     $run.ExportMs = $exportTimer.Elapsed.TotalMilliseconds

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -7,6 +7,11 @@ param(
     [string[]] $ColumnShape = @('Default'),
     [int] $Iterations = 3,
     [int] $WarmupCount = 1,
+    [switch] $ParallelCsvRead,
+    [ValidateRange(1, [int]::MaxValue)]
+    [int] $CsvReaderMaxDegreeOfParallelism = 4,
+    [ValidateRange(1, [int]::MaxValue)]
+    [int] $CsvReaderParallelBatchSize = 4096,
     [string[]] $Engine,
     [string] $ModulePath = $(
         if ($env:DBACLIENTX_BENCHMARK_MODULE_PATH) {
@@ -161,6 +166,9 @@ $settings = {
     )
     $benchmarkWarmupCount = $WarmupCount
     $benchmarkIterationCount = $Iterations
+    $parallelCsvRead = $ParallelCsvRead.IsPresent
+    $csvReaderMaxDegreeOfParallelism = $CsvReaderMaxDegreeOfParallelism
+    $csvReaderParallelBatchSize = $CsvReaderParallelBatchSize
 
     $engineComparisonBaseline = if ($selectedEngines -contains 'DbaClientX') { 'DbaClientX' } else { $selectedEngines[0] }
 
@@ -223,6 +231,9 @@ $settings = {
         metadata PSWriteOfficeAssembly $psWriteOfficeAssemblyIdentity
         metadata OfficeIMOExcelAssembly $officeIMOExcelAssemblyIdentity
         metadata OfficeIMOCsvAssembly $officeIMOCsvAssemblyIdentity
+        metadata ParallelCsvRead $parallelCsvRead
+        metadata CsvReaderMaxDegreeOfParallelism $csvReaderMaxDegreeOfParallelism
+        metadata CsvReaderParallelBatchSize $csvReaderParallelBatchSize
         metadata ImportExcelModule $importExcelModuleIdentity
         metadata EPPlusAssembly $epplusAssemblyIdentity
 
@@ -382,6 +393,11 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                                 Score = [decimal]
                                 CreatedUtc = [datetime]
                             }
+                        }
+                        if ($parallelCsvRead) {
+                            $csvImportParameters.Parallel = $true
+                            $csvImportParameters.MaxDegreeOfParallelism = $csvReaderMaxDegreeOfParallelism
+                            $csvImportParameters.ParallelBatchSize = $csvReaderParallelBatchSize
                         }
                     }
 
@@ -575,6 +591,11 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 }
                 if ($case.FileKind -in @('CsvTyped', 'CsvGZipTyped')) {
                     $importParameters.DetectColumnTypes = $true
+                    if ($parallelCsvRead) {
+                        $importParameters.Parallel = $true
+                        $importParameters.ThrottleLimit = $csvReaderMaxDegreeOfParallelism
+                        $importParameters.ParallelBatchSize = $csvReaderParallelBatchSize
+                    }
                 }
                 if ($null -ne $run.ColumnMap) {
                     $importParameters.ColumnMap = $run.ColumnMap
@@ -773,5 +794,34 @@ if (-not $Plan -and $result.Summary) {
 
 $result
 } finally {
+    if (-not $KeepArtifacts -and -not $Plan) {
+        try {
+            $cleanupCommand = Get-Command Invoke-DbaXNonQuery -ErrorAction SilentlyContinue
+            if ($null -ne $cleanupCommand) {
+                $cleanupQuery = @"
+DECLARE @sql nvarchar(max) = N'';
+SELECT @sql = @sql + N'DROP TABLE ' + QUOTENAME(SCHEMA_NAME(schema_id)) + N'.' + QUOTENAME(name) + N';'
+FROM sys.tables
+WHERE name LIKE N'DbaClientXBench_FileSource_$benchmarkRunToken[_]%'
+   OR name LIKE N'DbaClientXBench_FileDest_$benchmarkRunToken[_]%';
+IF LEN(@sql) > 0 EXEC sys.sp_executesql @sql;
+"@
+                Invoke-DbaXNonQuery -Server $Server -Database $Database -TrustServerCertificate -Query $cleanupQuery -QueryTimeout 120 -ErrorAction Stop | Out-Null
+            }
+
+            $cleanupOutputRoot = if ($OutputRoot) {
+                $OutputRoot
+            } else {
+                $sourceRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..\..')).Path
+                Join-Path $sourceRoot 'Ignore\Benchmarks\OfficeFileRoundTrip'
+            }
+            if (Test-Path -LiteralPath $cleanupOutputRoot) {
+                Get-ChildItem -LiteralPath $cleanupOutputRoot -File -Filter "DbaClientXBench_$benchmarkRunToken*" |
+                    Remove-Item -Force -ErrorAction Stop
+            }
+        } catch {
+            Write-Warning "Benchmark cleanup for run token '$benchmarkRunToken' failed: $($_.Exception.Message)"
+        }
+    }
     Restore-DbaClientXBenchmarkProcess -State $benchmarkProcess
 }

--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -18,6 +18,12 @@ param(
         }
     ),
     [string] $PSWriteOfficeModulePath = $(if ($env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH) { $env:PSWRITEOFFICE_BENCHMARK_MODULE_PATH } else { 'PSWriteOffice' }),
+    [string] $ImportExcelModulePath = $(if ($env:IMPORTEXCEL_BENCHMARK_MODULE_PATH) { $env:IMPORTEXCEL_BENCHMARK_MODULE_PATH } else { 'ImportExcel' }),
+    [string] $ImportExcelModuleCachePath,
+    [switch] $SkipImportExcelInstall,
+    [string] $ProcessorAffinity,
+    [ValidateSet('Current', 'Normal', 'AboveNormal', 'High')]
+    [string] $ProcessPriority = 'Current',
     [string] $OutputRoot,
     [switch] $Plan,
     [switch] $UpdateReadme,
@@ -26,6 +32,7 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'DbaClientX.Benchmark.Process.ps1')
 
 function Convert-DbaClientXBenchmarkList {
     param([object[]] $Value)
@@ -74,7 +81,7 @@ if ($ColumnShape.Count -eq 0) {
 }
 Assert-DbaClientXBenchmarkValue -Name FileKind -Value $FileKind -ValidValue @('Csv', 'CsvGZip', 'CsvTyped', 'CsvGZipTyped', 'Excel', 'ExcelReader', 'ExcelReaderMapped')
 Assert-DbaClientXBenchmarkValue -Name ColumnShape -Value $ColumnShape -ValidValue @('Default', 'Mapped')
-Assert-DbaClientXBenchmarkValue -Name Engine -Value $Engine -ValidValue @('DbaClientX', 'dbatools')
+Assert-DbaClientXBenchmarkValue -Name Engine -Value $Engine -ValidValue @('DbaClientX', 'dbatools', 'NativePowerShell', 'ImportExcel')
 if ($Iterations -lt 1) {
     throw 'Iterations must be greater than zero.'
 }
@@ -90,10 +97,17 @@ if ($Engine -contains 'dbatools') {
     }
 }
 
+$nativePowerShellCsvAvailable = (Get-Command Export-Csv).Parameters.ContainsKey('UseQuotes')
+if ($Engine -contains 'NativePowerShell' -and -not $nativePowerShellCsvAvailable) {
+    Write-Warning 'Skipping NativePowerShell because this host does not support Export-Csv -UseQuotes. Use PowerShell 7 for the equivalent AsNeeded-quoting lane.'
+}
+
 Import-Module PSPublishModule -MinimumVersion 3.0.64 -ErrorAction Stop
 
 $benchmarkScriptRoot = $PSScriptRoot
 $benchmarkRunToken = [guid]::NewGuid().ToString('N').Substring(0, 8)
+$benchmarkProcess = Set-DbaClientXBenchmarkProcess -ProcessorAffinity $ProcessorAffinity -ProcessPriority $ProcessPriority
+try {
 $settings = {
     $sourceRoot = (Resolve-Path -LiteralPath (Join-Path $benchmarkScriptRoot '..\..')).Path
     $readmePath = Join-Path $sourceRoot 'README.md'
@@ -108,6 +122,16 @@ $settings = {
     $database = $Database
     $modulePath = $ModulePath
     $psWriteOfficeModulePath = $PSWriteOfficeModulePath
+    $importExcelModulePath = $ImportExcelModulePath
+    $importExcelModuleCachePath = if ([string]::IsNullOrWhiteSpace($ImportExcelModuleCachePath)) {
+        Join-Path $defaultOutputRoot 'Modules'
+    } else {
+        $ImportExcelModuleCachePath
+    }
+    $skipImportExcelInstall = $SkipImportExcelInstall.IsPresent
+    $supportsNativePowerShellCsv = $nativePowerShellCsvAvailable
+    $appliedProcessorAffinity = $benchmarkProcess.ProcessorAffinity
+    $appliedProcessPriority = $benchmarkProcess.ProcessPriority
     $updateReadme = $UpdateReadme.IsPresent
     $keepArtifacts = $KeepArtifacts.IsPresent
     $rowCounts = $RowCount
@@ -120,6 +144,58 @@ $settings = {
     $benchmarkIterationCount = $Iterations
 
     $engineComparisonBaseline = if ($selectedEngines -contains 'DbaClientX') { 'DbaClientX' } else { $selectedEngines[0] }
+
+    function Import-DbaClientXBenchmarkImportExcel {
+        param(
+            [string] $ModulePath,
+            [string] $ModuleCachePath,
+            [switch] $SkipInstall
+        )
+
+        if ($ModulePath -eq 'ImportExcel' -and -not (Get-Module -ListAvailable -Name ImportExcel)) {
+            if ($SkipInstall.IsPresent) {
+                throw 'ImportExcel is not installed and automatic benchmark dependency preparation is disabled.'
+            }
+
+            New-Item -ItemType Directory -Force -Path $ModuleCachePath | Out-Null
+            $modulePaths = @($env:PSModulePath -split [System.IO.Path]::PathSeparator | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+            if ($ModuleCachePath -notin $modulePaths) {
+                $env:PSModulePath = (@($ModuleCachePath) + $modulePaths) -join [System.IO.Path]::PathSeparator
+            }
+
+            if (-not (Get-Module -ListAvailable -Name ImportExcel | Where-Object { $_.Path -like "$ModuleCachePath*" })) {
+                Save-Module -Name ImportExcel -Repository PSGallery -Path $ModuleCachePath -Force -ErrorAction Stop
+            }
+        }
+
+        Import-Module $ModulePath -Global -Force -PassThru -ErrorAction Stop
+    }
+
+    function Test-ImportExcelCommandAvailability {
+        param(
+            [string] $ModulePath,
+            [string] $ModuleCachePath,
+            [switch] $SkipInstall,
+            [scriptblock] $ImportModuleCommand
+        )
+
+        try {
+            $importedModule = & $ImportModuleCommand -ModulePath $ModulePath -ModuleCachePath $ModuleCachePath -SkipInstall:$SkipInstall.IsPresent
+        } catch {
+            Write-Warning "Skipping ImportExcel benchmark lane because ImportExcel could not be imported from '$ModulePath': $($_.Exception.Message)"
+            return $false
+        }
+
+        $moduleNames = @($importedModule | ForEach-Object { $_.Name })
+        $exportCommand = Get-Command Export-Excel -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
+        $importCommand = Get-Command Import-Excel -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
+        if (-not $exportCommand -or -not $importCommand) {
+            Write-Warning 'Skipping ImportExcel benchmark lane because the imported module does not expose Export-Excel and Import-Excel.'
+            return $false
+        }
+
+        return $true
+    }
 
     function Get-DbaClientXOfficeBenchmarkCreateTableQuery {
         param([string] $TableName)
@@ -155,7 +231,7 @@ SELECT
     Id,
     CONCAT(N'Row ', Id),
     CONVERT(decimal(18,2), Id * 1.25),
-    SYSUTCDATETIME()
+    DATEADD(second, Id, CONVERT(datetime2, '2026-01-01T00:00:00'))
 FROM numbers;
 "@
     }
@@ -188,8 +264,9 @@ FROM numbers;
         if ($Actual.MinId -ne $Expected.MinId -or
             $Actual.MaxId -ne $Expected.MaxId -or
             $Actual.IdSum -ne $Expected.IdSum -or
-            $Actual.ScoreSum -ne $Expected.ScoreSum) {
-            throw "$FileKind round trip produced unexpected data for dbo.${TableName}: MinId=$($Actual.MinId), MaxId=$($Actual.MaxId), IdSum=$($Actual.IdSum), ScoreSum=$($Actual.ScoreSum)."
+            $Actual.ScoreSum -ne $Expected.ScoreSum -or
+            $Actual.ExactMismatchCount -ne 0) {
+            throw "$FileKind round trip produced unexpected data for dbo.${TableName}: MinId=$($Actual.MinId), MaxId=$($Actual.MaxId), IdSum=$($Actual.IdSum), ScoreSum=$($Actual.ScoreSum), ExactMismatchCount=$($Actual.ExactMismatchCount)."
         }
     }
 
@@ -205,10 +282,11 @@ FROM numbers;
             $actualTypes[[string] $column.ColumnName] = [string] $column.TypeName
         }
 
+        $excelNumericTypes = $FileKind -in @('Excel', 'ExcelReader', 'ExcelReaderMapped')
         $expectedTypes = [ordered] @{
-            Id = @('int')
+            Id = if ($excelNumericTypes) { @('float') } else { @('int') }
             DisplayName = @('nvarchar', 'varchar')
-            Score = @('decimal', 'numeric')
+            Score = if ($excelNumericTypes) { @('float') } else { @('decimal', 'numeric') }
             CreatedUtc = @('datetime2', 'datetime', 'datetimeoffset')
         }
 
@@ -228,9 +306,13 @@ FROM numbers;
     $getExpectedIntegrity = ${function:Get-DbaClientXOfficeBenchmarkExpectedIntegrity}
     $assertIntegrity = ${function:Assert-DbaClientXOfficeBenchmarkIntegrity}
     $assertTypedSchema = ${function:Assert-DbaClientXOfficeBenchmarkTypedSchema}
+    $importImportExcelModule = ${function:Import-DbaClientXBenchmarkImportExcel}
+    $testImportExcelCommands = ${function:Test-ImportExcelCommandAvailability}
     benchmark 'office-file-roundtrip' -out $outputRootBase {
-        policy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -OutlierMode None
+        policy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
         profile Current -Cleanup KeepOnFailure
+        metadata ProcessorAffinity $appliedProcessorAffinity
+        metadata ProcessPriority $appliedProcessPriority
 
         caseSource {
             foreach ($rowCount in $rowCounts) {
@@ -298,6 +380,10 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 Import-Module $psWriteOfficeModulePath -Global -Force -ErrorAction Stop
             }
 
+            if ($case.Engine -eq 'ImportExcel') {
+                & $importImportExcelModule -ModulePath $importExcelModulePath -ModuleCachePath $importExcelModuleCachePath -SkipInstall:$skipImportExcelInstall | Out-Null
+            }
+
             Invoke-DbaXNonQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.DropQuery -QueryTimeout 120 -ErrorAction Stop | Out-Null
             if (Test-Path -LiteralPath $run.FilePath) {
                 Remove-Item -LiteralPath $run.FilePath -Force
@@ -322,6 +408,18 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
 
             if ($case.Engine -eq 'dbatools') {
                 return $case.FileKind -notin @('Csv', 'CsvGZip', 'CsvTyped', 'CsvGZipTyped')
+            }
+
+            if ($case.Engine -eq 'NativePowerShell') {
+                return -not $supportsNativePowerShellCsv -or $case.FileKind -ne 'Csv' -or $case.ColumnShape -ne 'Default'
+            }
+
+            if ($case.Engine -eq 'ImportExcel') {
+                if ($case.FileKind -ne 'ExcelReader' -or $case.ColumnShape -ne 'Default') {
+                    return $true
+                }
+
+                return -not (& $testImportExcelCommands -ModulePath $importExcelModulePath -ModuleCachePath $importExcelModuleCachePath -SkipInstall:$skipImportExcelInstall -ImportModuleCommand $importImportExcelModule)
             }
 
             return $false
@@ -427,7 +525,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                         Path = $run.FilePath
                         WorksheetName = 'Data'
                         AsDataReader = $true
-                        SchemaSampleSize = [int] $case.RowCount
+                        SchemaSampleSize = [Math]::Min([int] $case.RowCount, 4096)
                         ErrorAction = 'Stop'
                     }
 
@@ -482,6 +580,44 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                         $imported.Dispose()
                     }
                 }
+                $loadTimer.Stop()
+                $run.LoadMs = $loadTimer.Elapsed.TotalMilliseconds
+            }
+        }
+
+        engine NativePowerShell {
+            operation RoundTrip {
+                param($case, $run)
+
+                $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                $exportTimer = [System.Diagnostics.Stopwatch]::StartNew()
+                Invoke-DbaXQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.SelectQuery -QueryTimeout 120 -ReturnType PSObject -Stream -ErrorAction Stop |
+                    Export-Csv -Path $run.FilePath -NoTypeInformation -Encoding utf8 -UseQuotes AsNeeded
+                $exportTimer.Stop()
+                $run.ExportMs = $exportTimer.Elapsed.TotalMilliseconds
+
+                $loadTimer = [System.Diagnostics.Stopwatch]::StartNew()
+                Import-Csv -Path $run.FilePath |
+                    Write-DbaXTableData -Provider SqlServer -ConnectionString $run.ConnectionString -DestinationTable "dbo.$($run.DestinationTable)" -AutoCreateTable -BatchSize 5000 -BulkCopyTimeout 120 -TableLock -ErrorAction Stop
+                $loadTimer.Stop()
+                $run.LoadMs = $loadTimer.Elapsed.TotalMilliseconds
+            }
+        }
+
+        engine ImportExcel {
+            operation RoundTrip {
+                param($case, $run)
+
+                $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
+                $exportTimer = [System.Diagnostics.Stopwatch]::StartNew()
+                Invoke-DbaXQuery -Server $run.Server -Database $run.Database -TrustServerCertificate -Query $run.SelectQuery -QueryTimeout 120 -ReturnType PSObject -Stream -ErrorAction Stop |
+                    Export-Excel -Path $run.FilePath -WorksheetName Data -TableName Data -AutoFilter
+                $exportTimer.Stop()
+                $run.ExportMs = $exportTimer.Elapsed.TotalMilliseconds
+
+                $loadTimer = [System.Diagnostics.Stopwatch]::StartNew()
+                Import-Excel -Path $run.FilePath -WorksheetName Data |
+                    Write-DbaXTableData -Provider SqlServer -ConnectionString $run.ConnectionString -DestinationTable "dbo.$($run.DestinationTable)" -AutoCreateTable -BatchSize 5000 -BulkCopyTimeout 120 -TableLock -ErrorAction Stop
                 $loadTimer.Stop()
                 $run.LoadMs = $loadTimer.Elapsed.TotalMilliseconds
             }
@@ -551,7 +687,27 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 -Server $run.Server `
                 -Database $run.Database `
                 -TrustServerCertificate `
-                -Query "SELECT COUNT(*) AS [Rows], MIN(CAST(Id AS int)) AS [MinId], MAX(CAST(Id AS int)) AS [MaxId], SUM(CAST(Id AS bigint)) AS [IdSum], SUM(CAST(Score AS decimal(38,2))) AS [ScoreSum] FROM dbo.$($run.DestinationTable);" `
+                -Query @"
+SELECT
+    COUNT(*) AS [Rows],
+    MIN(CAST(destination.Id AS int)) AS [MinId],
+    MAX(CAST(destination.Id AS int)) AS [MaxId],
+    SUM(CAST(destination.Id AS bigint)) AS [IdSum],
+    SUM(CAST(destination.Score AS decimal(38,2))) AS [ScoreSum],
+    SUM(CASE
+        WHEN source.Id IS NULL OR destination.Id IS NULL
+          OR destination.DisplayName IS NULL
+          OR CONVERT(nvarchar(100), destination.DisplayName) <> source.DisplayName
+          OR TRY_CONVERT(decimal(18,2), destination.Score) IS NULL
+          OR TRY_CONVERT(decimal(18,2), destination.Score) <> source.Score
+          OR TRY_CONVERT(datetime2, destination.CreatedUtc) IS NULL
+          OR TRY_CONVERT(datetime2, destination.CreatedUtc) <> source.CreatedUtc
+        THEN CONVERT(bigint, 1) ELSE CONVERT(bigint, 0)
+    END) AS [ExactMismatchCount]
+FROM dbo.$($run.DestinationTable) AS destination
+FULL OUTER JOIN dbo.$($run.SourceTable) AS source
+    ON TRY_CONVERT(int, destination.Id) = source.Id;
+"@ `
                 -QueryTimeout 120 `
                 -ReturnType PSObject `
                 -ErrorAction Stop
@@ -561,11 +717,12 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
                 MaxId = [int] $integrity.MaxId
                 IdSum = [long] $integrity.IdSum
                 ScoreSum = [decimal] $integrity.ScoreSum
+                ExactMismatchCount = [long] $integrity.ExactMismatchCount
             }
             $expected = & $getExpectedIntegrity -RowCount ([int] $case.RowCount)
             & $assertIntegrity -FileKind $case.FileKind -TableName $run.DestinationTable -Actual $actual -Expected $expected
 
-            if ($case.FileKind -in @('CsvTyped', 'CsvGZipTyped')) {
+            if ($case.FileKind -in @('CsvTyped', 'CsvGZipTyped', 'Excel', 'ExcelReader', 'ExcelReaderMapped')) {
                 $schema = Invoke-DbaXQuery `
                     -Server $run.Server `
                     -Database $run.Database `
@@ -700,3 +857,6 @@ if (-not $Plan -and $result.Summary) {
 }
 
 $result
+} finally {
+    Restore-DbaClientXBenchmarkProcess -State $benchmarkProcess
+}

--- a/Module/Examples/Benchmark.SqlServerCsvExport.ps1
+++ b/Module/Examples/Benchmark.SqlServerCsvExport.ps1
@@ -452,29 +452,21 @@ ORDER BY Id;
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
-                $connectionString = [DBAClientX.SqlServer]::BuildConnectionString(
-                    $run.Server,
-                    $run.Database,
-                    $true,
-                    $null,
-                    $null,
-                    $null,
-                    $null,
-                    $true,
-                    $null,
-                    $null)
-
-                $client = [DBAClientX.SqlServer]::new()
                 $reader = $null
                 try {
-                    $reader = $client.QueryReader($connectionString, $run.Query)
+                    $reader = Invoke-DbaXQuery `
+                        -Server $run.Server `
+                        -Database $run.Database `
+                        -TrustServerCertificate `
+                        -Query $run.Query `
+                        -QueryTimeout 120 `
+                        -AsDataReader `
+                        -ErrorAction Stop
                     Export-OfficeCsv -InputObject $reader -Path $run.FilePath -NoHeader -DateTimeFormat 'yyyy-MM-dd HH:mm:ss.fffffff' -ErrorAction Stop
                 } finally {
                     if ($null -ne $reader) {
                         $reader.Dispose()
                     }
-
-                    $client.Dispose()
                 }
             }
         }

--- a/Module/Examples/Benchmark.SqlServerCsvExport.ps1
+++ b/Module/Examples/Benchmark.SqlServerCsvExport.ps1
@@ -21,6 +21,9 @@ param(
     [string] $FastBcpParallelMethod = 'Ntile',
     [int] $FastBcpParallelDegree = -2,
     [int] $DbaClientXPartitionDegree = 0,
+    [string] $ProcessorAffinity,
+    [ValidateSet('Current', 'Normal', 'AboveNormal', 'High')]
+    [string] $ProcessPriority = 'Current',
     [string] $OutputRoot,
     [switch] $Plan,
     [switch] $UpdateReadme,
@@ -29,6 +32,7 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'DbaClientX.Benchmark.Process.ps1')
 
 function Convert-DbaClientXBenchmarkList {
     param([object[]] $Value)
@@ -115,6 +119,8 @@ if ($Engine -contains 'DbaClientXPartitionedReader' -and -not (Get-Command Start
 Import-Module PSPublishModule -MinimumVersion 3.0.64 -ErrorAction Stop
 
 $benchmarkScriptRoot = $PSScriptRoot
+$benchmarkProcess = Set-DbaClientXBenchmarkProcess -ProcessorAffinity $ProcessorAffinity -ProcessPriority $ProcessPriority
+try {
 $settings = {
     $sourceRoot = (Resolve-Path -LiteralPath (Join-Path $benchmarkScriptRoot '..\..')).Path
     $readmePath = Join-Path $sourceRoot 'README.md'
@@ -132,6 +138,10 @@ $settings = {
     $fastBcpParallelMethod = $FastBcpParallelMethod
     $fastBcpParallelDegree = $FastBcpParallelDegree
     $dbaClientXPartitionDegree = $DbaClientXPartitionDegree
+    $benchmarkWarmupCount = $WarmupCount
+    $benchmarkIterationCount = $Iterations
+    $appliedProcessorAffinity = $benchmarkProcess.ProcessorAffinity
+    $appliedProcessPriority = $benchmarkProcess.ProcessPriority
     $updateReadme = $UpdateReadme.IsPresent
     $keepArtifacts = $KeepArtifacts.IsPresent
     $rowCounts = $RowCount
@@ -271,8 +281,10 @@ FROM numbers;
     $getFileMetrics = ${function:Get-DbaClientXCsvExportFileMetrics}
 
     benchmark 'sqlserver-csv-export' -out $outputRootBase {
-        policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
+        policy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
         profile Current -Cleanup KeepOnFailure
+        metadata ProcessorAffinity $appliedProcessorAffinity
+        metadata ProcessPriority $appliedProcessPriority
 
         caseSource {
             foreach ($rowCount in $rowCounts) {
@@ -721,3 +733,6 @@ if (-not $Plan -and $result.Summary) {
 }
 
 $result
+} finally {
+    Restore-DbaClientXBenchmarkProcess -State $benchmarkProcess
+}

--- a/Module/Examples/Benchmark.SqlServerCsvExport.ps1
+++ b/Module/Examples/Benchmark.SqlServerCsvExport.ps1
@@ -120,7 +120,11 @@ Import-Module PSPublishModule -MinimumVersion 3.0.64 -ErrorAction Stop
 
 $benchmarkScriptRoot = $PSScriptRoot
 $benchmarkProcess = Set-DbaClientXBenchmarkProcess -ProcessorAffinity $ProcessorAffinity -ProcessPriority $ProcessPriority
+$originalCulture = [System.Globalization.CultureInfo]::CurrentCulture
+$originalUICulture = [System.Globalization.CultureInfo]::CurrentUICulture
 try {
+[System.Globalization.CultureInfo]::CurrentCulture = [System.Globalization.CultureInfo]::InvariantCulture
+[System.Globalization.CultureInfo]::CurrentUICulture = [System.Globalization.CultureInfo]::InvariantCulture
 $settings = {
     $sourceRoot = (Resolve-Path -LiteralPath (Join-Path $benchmarkScriptRoot '..\..')).Path
     $readmePath = Join-Path $sourceRoot 'README.md'
@@ -245,11 +249,32 @@ FROM numbers;
                         continue
                     }
 
-                    $firstDelimiter = $line.IndexOf($Delimiter)
-                    $firstField = if ($firstDelimiter -ge 0) { $line.Substring(0, $firstDelimiter) } else { $line }
+                    $fields = $line.Split($Delimiter)
+                    if ($fields.Length -ne 4) {
+                        throw "CSV row has $($fields.Length) fields instead of 4: '$line'."
+                    }
+
                     $id = 0
-                    if (-not [int]::TryParse($firstField.Trim('"'), [ref] $id)) {
-                        continue
+                    if (-not [int]::TryParse(
+                        $fields[0],
+                        [System.Globalization.NumberStyles]::Integer,
+                        [System.Globalization.CultureInfo]::InvariantCulture,
+                        [ref] $id)) {
+                        throw "CSV row has an invalid Id value '$($fields[0])'."
+                    }
+
+                    $expectedName = "Row $id"
+                    if ($fields[1] -cne $expectedName) {
+                        throw "CSV row $id has DisplayName '$($fields[1])', expected '$expectedName'."
+                    }
+
+                    $expectedScore = ([decimal] $id * [decimal] 1.25).ToString('0.00', [System.Globalization.CultureInfo]::InvariantCulture)
+                    if ($fields[2] -cne $expectedScore) {
+                        throw "CSV row $id has Score '$($fields[2])', expected '$expectedScore'."
+                    }
+
+                    if ($fields[3] -cne '2026-07-08 00:00:00.0000000') {
+                        throw "CSV row $id has CreatedUtc '$($fields[3])', expected '2026-07-08 00:00:00.0000000'."
                     }
 
                     $dataRows++
@@ -285,6 +310,7 @@ FROM numbers;
         profile Current -Cleanup KeepOnFailure
         metadata ProcessorAffinity $appliedProcessorAffinity
         metadata ProcessPriority $appliedProcessPriority
+        metadata Culture InvariantCulture
 
         caseSource {
             foreach ($rowCount in $rowCounts) {
@@ -400,7 +426,7 @@ ORDER BY Id;
                     -ReturnType DataTable `
                     -ErrorAction Stop
 
-                $data | Export-OfficeCsv -Path $run.FilePath -NoHeader -ErrorAction Stop
+                $data | Export-OfficeCsv -Path $run.FilePath -NoHeader -DateTimeFormat 'yyyy-MM-dd HH:mm:ss.fffffff' -ErrorAction Stop
             }
         }
 
@@ -417,7 +443,7 @@ ORDER BY Id;
                     -Stream `
                     -ReturnType DataRow `
                     -ErrorAction Stop |
-                    Export-OfficeCsv -Path $run.FilePath -NoHeader -ErrorAction Stop
+                    Export-OfficeCsv -Path $run.FilePath -NoHeader -DateTimeFormat 'yyyy-MM-dd HH:mm:ss.fffffff' -ErrorAction Stop
             }
         }
 
@@ -442,7 +468,7 @@ ORDER BY Id;
                 $reader = $null
                 try {
                     $reader = $client.QueryReader($connectionString, $run.Query)
-                    Export-OfficeCsv -InputObject $reader -Path $run.FilePath -NoHeader -ErrorAction Stop
+                    Export-OfficeCsv -InputObject $reader -Path $run.FilePath -NoHeader -DateTimeFormat 'yyyy-MM-dd HH:mm:ss.fffffff' -ErrorAction Stop
                 } finally {
                     if ($null -ne $reader) {
                         $reader.Dispose()
@@ -483,7 +509,7 @@ ORDER BY Id;
                             $reader = $null
                             try {
                                 $reader = $client.QueryReader($ConnectionString, $Query)
-                                Export-OfficeCsv -InputObject $reader -Path $Path -NoHeader -ErrorAction Stop
+                                Export-OfficeCsv -InputObject $reader -Path $Path -NoHeader -DateTimeFormat 'yyyy-MM-dd HH:mm:ss.fffffff' -ErrorAction Stop
                             } finally {
                                 if ($null -ne $reader) {
                                     $reader.Dispose()
@@ -517,6 +543,7 @@ ORDER BY Id;
                     Query = $run.Query
                     Path = $run.FilePath
                     Delimiter = ','
+                    DateTimeFormat = 'yyyy-MM-dd HH:mm:ss.fffffff'
                 }
                 $command = Get-Command Export-DbaCsv -ErrorAction Stop
                 if ($command.Parameters.ContainsKey('NoHeader')) {
@@ -544,7 +571,7 @@ ORDER BY Id;
                     '-T',
                     '-c',
                     '-t', ',',
-                    '-r', '0x0A',
+                    '-r', '0x0D0A',
                     '-C', '65001'
                 )
 
@@ -577,7 +604,7 @@ ORDER BY Id;
                     '--fileoutput', $run.FastBcpFileName,
                     '--decimalseparator', '.',
                     '--delimiter', ',',
-                    '--dateformat', 'yyyy-MM-dd HH:mm:ss',
+                    '--dateformat', 'yyyy-MM-dd HH:mm:ss.fffffff',
                     '--encoding', 'UTF-8',
                     '--parallelmethod', $fastBcpParallelMethod
                 )
@@ -734,5 +761,7 @@ if (-not $Plan -and $result.Summary) {
 
 $result
 } finally {
+    [System.Globalization.CultureInfo]::CurrentCulture = $originalCulture
+    [System.Globalization.CultureInfo]::CurrentUICulture = $originalUICulture
     Restore-DbaClientXBenchmarkProcess -State $benchmarkProcess
 }

--- a/Module/Examples/Benchmark.SqlServerDataMovement.ps1
+++ b/Module/Examples/Benchmark.SqlServerDataMovement.ps1
@@ -20,6 +20,9 @@ param(
     ),
     [string[]] $Engine,
     [string[]] $Operation,
+    [string] $ProcessorAffinity,
+    [ValidateSet('Current', 'Normal', 'AboveNormal', 'High')]
+    [string] $ProcessPriority = 'Current',
     [string] $OutputRoot,
     [switch] $Plan,
     [switch] $KeepTables,
@@ -28,6 +31,7 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'DbaClientX.Benchmark.Process.ps1')
 
 function Convert-DbaClientXBenchmarkList {
     param([object[]] $Value)
@@ -127,6 +131,8 @@ if ($Engine -contains 'SqlServer' -and (-not $Operation -or $Operation -contains
 Import-Module PSPublishModule -MinimumVersion 3.0.64 -ErrorAction Stop
 
 $benchmarkScriptRoot = $PSScriptRoot
+$benchmarkProcess = Set-DbaClientXBenchmarkProcess -ProcessorAffinity $ProcessorAffinity -ProcessPriority $ProcessPriority
+try {
 $settings = {
     $sourceRoot = (Resolve-Path -LiteralPath (Join-Path $benchmarkScriptRoot '..\..')).Path
     $moduleRoot = (Resolve-Path -LiteralPath (Join-Path $benchmarkScriptRoot '..')).Path
@@ -144,6 +150,10 @@ $settings = {
     $modulePath = $ModulePath
     $keepTables = $KeepTables.IsPresent
     $updateReadme = $UpdateReadme.IsPresent
+    $benchmarkWarmupCount = $WarmupCount
+    $benchmarkIterationCount = $Iterations
+    $appliedProcessorAffinity = $benchmarkProcess.ProcessorAffinity
+    $appliedProcessPriority = $benchmarkProcess.ProcessPriority
     $rowCounts = $RowCount
     $batchSizes = $BatchSize
     $inputKinds = $InputKind
@@ -364,8 +374,10 @@ CREATE TABLE dbo.$TableName
 
     if ($selectedOperations -contains 'Write') {
         benchmark 'sqlserver-data-movement-write' -out (Join-Path $outputRootBase 'Write') {
-            policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
+            policy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
             profile Current -Cleanup KeepOnFailure
+            metadata ProcessorAffinity $appliedProcessorAffinity
+            metadata ProcessPriority $appliedProcessPriority
 
             caseSource {
                 foreach ($rowCount in $rowCounts) {
@@ -594,8 +606,10 @@ CREATE TABLE dbo.$TableName
 
     if ($selectedOperations -contains 'Read') {
         benchmark 'sqlserver-data-movement-read' -out (Join-Path $outputRootBase 'Read') {
-            policy -Warmup 1 -Iterations 3 -Order Rotated -OutlierMode None
+            policy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
             profile Current -Cleanup KeepOnFailure
+            metadata ProcessorAffinity $appliedProcessorAffinity
+            metadata ProcessPriority $appliedProcessPriority
 
             caseSource {
                 foreach ($rowCount in $rowCounts) {
@@ -832,3 +846,6 @@ if (-not $Plan -and $result.Summary) {
 }
 
 $result
+} finally {
+    Restore-DbaClientXBenchmarkProcess -State $benchmarkProcess
+}

--- a/Module/Examples/DbaClientX.Benchmark.OfficeRoundTrip.ps1
+++ b/Module/Examples/DbaClientX.Benchmark.OfficeRoundTrip.ps1
@@ -1,0 +1,229 @@
+function Import-DbaClientXBenchmarkImportExcel {
+    param(
+        [string] $ModulePath,
+        [string] $ModuleCachePath,
+        [version] $RequiredVersion,
+        [switch] $SkipInstall
+    )
+
+    $resolvedModulePath = $ModulePath
+    if ($ModulePath -eq 'ImportExcel') {
+        New-Item -ItemType Directory -Force -Path $ModuleCachePath | Out-Null
+        $modulePaths = @($env:PSModulePath -split [System.IO.Path]::PathSeparator | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        if ($ModuleCachePath -notin $modulePaths) {
+            $env:PSModulePath = (@($ModuleCachePath) + $modulePaths) -join [System.IO.Path]::PathSeparator
+        }
+
+        $availableModules = @(Get-Module -ListAvailable -Name ImportExcel)
+        if ($null -ne $RequiredVersion) {
+            $availableModules = @($availableModules | Where-Object { $_.Version -eq $RequiredVersion })
+        }
+
+        if ($availableModules.Count -eq 0) {
+            if ($SkipInstall.IsPresent) {
+                $versionLabel = if ($null -ne $RequiredVersion) { " version $RequiredVersion" } else { '' }
+                throw "ImportExcel$versionLabel is not installed and automatic benchmark dependency preparation is disabled."
+            }
+
+            $saveParameters = @{
+                Name = 'ImportExcel'
+                Repository = 'PSGallery'
+                Path = $ModuleCachePath
+                Force = $true
+                ErrorAction = 'Stop'
+            }
+            if ($null -ne $RequiredVersion) {
+                $saveParameters.RequiredVersion = $RequiredVersion
+            }
+            Save-Module @saveParameters
+            $availableModules = @(Get-Module -ListAvailable -Name ImportExcel)
+            if ($null -ne $RequiredVersion) {
+                $availableModules = @($availableModules | Where-Object { $_.Version -eq $RequiredVersion })
+            }
+        }
+
+        if ($null -ne $RequiredVersion) {
+            if ($availableModules.Count -eq 0) {
+                throw "ImportExcel $RequiredVersion could not be resolved after dependency preparation."
+            }
+            $resolvedModulePath = ($availableModules | Sort-Object Path | Select-Object -First 1).Path
+        }
+    }
+
+    $importedModule = Import-Module $resolvedModulePath -Global -Force -PassThru -ErrorAction Stop
+    if ($null -ne $RequiredVersion -and $importedModule.Version -ne $RequiredVersion) {
+        throw "ImportExcel $RequiredVersion was requested, but $($importedModule.Version) was imported from '$($importedModule.Path)'."
+    }
+
+    $importedModule
+}
+
+function Test-ImportExcelCommandAvailability {
+    param(
+        [string] $ModulePath,
+        [string] $ModuleCachePath,
+        [version] $RequiredVersion,
+        [switch] $SkipInstall,
+        [scriptblock] $ImportModuleCommand
+    )
+
+    try {
+        $importedModule = & $ImportModuleCommand -ModulePath $ModulePath -ModuleCachePath $ModuleCachePath -RequiredVersion $RequiredVersion -SkipInstall:$SkipInstall.IsPresent
+    } catch {
+        Write-Warning "Skipping ImportExcel benchmark lane because ImportExcel could not be imported from '$ModulePath': $($_.Exception.Message)"
+        return $false
+    }
+
+    $moduleNames = @($importedModule | ForEach-Object { $_.Name })
+    $exportCommand = Get-Command Export-Excel -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
+    $importCommand = Get-Command Import-Excel -All -ErrorAction SilentlyContinue | Where-Object { $_.ModuleName -in $moduleNames }
+    if (-not $exportCommand -or -not $importCommand) {
+        Write-Warning 'Skipping ImportExcel benchmark lane because the imported module does not expose Export-Excel and Import-Excel.'
+        return $false
+    }
+
+    return $true
+}
+
+function Get-DbaClientXBenchmarkModuleIdentity {
+    param(
+        [object] $Module,
+        [string] $Label
+    )
+
+    $resolvedModules = @($Module | Where-Object { $null -ne $_ } | Select-Object -First 1)
+    if ($resolvedModules.Count -eq 0) {
+        return "$Label=Not loaded"
+    }
+    $resolvedModule = $resolvedModules[0]
+
+    "Name=$($resolvedModule.Name); Version=$($resolvedModule.Version); Path=$($resolvedModule.Path)"
+}
+
+function Get-DbaClientXBenchmarkAssemblyIdentity {
+    param([string] $SimpleName)
+
+    $identities = @(
+        [AppDomain]::CurrentDomain.GetAssemblies() |
+            Where-Object { $_.GetName().Name -eq $SimpleName -and -not [string]::IsNullOrWhiteSpace($_.Location) } |
+            Sort-Object Location -Unique |
+            ForEach-Object {
+                $hash = if (Test-Path -LiteralPath $_.Location) {
+                    (Get-FileHash -LiteralPath $_.Location -Algorithm SHA256).Hash
+                } else {
+                    'Unavailable'
+                }
+                "Version=$($_.GetName().Version); Path=$($_.Location); SHA256=$hash"
+            }
+    )
+
+    if ($identities.Count -eq 0) {
+        return 'Not loaded'
+    }
+
+    $identities -join ' | '
+}
+
+function Get-DbaClientXOfficeBenchmarkCreateTableQuery {
+    param([string] $TableName)
+
+    @"
+IF OBJECT_ID(N'dbo.$TableName', N'U') IS NOT NULL DROP TABLE dbo.$TableName;
+CREATE TABLE dbo.$TableName
+(
+    Id int NOT NULL CONSTRAINT PK_${TableName}_Id PRIMARY KEY CLUSTERED,
+    DisplayName nvarchar(100) NOT NULL,
+    Score decimal(18,2) NOT NULL,
+    CreatedUtc datetime2 NOT NULL
+);
+"@
+}
+
+function Get-DbaClientXOfficeBenchmarkSeedQuery {
+    param(
+        [string] $TableName,
+        [int] $RowCount
+    )
+
+    @"
+WITH numbers AS
+(
+    SELECT TOP ($RowCount)
+        ROW_NUMBER() OVER (ORDER BY (SELECT NULL)) AS Id
+    FROM sys.all_objects AS a
+    CROSS JOIN sys.all_objects AS b
+)
+INSERT INTO dbo.$TableName (Id, DisplayName, Score, CreatedUtc)
+SELECT
+    Id,
+    CONCAT(N'Row ', Id),
+    CONVERT(decimal(18,2), Id * 1.25),
+    DATEADD(second, Id, CONVERT(datetime2, '2026-01-01T00:00:00'))
+FROM numbers;
+"@
+}
+
+function Get-DbaClientXOfficeBenchmarkExpectedIntegrity {
+    param([int] $RowCount)
+
+    $expectedIdSum = [long] ([int64] $RowCount * ([int64] $RowCount + 1) / 2)
+    [pscustomobject]@{
+        Rows = $RowCount
+        MinId = 1
+        MaxId = $RowCount
+        IdSum = $expectedIdSum
+        ScoreSum = [decimal] $expectedIdSum * 1.25
+    }
+}
+
+function Assert-DbaClientXOfficeBenchmarkIntegrity {
+    param(
+        [string] $FileKind,
+        [string] $TableName,
+        [object] $Actual,
+        [object] $Expected
+    )
+
+    if ($Actual.Rows -ne $Expected.Rows) {
+        throw "$FileKind round trip processed $($Actual.Rows) of $($Expected.Rows) expected row(s) for dbo.$TableName."
+    }
+
+    if ($Actual.MinId -ne $Expected.MinId -or
+        $Actual.MaxId -ne $Expected.MaxId -or
+        $Actual.IdSum -ne $Expected.IdSum -or
+        $Actual.ScoreSum -ne $Expected.ScoreSum -or
+        $Actual.ExactMismatchCount -ne 0) {
+        throw "$FileKind round trip produced unexpected data for dbo.${TableName}: MinId=$($Actual.MinId), MaxId=$($Actual.MaxId), IdSum=$($Actual.IdSum), ScoreSum=$($Actual.ScoreSum), ExactMismatchCount=$($Actual.ExactMismatchCount)."
+    }
+}
+
+function Assert-DbaClientXOfficeBenchmarkTypedSchema {
+    param(
+        [string] $FileKind,
+        [string] $TableName,
+        [object[]] $Columns
+    )
+
+    $actualTypes = @{}
+    foreach ($column in @($Columns)) {
+        $actualTypes[[string] $column.ColumnName] = [string] $column.TypeName
+    }
+
+    $excelNumericTypes = $FileKind -in @('Excel', 'ExcelReader', 'ExcelReaderMapped')
+    $expectedTypes = [ordered] @{
+        Id = if ($excelNumericTypes) { @('float') } else { @('int') }
+        DisplayName = @('nvarchar', 'varchar')
+        Score = if ($excelNumericTypes) { @('float') } else { @('decimal', 'numeric') }
+        CreatedUtc = @('datetime2', 'datetime', 'datetimeoffset')
+    }
+
+    foreach ($entry in $expectedTypes.GetEnumerator()) {
+        if (-not $actualTypes.ContainsKey($entry.Key)) {
+            throw "$FileKind typed round trip did not create expected column '$($entry.Key)' in dbo.$TableName."
+        }
+
+        if ($actualTypes[$entry.Key] -notin $entry.Value) {
+            throw "$FileKind typed round trip created dbo.$TableName.$($entry.Key) as $($actualTypes[$entry.Key]); expected one of: $($entry.Value -join ', ')."
+        }
+    }
+}

--- a/Module/Examples/DbaClientX.Benchmark.Process.ps1
+++ b/Module/Examples/DbaClientX.Benchmark.Process.ps1
@@ -1,0 +1,71 @@
+function Set-DbaClientXBenchmarkProcess {
+    [CmdletBinding()]
+    param(
+        [string] $ProcessorAffinity,
+        [ValidateSet('Current', 'Normal', 'AboveNormal', 'High')]
+        [string] $ProcessPriority = 'Current'
+    )
+
+    $process = [System.Diagnostics.Process]::GetCurrentProcess()
+    $originalAffinity = $process.ProcessorAffinity
+    $originalPriority = $process.PriorityClass
+    try {
+        if (-not [string]::IsNullOrWhiteSpace($ProcessorAffinity)) {
+            $text = $ProcessorAffinity.Trim()
+            $mask = if ($text.StartsWith('0x', [System.StringComparison]::OrdinalIgnoreCase)) {
+                [uint64]::Parse($text.Substring(2), [System.Globalization.NumberStyles]::AllowHexSpecifier, [System.Globalization.CultureInfo]::InvariantCulture)
+            } else {
+                [uint64]::Parse($text, [System.Globalization.NumberStyles]::Integer, [System.Globalization.CultureInfo]::InvariantCulture)
+            }
+
+            if ($mask -eq 0) {
+                throw 'ProcessorAffinity must select at least one processor.'
+            }
+
+            if ([IntPtr]::Size -eq 4) {
+                if ($mask -gt [uint32]::MaxValue) {
+                    throw "ProcessorAffinity '$ProcessorAffinity' exceeds the native 32-bit processor mask."
+                }
+
+                $signedMask = [BitConverter]::ToInt32([BitConverter]::GetBytes([uint32] $mask), 0)
+                $process.ProcessorAffinity = [IntPtr]::new($signedMask)
+            } else {
+                $signedMask = [BitConverter]::ToInt64([BitConverter]::GetBytes($mask), 0)
+                $process.ProcessorAffinity = [IntPtr]::new($signedMask)
+            }
+        }
+
+        if ($ProcessPriority -ne 'Current') {
+            $process.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::$ProcessPriority
+        }
+    } catch {
+        $process.ProcessorAffinity = $originalAffinity
+        $process.PriorityClass = $originalPriority
+        throw
+    }
+
+    $nativeMask = if ([IntPtr]::Size -eq 4) {
+        [uint64] [BitConverter]::ToUInt32([BitConverter]::GetBytes($process.ProcessorAffinity.ToInt32()), 0)
+    } else {
+        [BitConverter]::ToUInt64([BitConverter]::GetBytes($process.ProcessorAffinity.ToInt64()), 0)
+    }
+
+    [pscustomobject]@{
+        ProcessorAffinity = '0x{0}' -f $nativeMask.ToString(('X{0}' -f ([IntPtr]::Size * 2)), [System.Globalization.CultureInfo]::InvariantCulture)
+        ProcessPriority = [string] $process.PriorityClass
+        OriginalProcessorAffinity = $originalAffinity
+        OriginalProcessPriority = $originalPriority
+    }
+}
+
+function Restore-DbaClientXBenchmarkProcess {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [object] $State
+    )
+
+    $process = [System.Diagnostics.Process]::GetCurrentProcess()
+    $process.ProcessorAffinity = [IntPtr] $State.OriginalProcessorAffinity
+    $process.PriorityClass = [System.Diagnostics.ProcessPriorityClass] $State.OriginalProcessPriority
+}

--- a/Module/Examples/DbaClientX.Benchmark.Process.ps1
+++ b/Module/Examples/DbaClientX.Benchmark.Process.ps1
@@ -7,54 +7,84 @@ function Set-DbaClientXBenchmarkProcess {
     )
 
     $process = [System.Diagnostics.Process]::GetCurrentProcess()
-    $originalAffinity = $process.ProcessorAffinity
-    $originalPriority = $process.PriorityClass
+    $supportsAffinity =
+        [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Windows) -or
+        [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform([System.Runtime.InteropServices.OSPlatform]::Linux)
+    $originalAffinity = $null
+    $originalPriority = $null
+    $affinityApplied = $false
+    $priorityApplied = $false
+    $affinityDisplay = 'Unsupported'
+    $priorityDisplay = 'Unsupported'
     try {
-        if (-not [string]::IsNullOrWhiteSpace($ProcessorAffinity)) {
-            $text = $ProcessorAffinity.Trim()
-            $mask = if ($text.StartsWith('0x', [System.StringComparison]::OrdinalIgnoreCase)) {
-                [uint64]::Parse($text.Substring(2), [System.Globalization.NumberStyles]::AllowHexSpecifier, [System.Globalization.CultureInfo]::InvariantCulture)
-            } else {
-                [uint64]::Parse($text, [System.Globalization.NumberStyles]::Integer, [System.Globalization.CultureInfo]::InvariantCulture)
-            }
-
-            if ($mask -eq 0) {
-                throw 'ProcessorAffinity must select at least one processor.'
-            }
-
-            if ([IntPtr]::Size -eq 4) {
-                if ($mask -gt [uint32]::MaxValue) {
-                    throw "ProcessorAffinity '$ProcessorAffinity' exceeds the native 32-bit processor mask."
+        if ($supportsAffinity) {
+            $originalAffinity = $process.ProcessorAffinity
+            if (-not [string]::IsNullOrWhiteSpace($ProcessorAffinity)) {
+                $text = $ProcessorAffinity.Trim()
+                $mask = if ($text.StartsWith('0x', [System.StringComparison]::OrdinalIgnoreCase)) {
+                    [uint64]::Parse($text.Substring(2), [System.Globalization.NumberStyles]::AllowHexSpecifier, [System.Globalization.CultureInfo]::InvariantCulture)
+                } else {
+                    [uint64]::Parse($text, [System.Globalization.NumberStyles]::Integer, [System.Globalization.CultureInfo]::InvariantCulture)
                 }
 
-                $signedMask = [BitConverter]::ToInt32([BitConverter]::GetBytes([uint32] $mask), 0)
-                $process.ProcessorAffinity = [IntPtr]::new($signedMask)
-            } else {
-                $signedMask = [BitConverter]::ToInt64([BitConverter]::GetBytes($mask), 0)
-                $process.ProcessorAffinity = [IntPtr]::new($signedMask)
+                if ($mask -eq 0) {
+                    throw 'ProcessorAffinity must select at least one processor.'
+                }
+
+                if ([IntPtr]::Size -eq 4) {
+                    if ($mask -gt [uint32]::MaxValue) {
+                        throw "ProcessorAffinity '$ProcessorAffinity' exceeds the native 32-bit processor mask."
+                    }
+
+                    $signedMask = [BitConverter]::ToInt32([BitConverter]::GetBytes([uint32] $mask), 0)
+                    $process.ProcessorAffinity = [IntPtr]::new($signedMask)
+                } else {
+                    $signedMask = [BitConverter]::ToInt64([BitConverter]::GetBytes($mask), 0)
+                    $process.ProcessorAffinity = [IntPtr]::new($signedMask)
+                }
+
+                $affinityApplied = $true
             }
+
+            $nativeMask = if ([IntPtr]::Size -eq 4) {
+                [uint64] [BitConverter]::ToUInt32([BitConverter]::GetBytes($process.ProcessorAffinity.ToInt32()), 0)
+            } else {
+                [BitConverter]::ToUInt64([BitConverter]::GetBytes($process.ProcessorAffinity.ToInt64()), 0)
+            }
+            $affinityDisplay = '0x{0}' -f $nativeMask.ToString(('X{0}' -f ([IntPtr]::Size * 2)), [System.Globalization.CultureInfo]::InvariantCulture)
+        } elseif (-not [string]::IsNullOrWhiteSpace($ProcessorAffinity)) {
+            throw [System.PlatformNotSupportedException]::new('ProcessorAffinity is supported only on Windows and Linux.')
         }
 
-        if ($ProcessPriority -ne 'Current') {
-            $process.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::$ProcessPriority
+        try {
+            $originalPriority = $process.PriorityClass
+            if ($ProcessPriority -ne 'Current') {
+                $process.PriorityClass = [System.Diagnostics.ProcessPriorityClass]::$ProcessPriority
+                $priorityApplied = $true
+            }
+            $priorityDisplay = [string] $process.PriorityClass
+        } catch [System.PlatformNotSupportedException], [System.NotSupportedException] {
+            if ($ProcessPriority -ne 'Current') {
+                throw [System.PlatformNotSupportedException]::new('ProcessPriority is not supported on this platform.', $_.Exception)
+            }
         }
     } catch {
-        $process.ProcessorAffinity = $originalAffinity
-        $process.PriorityClass = $originalPriority
+        if ($affinityApplied) {
+            $process.ProcessorAffinity = [IntPtr] $originalAffinity
+        }
+        if ($priorityApplied) {
+            $process.PriorityClass = [System.Diagnostics.ProcessPriorityClass] $originalPriority
+        }
         throw
     }
 
-    $nativeMask = if ([IntPtr]::Size -eq 4) {
-        [uint64] [BitConverter]::ToUInt32([BitConverter]::GetBytes($process.ProcessorAffinity.ToInt32()), 0)
-    } else {
-        [BitConverter]::ToUInt64([BitConverter]::GetBytes($process.ProcessorAffinity.ToInt64()), 0)
-    }
-
     [pscustomobject]@{
-        ProcessorAffinity = '0x{0}' -f $nativeMask.ToString(('X{0}' -f ([IntPtr]::Size * 2)), [System.Globalization.CultureInfo]::InvariantCulture)
-        ProcessPriority = [string] $process.PriorityClass
+        ProcessorAffinity = $affinityDisplay
+        ProcessPriority = $priorityDisplay
         OriginalProcessorAffinity = $originalAffinity
         OriginalProcessPriority = $originalPriority
+        RestoreProcessorAffinity = $affinityApplied
+        RestoreProcessPriority = $priorityApplied
     }
 }
 
@@ -66,6 +96,10 @@ function Restore-DbaClientXBenchmarkProcess {
     )
 
     $process = [System.Diagnostics.Process]::GetCurrentProcess()
-    $process.ProcessorAffinity = [IntPtr] $State.OriginalProcessorAffinity
-    $process.PriorityClass = [System.Diagnostics.ProcessPriorityClass] $State.OriginalProcessPriority
+    if ($State.RestoreProcessorAffinity) {
+        $process.ProcessorAffinity = [IntPtr] $State.OriginalProcessorAffinity
+    }
+    if ($State.RestoreProcessPriority) {
+        $process.PriorityClass = [System.Diagnostics.ProcessPriorityClass] $State.OriginalProcessPriority
+    }
 }

--- a/Module/Examples/Example.CsvRoundTrip.ps1
+++ b/Module/Examples/Example.CsvRoundTrip.ps1
@@ -79,17 +79,20 @@ try {
         $csvImportParameters.CompressionType = $CompressionType
     }
 
-    $client = [DBAClientX.SqlServer]::new()
     $sqlReader = $null
     try {
-        $sqlReader = $client.QueryReader($connectionString, "SELECT Id, DisplayName, Score, CreatedUtc FROM $SourceTable ORDER BY Id;")
+        $sqlReader = Invoke-DbaXQuery `
+            -Server $Server `
+            -Database $Database `
+            -TrustServerCertificate `
+            -Query "SELECT Id, DisplayName, Score, CreatedUtc FROM $SourceTable ORDER BY Id;" `
+            -AsDataReader `
+            -ErrorAction Stop
         Export-OfficeCsv -InputObject $sqlReader @csvExportParameters | Out-Null
     } finally {
         if ($null -ne $sqlReader) {
             $sqlReader.Dispose()
         }
-
-        $client.Dispose()
     }
 
     $csvReader = $null

--- a/Module/Examples/Example.ExcelRoundTrip.ps1
+++ b/Module/Examples/Example.ExcelRoundTrip.ps1
@@ -61,11 +61,16 @@ try {
         Remove-Item -LiteralPath $ExcelPath -Force
     }
 
-    $client = [DBAClientX.SqlServer]::new()
     $sqlReader = $null
     try {
-        $client.CommandTimeout = $QueryTimeout
-        $sqlReader = $client.QueryReader($connectionString, "SELECT Id, DisplayName, Score, CreatedUtc FROM $SourceTable ORDER BY Id;")
+        $sqlReader = Invoke-DbaXQuery `
+            -Server $Server `
+            -Database $Database `
+            -TrustServerCertificate `
+            -Query "SELECT Id, DisplayName, Score, CreatedUtc FROM $SourceTable ORDER BY Id;" `
+            -QueryTimeout $QueryTimeout `
+            -AsDataReader `
+            -ErrorAction Stop
         Export-OfficeExcel `
             -InputObject $sqlReader `
             -Path $ExcelPath `
@@ -77,8 +82,6 @@ try {
         if ($null -ne $sqlReader) {
             $sqlReader.Dispose()
         }
-
-        $client.Dispose()
     }
 
     $importedExcel = Import-OfficeExcel `

--- a/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
@@ -13,6 +13,17 @@ describe 'Invoke-DbaXQuery cmdlet' {
         (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'Stream'
     }
 
+    it 'supports the owned DataReader parameter set' {
+        $command = Get-Command Invoke-DbaXQuery
+        $command.Parameters.Keys | Should -Contain 'AsDataReader'
+        @($command.ParameterSets.Name) | Should -Contain 'QueryReader'
+    }
+
+    it 'keeps DataReader output exclusive from row streaming and buffered return types' {
+        { Invoke-DbaXQuery -Server s -Database db -Query 'SELECT 1' -AsDataReader -Stream -ErrorAction Stop } | Should -Throw
+        { Invoke-DbaXQuery -Server s -Database db -Query 'SELECT 1' -AsDataReader -ReturnType DataTable -ErrorAction Stop } | Should -Throw
+    }
+
     it 'supports Username and Password parameters' {
         (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'Username'
         (Get-Command Invoke-DbaXQuery).Parameters.Keys | Should -Contain 'Password'
@@ -153,6 +164,30 @@ describe 'Invoke-DbaXQuery cmdlet' {
             $rows = @(Invoke-DbaXQuery -Server s -Database db -Query 'SELECT 1')
             $rows.Count | Should -Be 1
             $rows[0].Value | Should -Be 1
+        } finally {
+            $prop.SetValue($null, $orig)
+        }
+    }
+
+    it 'emits PSObject columns instead of exposing the internal column count' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletIInvokeDbaXQuery].GetProperty('QueryOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $parameters, $dbParameters)
+            $table = [System.Data.DataTable]::new()
+            $null = $table.Columns.Add('Id', [int])
+            $null = $table.Columns.Add('DisplayName', [string])
+            $null = $table.Rows.Add(1, 'Row 1')
+            return [System.Threading.Tasks.Task[System.Data.DataTable]]::FromResult($table)
+        })
+        try {
+            $rows = @(Invoke-DbaXQuery -Server s -Database db -Query 'SELECT 1' -ReturnType PSObject)
+            $rows.Count | Should -Be 1
+            $rows[0].PSObject.Properties.Name | Should -Contain 'Id'
+            $rows[0].PSObject.Properties.Name | Should -Contain 'DisplayName'
+            $rows[0].Id | Should -Be 1
+            $rows[0].DisplayName | Should -Be 'Row 1'
         } finally {
             $prop.SetValue($null, $orig)
         }

--- a/Module/en-US/DbaClientX-help.xml
+++ b/Module/en-US/DbaClientX-help.xml
@@ -7244,6 +7244,19 @@
       <command:syntaxItem parameterSetName="Query">
         <maml:name>Invoke-DbaXQuery</maml:name>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AsDataReader</maml:name>
+          <maml:description>
+            <maml:para>When enabled, returns one live reader that owns its command and connection until the caller disposes it.&#xD;
+A disabled switch remains compatible with ordinary buffered query options.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Credential</maml:name>
           <maml:description>
             <maml:para>Optional SQL authentication credential.</maml:para>
@@ -7387,7 +7400,8 @@
         <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>AsDataReader</maml:name>
           <maml:description>
-            <maml:para>Returns one live reader that owns its command and connection until the caller disposes it.</maml:para>
+            <maml:para>When enabled, returns one live reader that owns its command and connection until the caller disposes it.&#xD;
+A disabled switch remains compatible with ordinary buffered query options.</maml:para>
           </maml:description>
           <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
@@ -7651,7 +7665,8 @@
       <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>AsDataReader</maml:name>
         <maml:description>
-          <maml:para>Returns one live reader that owns its command and connection until the caller disposes it.</maml:para>
+          <maml:para>When enabled, returns one live reader that owns its command and connection until the caller disposes it.&#xD;
+A disabled switch remains compatible with ordinary buffered query options.</maml:para>
         </maml:description>
         <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>

--- a/Module/en-US/DbaClientX-help.xml
+++ b/Module/en-US/DbaClientX-help.xml
@@ -7238,7 +7238,7 @@
     </command:details>
     <maml:description>
       <maml:para>Connects to a SQL Server instance using integrated security or supplied credentials and executes the specified command.</maml:para>
-      <maml:para>Supports streaming results and multiple return formats via the ReturnType parameter.</maml:para>
+      <maml:para>Supports streaming results, multiple buffered return formats, and transferring an owned data reader to a consuming API.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem parameterSetName="Query">
@@ -7353,6 +7353,129 @@
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TrustServerCertificate</maml:name>
+          <maml:description>
+            <maml:para>Trusts the SQL Server TLS certificate without validating the certificate chain.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Username</maml:name>
+          <maml:description>
+            <maml:para>Optional user name for SQL authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="QueryReader">
+        <maml:name>Invoke-DbaXQuery</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AsDataReader</maml:name>
+          <maml:description>
+            <maml:para>Returns one live reader that owns its command and connection until the caller disposes it.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Optional SQL authentication credential.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Database</maml:name>
+          <maml:description>
+            <maml:para>Defines the database name.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Parameters</maml:name>
+          <maml:description>
+            <maml:para>Provides additional parameters for the query or procedure.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Optional password for SQL authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Query</maml:name>
+          <maml:description>
+            <maml:para>The SQL statement to execute.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>QueryTimeout</maml:name>
+          <maml:description>
+            <maml:para>Sets the command timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="DBServer,SqlInstance,Instance">
+          <maml:name>Server</maml:name>
+          <maml:description>
+            <maml:para>Specifies the SQL Server instance.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -7525,6 +7648,18 @@
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AsDataReader</maml:name>
+        <maml:description>
+          <maml:para>Returns one live reader that owns its command and connection until the caller disposes it.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Credential</maml:name>
         <maml:description>
@@ -7720,6 +7855,21 @@
              Invoke-DbaXQuery -Server 'sql01' -Database 'app' -StoredProcedure 'dbo.usp_GetActiveUsers' -Credential $credential -ReturnType DataTable</dev:code>
         <dev:remarks>
           <maml:para>Runs the stored procedure and outputs a DataTable.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Stream query rows into a file writer.</maml:title>
+        <maml:introduction>
+          <maml:para>PS&gt; </maml:para>
+        </maml:introduction>
+        <dev:code>$reader = Invoke-DbaXQuery -Server 'sql01' -Database 'app' -Query 'SELECT * FROM dbo.Users' -AsDataReader&#xD;
+             try {&#xD;
+                 Export-OfficeCsv -InputObject $reader -Path .\Users.csv&#xD;
+             } finally {&#xD;
+                 $reader.Dispose()&#xD;
+             }</dev:code>
+        <dev:remarks>
+          <maml:para>Returns one live DbDataReader. The caller must dispose it after the consuming API finishes reading.</maml:para>
         </dev:remarks>
       </command:example>
     </command:examples>

--- a/PowerShell.Shared/AsyncPSCmdlet.Execution.cs
+++ b/PowerShell.Shared/AsyncPSCmdlet.Execution.cs
@@ -96,6 +96,20 @@ public abstract partial class AsyncPSCmdlet
                     case PipelineType.OutputEnumerate:
                         base.WriteObject(item.Value, enumerateCollection: true);
                         break;
+                    case PipelineType.OutputAcknowledged:
+                        item.ReplyPipe!.Publish(() =>
+                        {
+                            base.WriteObject(item.Value);
+                            return null;
+                        });
+                        break;
+                    case PipelineType.OutputEnumerateAcknowledged:
+                        item.ReplyPipe!.Publish(() =>
+                        {
+                            base.WriteObject(item.Value, enumerateCollection: true);
+                            return null;
+                        });
+                        break;
                     case PipelineType.Error:
                         base.WriteError((ErrorRecord)item.Value!);
                         break;

--- a/PowerShell.Shared/AsyncPSCmdlet.Pipeline.cs
+++ b/PowerShell.Shared/AsyncPSCmdlet.Pipeline.cs
@@ -222,7 +222,10 @@ public abstract partial class AsyncPSCmdlet
         }
     }
 
-    private object? RequestPipelineReply(object? value, PipelineType type)
+    private object? RequestPipelineReply(
+        object? value,
+        PipelineType type,
+        bool throwIfStoppedAfterReply = true)
     {
         ThrowIfStopped();
         ValidateInteractionGeneration();
@@ -247,7 +250,8 @@ public abstract partial class AsyncPSCmdlet
                 throw new PipelineStoppedException();
             }
 
-            ThrowIfStopped();
+            if (throwIfStoppedAfterReply)
+                ThrowIfStopped();
             if (reply.Rejection is not null)
                 ExceptionDispatchInfo.Capture(reply.Rejection).Throw();
 

--- a/PowerShell.Shared/AsyncPSCmdlet.cs
+++ b/PowerShell.Shared/AsyncPSCmdlet.cs
@@ -73,6 +73,8 @@ public abstract partial class AsyncPSCmdlet : PSCmdlet, IDisposable
     {
         Output,
         OutputEnumerate,
+        OutputAcknowledged,
+        OutputEnumerateAcknowledged,
         Error,
         TerminatingError,
         Warning,
@@ -601,6 +603,32 @@ public abstract partial class AsyncPSCmdlet : PSCmdlet, IDisposable
             return;
 
         _ = TryQueue(item);
+    }
+
+    /// <summary>
+    /// Writes an object to the PowerShell pipeline and returns only after the pipeline has accepted it.
+    /// </summary>
+    /// <remarks>
+    /// Use this ownership-transfer bridge for disposable or otherwise caller-owned values. If pipeline
+    /// delivery is rejected or stopped before acceptance, the method throws and ownership remains with
+    /// the caller.
+    /// </remarks>
+    protected void WriteObjectAndWait(object? sendToPipeline, bool enumerateCollection = false)
+    {
+        ThrowIfStopped();
+        if (CanAccessPipelineDirectly)
+        {
+            using var pipelineContext = EnterDirectPipelineAccess();
+            base.WriteObject(sendToPipeline, enumerateCollection);
+            return;
+        }
+
+        _ = RequestPipelineReply(
+            sendToPipeline,
+            enumerateCollection
+                ? PipelineType.OutputEnumerateAcknowledged
+                : PipelineType.OutputAcknowledged,
+            throwIfStoppedAfterReply: false);
     }
 
     /// <summary>Thread-safe error bridge for asynchronous cmdlet code.</summary>

--- a/README.md
+++ b/README.md
@@ -400,6 +400,12 @@ and artifact details are in [SQL Server benchmark notes](docs/sqlserver-benchmar
 | 100000 rows / CsvTyped / Mapped columns | ColumnShape=Mapped, FileKind=CsvTyped, RowCount=100000 | Core-7.6.3 | RoundTrip | 1.00x (282ms) | 1.92x (541ms) | DbaClientX fastest |
 <!-- office-file-roundtrip-benchmark:end -->
 
+The affinity-pinned streaming XLSX round-trip comparison is documented in the
+[SQL Server benchmark notes](docs/sqlserver-benchmark-notes.md#dated-streaming-xlsx-round-trip-snapshot-2026-08-09).
+On this source-linked run, the DbaClientX/PSWriteOffice/OfficeIMO path used
+6.2-6.6% of ImportExcel's median time while passing the same SQL-side value and
+schema validation.
+
 ## .NET Usage
 
 ### Query Data

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ and artifact details are in [SQL Server benchmark notes](docs/sqlserver-benchmar
 <!-- sqlserver-csv-export-benchmark:start -->
 | Scenario | Variables | Host | Operation | DbaClientXReader | bcp | DbaClientXDataTable | DbaClientXPowerShellStream | dbatools | Result |
 | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
-| 100000 rows / CSV export | RowCount=100000 | Core-7.6.3 | Export | 1.00x (60ms) | 2.36x (142ms) | 6.28x (378ms) | 5.53x (333ms) | 1.44x (87ms) | DbaClientXReader fastest |
+| 100000 rows / CSV export | RowCount=100000 | Core-7.6.4 | Export | 1.00x (58ms) | 1.92x (112ms) | 17.82x (1.04s) | 19.32x (1.13s) | 1.08x (63ms) | DbaClientXReader fastest |
 <!-- sqlserver-csv-export-benchmark:end -->
 
 ## Office File Round Trip

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Start with the job you need to finish:
 | Copy one or more tables between database providers | `Copy-DbaXTableData` | Uses reusable copy definitions plus provider adapters |
 | Stream Azure Table entities between accounts or Table API endpoints | `Copy-DbaXAzureTableData` | Preserves native continuation tokens and keeps each write transaction inside one partition |
 | Query or upsert Azure Table entities from PowerShell | `Get-DbaXAzureTableEntity` / `Write-DbaXAzureTableEntity` | Requires `PartitionKey` and `RowKey`; transaction batches are capped at 100 entities and the service payload limit |
-| Export SQL rows to CSV, compressed CSV, or Excel | `SqlServer.QueryReader(...)` or `Invoke-DbaXQuery -ReturnType DataTable` plus PSWriteOffice `Export-OfficeCsv` / `Export-OfficeExcel` | Streams or buffers database rows into the file writer |
+| Export SQL rows to CSV, compressed CSV, or Excel | `Invoke-DbaXQuery -AsDataReader` or `-ReturnType DataTable` plus PSWriteOffice `Export-OfficeCsv` / `Export-OfficeExcel` | Streams or buffers database rows into the file writer |
 | Import CSV, compressed CSV, or Excel into SQL Server | PSWriteOffice `Import-OfficeCsv -AsDataReader` / `Import-OfficeExcel -AsDataReader` plus `Write-DbaXTableData` | Reads the file as tabular data, then bulk-writes it |
 | Stream a reader into SQL Server bulk copy | `Write-DbaXTableData -Provider SqlServer -InputObject (, $reader)` | Pass the reader as a single input object with `, $reader` |
 
@@ -243,27 +243,20 @@ $rows | Export-OfficeCsv -Path .\Users.csv.gz -CompressionType GZip
 For the fastest SQL Server to CSV export path, stream an owned `DbDataReader` from DbaClientX directly into PSWriteOffice and dispose the reader when the file writer is done:
 
 ```powershell
-$connectionString = [DBAClientX.SqlServer]::BuildConnectionString(
-    'sql01',
-    'App',
-    $true,
-    $null,
-    $null,
-    $null,
-    $null,
-    $true)
-
-$client = [DBAClientX.SqlServer]::new()
 $reader = $null
 try {
-    $reader = $client.QueryReader($connectionString, 'SELECT Id, DisplayName, CreatedUtc FROM dbo.Users')
+    $reader = Invoke-DbaXQuery `
+        -Server 'sql01' `
+        -Database 'App' `
+        -TrustServerCertificate `
+        -Query 'SELECT Id, DisplayName, CreatedUtc FROM dbo.Users' `
+        -AsDataReader `
+        -ErrorAction Stop
     Export-OfficeCsv -InputObject $reader -Path .\Users.csv
 } finally {
     if ($null -ne $reader) {
         $reader.Dispose()
     }
-
-    $client.Dispose()
 }
 ```
 

--- a/docs/data-movement.md
+++ b/docs/data-movement.md
@@ -490,3 +490,10 @@ Use the office file benchmark when the question is not only "how fast is bulk co
 ```
 
 That matrix compares DbaClientX + PSWriteOffice against dbatools `Export-DbaCsv` and `Import-DbaCsv` for plain and compressed CSV. Excel lanes use DbaClientX + PSWriteOffice. Raw parser microbenchmarks against Dataplat/dbatools, Sep, Sylvan, CsvHelper, and LumenWorks are tracked in OfficeIMO.CSV; the DbaClientX benchmark stays focused on database/file round-trip behavior.
+
+For equivalent end-to-end comparisons, add `NativePowerShell` to the plain CSV
+lane or `ImportExcel` to the `ExcelReader` lane. Use `-ProcessorAffinity` and
+`-ProcessPriority` to keep heterogeneous CPU domains from changing the result
+between runs; the applied values are written to benchmark metadata. Parallel
+CSV export remains a separate opt-in lane because partitioning overhead can
+make it slower than one streaming reader at moderate row counts.

--- a/docs/data-movement.md
+++ b/docs/data-movement.md
@@ -136,6 +136,25 @@ $rows | Export-OfficeCsv -Path .\Customers.csv.gz -CompressionType GZip
 $rows | Export-OfficeExcel -Path .\Customers.xlsx -WorksheetName Customers
 ```
 
+For the lowest-allocation path, pass one owned reader directly to the file writer and dispose it after the export:
+
+```powershell
+$reader = Invoke-DbaXQuery `
+    -Server 'sql01' `
+    -Database 'warehouse' `
+    -Query 'SELECT CustomerId, DisplayName, ModifiedUtc FROM dbo.Customers' `
+    -TrustServerCertificate `
+    -AsDataReader `
+    -ErrorAction Stop
+try {
+    Export-OfficeCsv -InputObject $reader -Path .\Customers.csv
+} finally {
+    $reader.Dispose()
+}
+```
+
+Use `Export-OfficeExcel` instead of `Export-OfficeCsv` when the destination is XLSX; each export consumes its own fresh reader. `-AsDataReader` is query-only and mutually exclusive with `-Stream`, `-ReturnType`, and `-StoredProcedure`. It returns one live reader positioned before the first row; the caller owns disposal.
+
 ## Load A SQL Server Staging Table
 
 Start with the default `Write-DbaXTableData` path, then add SQL Server options only when the destination table needs them:

--- a/docs/sqlserver-benchmark-notes.md
+++ b/docs/sqlserver-benchmark-notes.md
@@ -123,7 +123,7 @@ module explicitly. Add `-ImportExcelVersion` to require a specific version;
 the run fails or skips that lane instead of silently substituting another
 version.
 
-### Dated streaming XLSX round-trip snapshot (2026-08-09)
+### Dated streaming XLSX round-trip snapshot (2026-08-10)
 
 This source-linked run measured the complete 25,000-row SQL Server to XLSX to
 SQL Server job. The DbaClientX lane streamed an owned database reader into
@@ -143,18 +143,18 @@ uses binary, length-aware text equality.
 
 | Engine | L3 domain 0 median | L3 domain 1 median | Rows/s at median, domain 0 | Rows/s at median, domain 1 |
 | --- | ---: | ---: | ---: | ---: |
-| DbaClientX + PSWriteOffice + OfficeIMO | 186.88 ms | 182.17 ms | 133,776 | 137,231 |
-| ImportExcel 7.8.10 | 3,003.41 ms | 2,770.94 ms | 8,324 | 9,022 |
-| ImportExcel / DbaClientX duration | 16.07x | 15.21x | n/a | n/a |
+| DbaClientX + PSWriteOffice + OfficeIMO | 218.62 ms | 174.12 ms | 114,355 | 143,580 |
+| ImportExcel 7.8.10 | 3,519.73 ms | 2,926.71 ms | 7,103 | 8,542 |
+| ImportExcel / DbaClientX duration | 16.10x | 16.81x | n/a | n/a |
 
 ImportExcel 7.8.10 bundled EPPlus 4.5.3.2 in this run. The DbaClientX path
-therefore used 6.2-6.6% of that public PowerShell workflow's median duration on
+therefore used 5.9-6.2% of that public PowerShell workflow's median duration on
 the two measured domains. This is not a comparison with current commercial
 EPPlus, whose direct .NET API remains covered by the OfficeIMO.Excel library
 benchmarks.
 
-The product source candidates were DbaClientX `0523a706`, PSWriteOffice
-`fa82e87a`, and OfficeIMO `dd5d2fea`. The benchmark metadata records the
+The product source candidates were DbaClientX `8241ccaa`, PSWriteOffice
+`36b00b6e`, and OfficeIMO `21ac64cb`. The benchmark metadata records the
 resolved module paths and versions, SQL Server identity, benchmark-script hash,
 benchmark-support hash, and SHA-256 identity of the DbaClientX, PSWriteOffice,
 OfficeIMO, and EPPlus assemblies. To reproduce the source-linked run, use
@@ -162,9 +162,9 @@ separate worktrees at those commits and the current benchmark harness:
 
 ```powershell
 $harnessRoot = (Resolve-Path '.').Path
-$dbaClientXRoot = '<path-to-DbaClientX-0523a706-worktree>'
-$psWriteOfficeRoot = '<path-to-PSWriteOffice-fa82e87a-worktree>'
-$officeIMORoot = '<path-to-OfficeIMO-dd5d2fea-worktree>'
+$dbaClientXRoot = '<path-to-DbaClientX-8241ccaa-worktree>'
+$psWriteOfficeRoot = '<path-to-PSWriteOffice-36b00b6e-worktree>'
+$officeIMORoot = '<path-to-OfficeIMO-21ac64cb-worktree>'
 $importExcelCache = Join-Path $harnessRoot 'Ignore\Benchmarks\Modules'
 
 dotnet build (Join-Path $dbaClientXRoot 'DbaClientX.PowerShell\DbaClientX.PowerShell.csproj') -c Release -f net8.0

--- a/docs/sqlserver-benchmark-notes.md
+++ b/docs/sqlserver-benchmark-notes.md
@@ -95,7 +95,85 @@ Run the Excel round-trip lanes:
 The runner can prepare ImportExcel in its benchmark-only module cache. Use
 `-SkipImportExcelInstall` when benchmark execution must not download optional
 comparison dependencies, or pass `-ImportExcelModulePath` to select an existing
-module explicitly.
+module explicitly. Add `-ImportExcelVersion` to require a specific version;
+the run fails or skips that lane instead of silently substituting another
+version.
+
+### Dated streaming XLSX round-trip snapshot (2026-08-09)
+
+This source-linked run measured the complete 25,000-row SQL Server to XLSX to
+SQL Server job. The DbaClientX lane streamed an owned database reader into
+PSWriteOffice, imported the workbook as an OfficeIMO reader, and streamed that
+reader into SQL Server bulk copy. The comparison lane used ImportExcel's public
+object pipeline for the same source query, XLSX table, destination table, and
+bulk-copy settings. These are equivalent user jobs, but not identical internal
+input shapes.
+
+The runner used PowerShell 7.6.4, SQL Server 17.0.1125.2 Standard Edition,
+`High` process priority, five warmups, fifteen rotated measured iterations, no
+removed outliers, and one 16-logical-processor L3 domain at a time. Every one
+of the 60 measured round trips passed the 25,000-row count, min/max, integer
+sum, decimal sum, destination schema, and strict full-join value comparison.
+The strict comparison rejects fractional IDs and sub-cent score changes and
+uses binary, length-aware text equality.
+
+| Engine | L3 domain 0 median | L3 domain 1 median | Rows/s at median, domain 0 | Rows/s at median, domain 1 |
+| --- | ---: | ---: | ---: | ---: |
+| DbaClientX + PSWriteOffice + OfficeIMO | 186.88 ms | 182.17 ms | 133,776 | 137,231 |
+| ImportExcel 7.8.10 | 3,003.41 ms | 2,770.94 ms | 8,324 | 9,022 |
+| ImportExcel / DbaClientX duration | 16.07x | 15.21x | n/a | n/a |
+
+ImportExcel 7.8.10 bundled EPPlus 4.5.3.2 in this run. The DbaClientX path
+therefore used 6.2-6.6% of that public PowerShell workflow's median duration on
+the two measured domains. This is not a comparison with current commercial
+EPPlus, whose direct .NET API remains covered by the OfficeIMO.Excel library
+benchmarks.
+
+The product source candidates were DbaClientX `0523a706`, PSWriteOffice
+`fa82e87a`, and OfficeIMO `dd5d2fea`. The benchmark metadata records the
+resolved module paths and versions, SQL Server identity, benchmark-script hash,
+benchmark-support hash, and SHA-256 identity of the DbaClientX, PSWriteOffice,
+OfficeIMO, and EPPlus assemblies. To reproduce the source-linked run, use
+separate worktrees at those commits and the current benchmark harness:
+
+```powershell
+$harnessRoot = (Resolve-Path '.').Path
+$dbaClientXRoot = '<path-to-DbaClientX-0523a706-worktree>'
+$psWriteOfficeRoot = '<path-to-PSWriteOffice-fa82e87a-worktree>'
+$officeIMORoot = '<path-to-OfficeIMO-dd5d2fea-worktree>'
+$importExcelCache = Join-Path $harnessRoot 'Ignore\Benchmarks\Modules'
+
+dotnet build (Join-Path $dbaClientXRoot 'DbaClientX.PowerShell\DbaClientX.PowerShell.csproj') -c Release -f net8.0
+dotnet build (Join-Path $psWriteOfficeRoot 'Sources\PSWriteOffice\PSWriteOffice.csproj') `
+    -c Release -f net8.0 `
+    -p:UseOfficeIMOProjectReferences=true `
+    -p:OfficeIMORoot=$officeIMORoot
+Save-Module ImportExcel -RequiredVersion 7.8.10 -Path $importExcelCache -Force
+
+$env:DBACLIENTX_USE_DEVELOPMENT_BINARIES = 'true'
+$env:DBACLIENTX_DEVELOPMENT_CONFIGURATION = 'Release'
+$env:PSWRITEOFFICE_USE_DEVELOPMENT_BINARIES = 'true'
+$env:PSWRITEOFFICE_DEVELOPMENT_CONFIGURATION = 'Release'
+
+& (Join-Path $harnessRoot 'Module\Examples\Benchmark.OfficeFileRoundTrip.ps1') `
+    -Server localhost `
+    -Database tempdb `
+    -RowCount 25000 `
+    -FileKind ExcelReader `
+    -ColumnShape Default `
+    -Engine DbaClientX,ImportExcel `
+    -WarmupCount 5 `
+    -Iterations 15 `
+    -ModulePath (Join-Path $dbaClientXRoot 'Module\DbaClientX.psd1') `
+    -PSWriteOfficeModulePath (Join-Path $psWriteOfficeRoot 'PSWriteOffice.psd1') `
+    -ImportExcelModulePath (Join-Path $importExcelCache 'ImportExcel\7.8.10\ImportExcel.psd1') `
+    -ImportExcelVersion 7.8.10 `
+    -SkipImportExcelInstall `
+    -ProcessorAffinity 0xFFFF `
+    -ProcessPriority High
+
+# Repeat with -ProcessorAffinity 0xFFFF0000 for the second measured domain.
+```
 
 On machines with heterogeneous CPU domains, pin comparable runs to the same
 native-width processor mask and record the applied process settings in the

--- a/docs/sqlserver-benchmark-notes.md
+++ b/docs/sqlserver-benchmark-notes.md
@@ -49,9 +49,12 @@ with PSWriteOffice, import the file back as a tabular reader, then bulk-write to
 SQL Server through `Write-DbaXTableData`. Equivalent comparison lanes cover
 dbatools and native PowerShell for plain CSV, and ImportExcel for XLSX.
 Comparison lanes use the same source rows, destination contract, batch size,
-table-lock setting, and integrity checks. Typed, compressed, mapped, and
-streaming-only shapes remain DbaClientX lanes when another engine cannot perform
-the same contract without an artificial adapter.
+table-lock setting, and integrity checks. A shape remains a DbaClientX-only lane
+when another engine cannot perform the same contract without an artificial
+adapter. In typed CSV comparisons,
+PSWriteOffice receives the declared column types while dbatools uses its public
+`DetectColumnTypes` workflow; the runner records that API difference and still
+requires the same typed destination values.
 
 Run the export comparison:
 
@@ -79,6 +82,27 @@ Run the CSV round-trip comparison:
     -Iterations 15 `
     -UpdateReadme
 ```
+
+Add bounded ordered projection to both typed CSV import lanes with the same
+worker and batch limits:
+
+```powershell
+.\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
+    -Server localhost `
+    -Database tempdb `
+    -RowCount 100000 `
+    -FileKind CsvTyped `
+    -Engine DbaClientX,dbatools `
+    -ParallelCsvRead `
+    -CsvReaderMaxDegreeOfParallelism 4 `
+    -CsvReaderParallelBatchSize 4096 `
+    -WarmupCount 3 `
+    -Iterations 15
+```
+
+The parallel controls are recorded in benchmark metadata. They affect only the
+typed CSV and typed compressed-CSV cases; other file kinds retain their normal
+reader path.
 
 Run the Excel round-trip lanes:
 

--- a/docs/sqlserver-benchmark-notes.md
+++ b/docs/sqlserver-benchmark-notes.md
@@ -35,8 +35,9 @@ The read suite seeds an isolated SQL Server table outside the measured operation
 ## CSV export and office round trips
 
 `Benchmark.SqlServerCsvExport.ps1` measures export-only throughput from SQL
-Server to CSV. The DbaClientX reader lane opens a SQL Server `IDataReader` and
-passes it directly to PSWriteOffice `Export-OfficeCsv`; the buffered lane uses a
+Server to CSV. The DbaClientX reader lane uses the public
+`Invoke-DbaXQuery -AsDataReader` API and passes its owned SQL Server reader
+directly to PSWriteOffice `Export-OfficeCsv`; the buffered lane uses a
 `DataTable`; the stream lane uses the public `Invoke-DbaXQuery -Stream` shape;
 and the partitioned lane opens one reader per partition and writes split CSV
 files. Comparison lanes cover dbatools `Export-DbaCsv`, native `bcp queryout`,

--- a/docs/sqlserver-benchmark-notes.md
+++ b/docs/sqlserver-benchmark-notes.md
@@ -45,12 +45,12 @@ and FastBCP.
 `Benchmark.OfficeFileRoundTrip.ps1` measures the combined database/file
 workflow: read source rows with DbaClientX, write CSV, compressed CSV, or Excel
 with PSWriteOffice, import the file back as a tabular reader, then bulk-write to
-SQL Server through `Write-DbaXTableData`.
-The dbatools comparison is CSV-only; Excel uses DbaClientX + PSWriteOffice.
-Both CSV engines use invariant culture, comma delimiters, `AsNeeded` quoting,
-batch size 5000, table locks, and `Fastest` compression for GZip lanes. Typed
-lanes validate the destination SQL column types in addition to row counts and
-value integrity.
+SQL Server through `Write-DbaXTableData`. Equivalent comparison lanes cover
+dbatools and native PowerShell for plain CSV, and ImportExcel for XLSX.
+Comparison lanes use the same source rows, destination contract, batch size,
+table-lock setting, and integrity checks. Typed, compressed, mapped, and
+streaming-only shapes remain DbaClientX lanes when another engine cannot perform
+the same contract without an artificial adapter.
 
 Run the export comparison:
 
@@ -86,10 +86,34 @@ Run the Excel round-trip lanes:
     -Server localhost `
     -Database tempdb `
     -RowCount 1000,5000,25000 `
-    -FileKind Excel,ExcelReader,ExcelReaderMapped `
-    -Engine DbaClientX `
+    -FileKind ExcelReader `
+    -Engine DbaClientX,ImportExcel `
     -Iterations 5
 ```
+
+The runner can prepare ImportExcel in its benchmark-only module cache. Use
+`-SkipImportExcelInstall` when benchmark execution must not download optional
+comparison dependencies, or pass `-ImportExcelModulePath` to select an existing
+module explicitly.
+
+On machines with heterogeneous CPU domains, pin comparable runs to the same
+native-width processor mask and record the applied process settings in the
+benchmark metadata:
+
+```powershell
+.\Module\Examples\Benchmark.OfficeFileRoundTrip.ps1 `
+    -RowCount 100000 `
+    -FileKind Csv,ExcelReader `
+    -Engine DbaClientX,NativePowerShell,ImportExcel `
+    -ProcessorAffinity 0x000000000000FFFF `
+    -ProcessPriority AboveNormal
+```
+
+`Benchmark.SqlServerDataMovement.ps1` and
+`Benchmark.SqlServerCsvExport.ps1` accept the same process controls. A
+partitioned CSV export is reported as its own engine; do not assume it is faster
+than one streaming reader unless the measured row count and SQL partitioning
+strategy prove it.
 
 For unreleased work, build PSWriteOffice with `OfficeIMORoot` pointing at the
 current OfficeIMO checkout and pass `-ModulePath` / `-PSWriteOfficeModulePath`


### PR DESCRIPTION
## Summary

- add Invoke-DbaXQuery -AsDataReader as an explicit query-only contract that returns one live, owned reader for direct handoff to CSV/Excel writers
- keep the command and connection alive until that reader is disposed, with cleanup on partial construction, early stop, and error paths
- reduce PowerShell object-conversion overhead for existing streamed and buffered query results
- update SQL-to-CSV, SQL-to-XLSX, and file-to-SQL examples around reader ownership and one-pass streaming
- add validated, affinity-aware comparisons for dbatools CSV lanes, parallel typed CSV round trips, and ImportExcel XLSX round trips
- refresh generated command help and current benchmark evidence

## Public contract

-AsDataReader is additive. When enabled, it activates the live-reader query contract and is mutually exclusive with -Stream, -ReturnType, and stored procedures. An explicitly disabled `-AsDataReader:$false` remains in the ordinary buffered query contract and can be combined with -ReturnType or `-Stream:$false`. The returned reader is positioned before the first row and the caller must dispose it after the consuming operation finishes.

The intended fast path is:

1. obtain one reader with Invoke-DbaXQuery -AsDataReader
2. pass it directly to Export-OfficeCsv or Export-OfficeExcel
3. dispose it after the writer has consumed it

No database rows need to be materialized as DataTable or PSObject instances unless that shape is explicitly requested.

## Dependencies

The Excel path and its measured evidence depend on:

- EvotecIT/OfficeIMO#2272 for the package-native DataReader writer and CSV/Excel fast paths
- EvotecIT/PSWriteOffice#166 for the atomic PowerShell streaming export surface

This PR should be merged/released only after the required package versions are publicly available to the normal consumer build. The comparison runner records the exact source-linked dependency heads used for the dated evidence; no temporary version probe or compatibility bridge is included.

## Measured evidence

In the checked SQL Server runs:

- direct 100k-row CSV export completed in 58 ms versus 63 ms for dbatools in that workload
- validated CSV round trips ranged from 1.10x to 4.07x faster than the compared dbatools paths, depending on shape and compression
- affinity-pinned SQL-to-XLSX-to-SQL round trips had median times of 218.6 ms versus 3519.7 ms on CPU 0 and 174.1 ms versus 2926.7 ms on CPU 16 against ImportExcel 7.8.10
- both XLSX domains completed with zero failures and SQL-side schema/value validation

These are dated workload-specific comparisons. The runners validate equivalent artifacts/results and record affinity, process priority, dependency versions, and source heads so heterogeneous CPU domains cannot silently decide the winner.

## Validation

- focused .NET and PowerShell cmdlet coverage passed for parameter sets, ownership transfer, disposal, stop behavior, and error cleanup
- SQL CSV and XLSX round-trip runners completed with zero mismatches
- the current documentation was generated/refreshed from the implemented command contract
- the cross-repository DataReader boundary received an independent read-only review; all validated findings were repaired before publication
