### PR TITLE
Align DbaClientX.Core with coordinated releases

### DIFF
--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -3,7 +3,7 @@
   "RootPath": "..",
   "ExpectedVersion": null,
   "ExpectedVersionMap": {
-    "DbaClientX.Core": "0.X.0",
+    "DbaClientX.Core": "1.0.X",
     "DbaClientX.AzureTables": "0.X.0",
     "DbaClientX.SqlServer": "0.X.0",
     "DbaClientX.PostgreSql": "0.X.0",


### PR DESCRIPTION
Moves only the primary DbaClientX.Core package pattern from 0.X.0 to 1.0.X so it can represent the module's existing coordinated 1.0.6 release floor. Provider packages keep their independent 0.x version lines.\n\nValidation: the full package and module build completes; all seven package lanes pack successfully and DbaClientX.Core resolves to 1.0.6. Nothing was published.