### PR TITLE
Return all PowerShell query rows by default

### DIFF
--- a/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
+++ b/DbaClientX.PowerShell/CmdletIInvokeDbaXQuery.cs
@@ -26,7 +26,7 @@ namespace DBAClientX.PowerShell;
 /// '@
 ///
 /// $rows | Format-Table name, database_id, create_date</code>
-/// <para>Executes a multi-line query against a local SQL Server instance and returns each row as a <see cref="DataRow"/>.</para>
+/// <para>Executes a multi-line query against a local SQL Server instance and returns every row as a PowerShell object.</para>
 /// </example>
 /// <example>
 /// <summary>Execute a stored procedure using credentials.</summary>
@@ -94,11 +94,11 @@ public sealed class CmdletIInvokeDbaXQuery : AsyncPSCmdlet {
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     public SwitchParameter Stream { get; set; }
 
-    /// <summary>Selects the type of returned objects.</summary>
+    /// <summary>Selects the type of returned objects. Defaults to PSObject so an ordinary PowerShell query emits every row.</summary>
     [Parameter(Mandatory = false, ParameterSetName = "Query")]
     [Parameter(Mandatory = false, ParameterSetName = "StoredProcedure")]
     [Alias("As")]
-    public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
+    public ReturnType ReturnType { get; set; } = ReturnType.PSObject;
 
     /// <summary>
     /// When enabled, returns one live reader that owns its command and connection until the caller disposes it.

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXMySql.cs
@@ -24,7 +24,7 @@ namespace DBAClientX.PowerShell;
 /// ORDER BY created_at DESC
 /// LIMIT 25;
 /// '@</code>
-/// <para>Returns recent active users as <see cref="DataRow"/> objects.</para>
+/// <para>Returns every recent active user as a PowerShell object.</para>
 /// </example>
 /// <example>
 /// <summary>Stream results as they arrive.</summary>
@@ -70,10 +70,10 @@ public sealed class CmdletInvokeDbaXMySql : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Stream { get; set; }
 
-    /// <summary>Selects the format of the returned data.</summary>
+    /// <summary>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</summary>
     [Parameter]
     [Alias("As")]
-    public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
+    public ReturnType ReturnType { get; set; } = ReturnType.PSObject;
 
     /// <summary>Provides additional parameters for the query.</summary>
     [Parameter]

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXOracle.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXOracle.cs
@@ -19,7 +19,7 @@ namespace DBAClientX.PowerShell;
 ///     SYS_CONTEXT('USERENV', 'SERVICE_NAME') AS ServiceName
 /// FROM dual
 /// '@</code>
-/// <para>Returns Oracle session context as <see cref="DataRow"/> objects.</para>
+/// <para>Returns every Oracle session context row as a PowerShell object.</para>
 /// </example>
 /// <example>
 /// <summary>Stream results as they arrive.</summary>
@@ -66,10 +66,10 @@ public sealed class CmdletInvokeDbaXOracle : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Stream { get; set; }
 
-    /// <summary>Selects the format of the returned data.</summary>
+    /// <summary>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</summary>
     [Parameter]
     [Alias("As")]
-    public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
+    public ReturnType ReturnType { get; set; } = ReturnType.PSObject;
 
     /// <summary>Provides additional parameters for the query.</summary>
     [Parameter]

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSql.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXPostgreSql.cs
@@ -22,7 +22,7 @@ namespace DBAClientX.PowerShell;
 ///     current_user AS connected_as,
 ///     version() AS server_version;
 /// '@</code>
-/// <para>Executes the query and returns each row as a <see cref="DataRow"/>.</para>
+/// <para>Executes the query and returns every row as a PowerShell object.</para>
 /// </example>
 /// <example>
 /// <summary>Execute a stored procedure and get a DataTable.</summary>
@@ -72,11 +72,11 @@ public sealed class CmdletInvokeDbaXPostgreSql : AsyncPSCmdlet {
     [Parameter(ParameterSetName = "Query")]
     public SwitchParameter Stream { get; set; }
 
-    /// <summary>Selects the format of returned data.</summary>
+    /// <summary>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</summary>
     [Parameter(ParameterSetName = "Query")]
     [Parameter(ParameterSetName = "StoredProcedure")]
     [Alias("As")]
-    public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
+    public ReturnType ReturnType { get; set; } = ReturnType.PSObject;
 
     /// <summary>Supplies parameters for the query or stored procedure.</summary>
     [Parameter(ParameterSetName = "Query")]

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXQueryStream.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXQueryStream.cs
@@ -33,10 +33,10 @@ public sealed class CmdletInvokeDbaXQueryStream : AsyncPSCmdlet
     [Parameter(Mandatory = false)]
     public SwitchParameter UseTransaction { get; set; }
 
-    /// <summary>Controls the returned object format.</summary>
+    /// <summary>Controls the returned object format. Defaults to PSObject so an ordinary PowerShell query emits every row.</summary>
     [Parameter(Mandatory = false)]
     [Alias("As")]
-    public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
+    public ReturnType ReturnType { get; set; } = ReturnType.PSObject;
 
     /// <summary>Optional command timeout in seconds.</summary>
     [Parameter(Mandatory = false)]

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXSQLite.cs
@@ -14,7 +14,7 @@ namespace DBAClientX.PowerShell;
 /// <summary>Run a query and return rows.</summary>
 /// <prefix>PS&gt; </prefix>
 /// <code>Invoke-DbaXSQLite -Database 'app.db' -Query 'SELECT * FROM Users'</code>
-/// <para>Executes the query and outputs each row as a <see cref="DataRow"/>.</para>
+/// <para>Executes the query and outputs every row as a PowerShell object.</para>
 /// </example>
 /// <example>
 /// <summary>Stream results from a large query.</summary>
@@ -47,10 +47,10 @@ public sealed class CmdletInvokeDbaXSQLite : AsyncPSCmdlet {
     [Parameter]
     public SwitchParameter Stream { get; set; }
 
-    /// <summary>Selects the format of returned data.</summary>
+    /// <summary>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</summary>
     [Parameter]
     [Alias("As")]
-    public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
+    public ReturnType ReturnType { get; set; } = ReturnType.PSObject;
 
     /// <summary>Provides additional query parameters.</summary>
     [Parameter]

--- a/DbaClientX.PowerShell/CmdletInvokeDbaXStoredProcedure.cs
+++ b/DbaClientX.PowerShell/CmdletInvokeDbaXStoredProcedure.cs
@@ -37,10 +37,10 @@ public sealed class CmdletInvokeDbaXStoredProcedure : AsyncPSCmdlet
     [Parameter(Mandatory = false)]
     public SwitchParameter Stream { get; set; }
 
-    /// <summary>Controls the returned object format.</summary>
+    /// <summary>Controls the returned object format. Defaults to PSObject so an ordinary PowerShell query emits every row.</summary>
     [Parameter(Mandatory = false)]
     [Alias("As")]
-    public ReturnType ReturnType { get; set; } = ReturnType.DataRow;
+    public ReturnType ReturnType { get; set; } = ReturnType.PSObject;
 
     /// <summary>Optional command timeout in seconds.</summary>
     [Parameter(Mandatory = false)]

--- a/DbaClientX.PowerShell/PSObjectConverter.cs
+++ b/DbaClientX.PowerShell/PSObjectConverter.cs
@@ -13,7 +13,11 @@ public static class PSObjectConverter
     /// Converts a <see cref="DataRow"/> into a PowerShell <see cref="PSObject"/> with note properties matching the row's columns.
     /// </summary>
     /// <param name="row">The data row to convert.</param>
-    /// <returns>A <see cref="PSObject"/> representing the provided data row.</returns>
+    /// <returns>
+    /// A <see cref="PSObject"/> representing the provided data row. Column names in PowerShell's reserved
+    /// <c>PS*</c> member namespace are prefixed with <c>Column_</c>; numeric suffixes keep all projected
+    /// names unique without hiding another source column.
+    /// </returns>
     public static PSObject DataRowToPSObject(DataRow row)
     {
         PSObject psObject = new PSObject();
@@ -23,11 +27,9 @@ public static class PSObjectConverter
             var table = row.Table;
             if (!_columnNameCache.TryGetValue(table, out var columnNames))
             {
-                columnNames = new string[table.Columns.Count];
-                for (int i = 0; i < table.Columns.Count; i++)
-                {
-                    columnNames[i] = table.Columns[i].ColumnName;
-                }
+                columnNames = GetUniqueColumnNames(
+                    table.Columns.Count,
+                    ordinal => table.Columns[ordinal].ColumnName);
                 _columnNameCache.Add(table, columnNames);
             }
 
@@ -42,23 +44,46 @@ public static class PSObjectConverter
     }
 
     internal static string[] GetUniqueColumnNames(IDataRecord record)
+        => GetUniqueColumnNames(record.FieldCount, record.GetName);
+
+    private static string[] GetUniqueColumnNames(int fieldCount, Func<int, string> getName)
     {
-        var names = new string[record.FieldCount];
+        var sourceNames = new string[fieldCount];
+        var ordinarySourceNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        for (int ordinal = 0; ordinal < sourceNames.Length; ordinal++)
+        {
+            string sourceName = getName(ordinal);
+            if (string.IsNullOrEmpty(sourceName))
+            {
+                sourceName = $"Column{ordinal + 1}";
+            }
+
+            sourceNames[ordinal] = sourceName;
+            if (!IsReservedPowerShellMemberName(sourceName))
+            {
+                ordinarySourceNames.Add(sourceName);
+            }
+        }
+
+        var names = new string[fieldCount];
         var usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         for (int ordinal = 0; ordinal < names.Length; ordinal++)
         {
-            string baseName = record.GetName(ordinal);
-            if (string.IsNullOrEmpty(baseName))
-            {
-                baseName = $"Column{ordinal + 1}";
-            }
+            string sourceName = sourceNames[ordinal];
+            string baseName = IsReservedPowerShellMemberName(sourceName)
+                ? "Column_" + sourceName
+                : sourceName;
 
             string name = baseName;
-            for (int suffix = 1; !usedNames.Add(name); suffix++)
+            for (int suffix = 1;
+                 usedNames.Contains(name) ||
+                 (!name.Equals(sourceName, StringComparison.OrdinalIgnoreCase) && ordinarySourceNames.Contains(name));
+                 suffix++)
             {
                 name = baseName + suffix.ToString(System.Globalization.CultureInfo.InvariantCulture);
             }
 
+            usedNames.Add(name);
             names[ordinal] = name;
         }
 
@@ -86,15 +111,10 @@ public static class PSObjectConverter
     private static void AddNoteProperty(PSObject psObject, string name, object? value)
     {
         var property = new PSNoteProperty(name, value);
-        if (name.StartsWith("PS", StringComparison.OrdinalIgnoreCase))
-        {
-            // PowerShell reserves the PS* namespace for adapted and extended members.
-            // Preserve its validation and exception behavior for those names.
-            psObject.Properties.Add(property);
-            return;
-        }
-
         psObject.Properties.Add(property, preValidated: true);
     }
+
+    private static bool IsReservedPowerShellMemberName(string name)
+        => name.StartsWith("PS", StringComparison.OrdinalIgnoreCase);
 }
 

--- a/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
+++ b/DbaClientX.Tests/InvokeDbaXQueryCmdletTests.cs
@@ -32,7 +32,7 @@ public class InvokeDbaXQueryCmdletTests
     }
 
     [Fact]
-    public void DataRowReturnType_EmitsEachDataRow()
+    public void DataRowReturnType_EmitsSingleDataRow()
     {
         using var table = CreateTable();
         CmdletIInvokeDbaXQuery.SqlServerFactory = () => new DataTableSqlServer(table);
@@ -41,13 +41,29 @@ public class InvokeDbaXQueryCmdletTests
         {
             var results = InvokeQuery(ReturnType.DataRow);
 
-            Assert.Equal(2, results.Count);
-            Assert.All(results, result => Assert.IsType<DataRow>(result.BaseObject));
+            var result = Assert.Single(results);
+            Assert.IsType<DataRow>(result.BaseObject);
         }
         finally
         {
             CmdletIInvokeDbaXQuery.SqlServerFactory = () => new SqlServer();
         }
+    }
+
+    [Theory]
+    [InlineData(typeof(CmdletIInvokeDbaXQuery))]
+    [InlineData(typeof(CmdletInvokeDbaXMySql))]
+    [InlineData(typeof(CmdletInvokeDbaXOracle))]
+    [InlineData(typeof(CmdletInvokeDbaXPostgreSql))]
+    [InlineData(typeof(CmdletInvokeDbaXSQLite))]
+    [InlineData(typeof(CmdletInvokeDbaXQueryStream))]
+    [InlineData(typeof(CmdletInvokeDbaXStoredProcedure))]
+    public void QueryCmdlets_DefaultToAllRowPowerShellObjects(Type cmdletType)
+    {
+        var cmdlet = Activator.CreateInstance(cmdletType);
+        var returnType = cmdletType.GetProperty("ReturnType")!.GetValue(cmdlet);
+
+        Assert.Equal(ReturnType.PSObject, returnType);
     }
 
     [Fact]
@@ -236,7 +252,7 @@ public class InvokeDbaXQueryCmdletTests
             bool useTransaction = false,
             IDictionary<string, SqlDbType>? parameterTypes = null,
             IDictionary<string, ParameterDirection>? parameterDirections = null)
-            => ReturnType == ReturnType.DataRow ? _table.Rows : _table;
+            => ReturnType == ReturnType.DataRow ? _table.Rows[0] : _table;
 
         public override Task<DbaDataReader> QueryReaderAsync(
             string connectionString,

--- a/DbaClientX.Tests/PSObjectConverterTests.cs
+++ b/DbaClientX.Tests/PSObjectConverterTests.cs
@@ -58,12 +58,36 @@ public class PSObjectConverterTests
     }
 
     [Fact]
-    public void DataRowToPSObjectRejectsReservedPowerShellMemberNames()
+    public void DataRowToPSObjectCanonicalizesReservedPowerShellMemberNamesWithoutHidingOrdinaryColumns()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Column_PSObject", typeof(int));
+        table.Columns.Add("PSObject", typeof(int));
+        table.Columns.Add("PSBase", typeof(int));
+        table.Rows.Add(1, 2, 3);
+
+        var converted = PSObjectConverter.DataRowToPSObject(table.Rows[0]);
+
+        Assert.Equal(1, converted.Properties["Column_PSObject"].Value);
+        Assert.Equal(2, converted.Properties["Column_PSObject1"].Value);
+        Assert.Equal(3, converted.Properties["Column_PSBase"].Value);
+    }
+
+    [Fact]
+    public void DataRecordToPSObjectCanonicalizesReservedPowerShellMemberNames()
     {
         var table = new DataTable();
         table.Columns.Add("PSObject", typeof(int));
-        table.Rows.Add(1);
+        table.Columns.Add("PSFoo", typeof(int));
+        table.Rows.Add(4, 5);
 
-        Assert.Throws<ExtendedTypeSystemException>(() => PSObjectConverter.DataRowToPSObject(table.Rows[0]));
+        using var reader = table.CreateDataReader();
+        Assert.True(reader.Read());
+        string[] columnNames = PSObjectConverter.GetUniqueColumnNames(reader);
+        var converted = PSObjectConverter.DataRecordToPSObject(reader, columnNames, new object[reader.FieldCount]);
+
+        Assert.Equal(new[] { "Column_PSObject", "Column_PSFoo" }, columnNames);
+        Assert.Equal(4, converted.Properties["Column_PSObject"].Value);
+        Assert.Equal(5, converted.Properties["Column_PSFoo"].Value);
     }
 }

--- a/Module/Docs/Invoke-DbaXMySql.md
+++ b/Module/Docs/Invoke-DbaXMySql.md
@@ -36,7 +36,7 @@ LIMIT 25;
 '@
 ```
 
-Returns recent active users as DataRow objects.
+Returns every recent active user as a PowerShell object.
 
 ### EXAMPLE 2
 ```powershell
@@ -150,7 +150,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReturnType
-Selects the format of the returned data.
+Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.
 
 ```yaml
 Type: ReturnType

--- a/Module/Docs/Invoke-DbaXOracle.md
+++ b/Module/Docs/Invoke-DbaXOracle.md
@@ -32,7 +32,7 @@ FROM dual
 '@
 ```
 
-Returns Oracle session context as DataRow objects.
+Returns every Oracle session context row as a PowerShell object.
 
 ### EXAMPLE 2
 ```powershell
@@ -146,7 +146,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReturnType
-Selects the format of the returned data.
+Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.
 
 ```yaml
 Type: ReturnType

--- a/Module/Docs/Invoke-DbaXPostgreSql.md
+++ b/Module/Docs/Invoke-DbaXPostgreSql.md
@@ -37,7 +37,7 @@ SELECT
 '@
 ```
 
-Executes the query and returns each row as a DataRow.
+Executes the query and returns every row as a PowerShell object.
 
 ### EXAMPLE 2
 ```powershell
@@ -146,7 +146,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReturnType
-Selects the format of returned data.
+Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.
 
 ```yaml
 Type: ReturnType

--- a/Module/Docs/Invoke-DbaXQuery.md
+++ b/Module/Docs/Invoke-DbaXQuery.md
@@ -46,7 +46,7 @@ PS> $rows = Invoke-DbaXQuery -Server 'localhost' -Database 'master' -TrustServer
              $rows | Format-Table name, database_id, create_date
 ```
 
-Executes a multi-line query against a local SQL Server instance and returns each row as a DataRow.
+Executes a multi-line query against a local SQL Server instance and returns every row as a PowerShell object.
 
 ### EXAMPLE 2
 ```powershell
@@ -184,7 +184,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReturnType
-Selects the type of returned objects.
+Selects the type of returned objects. Defaults to PSObject so an ordinary PowerShell query emits every row.
 
 ```yaml
 Type: ReturnType

--- a/Module/Docs/Invoke-DbaXQueryStream.md
+++ b/Module/Docs/Invoke-DbaXQueryStream.md
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReturnType
-Controls the returned object format.
+Controls the returned object format. Defaults to PSObject so an ordinary PowerShell query emits every row.
 
 ```yaml
 Type: ReturnType

--- a/Module/Docs/Invoke-DbaXSQLite.md
+++ b/Module/Docs/Invoke-DbaXSQLite.md
@@ -26,7 +26,7 @@ Supports streaming results for large data sets when the platform allows asynchro
 PS> Invoke-DbaXSQLite -Database 'app.db' -Query 'SELECT * FROM Users'
 ```
 
-Executes the query and outputs each row as a DataRow.
+Executes the query and outputs every row as a PowerShell object.
 
 ### EXAMPLE 2
 ```powershell
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReturnType
-Selects the format of returned data.
+Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.
 
 ```yaml
 Type: ReturnType

--- a/Module/Docs/Invoke-DbaXStoredProcedure.md
+++ b/Module/Docs/Invoke-DbaXStoredProcedure.md
@@ -109,7 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### -ReturnType
-Controls the returned object format.
+Controls the returned object format. Defaults to PSObject so an ordinary PowerShell query emits every row.
 
 ```yaml
 Type: ReturnType

--- a/Module/Tests/CmdletInvokeDbaXMySql.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXMySql.Tests.ps1
@@ -33,7 +33,7 @@ describe 'Invoke-DbaXMySql cmdlet' {
             $row = $table.NewRow()
             $row['Value'] = 1
             $table.Rows.Add($row)
-            return $table
+            return ,$table
         })
         try {
             Invoke-DbaXMySql -Server s -Database db -Query 'SELECT 1' -Credential $credential | Out-Null

--- a/Module/Tests/CmdletInvokeDbaXOracle.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXOracle.Tests.ps1
@@ -38,7 +38,7 @@ describe 'Invoke-DbaXOracle cmdlet' {
             $row = $table.NewRow()
             $row['Value'] = 1
             $table.Rows.Add($row)
-            return $table
+            return ,$table
         })
         try {
             Invoke-DbaXOracle -Server s -Database db -Query 'SELECT 1 FROM dual' -Username u -Password p | Out-Null
@@ -67,7 +67,7 @@ describe 'Invoke-DbaXOracle cmdlet' {
             $row = $table.NewRow()
             $row['Value'] = 1
             $table.Rows.Add($row)
-            return $table
+            return ,$table
         })
         try {
             Invoke-DbaXOracle -Server s -Database db -Query 'SELECT 1 FROM dual' -Credential $credential | Out-Null
@@ -94,7 +94,7 @@ describe 'Invoke-DbaXOracle cmdlet' {
             $row = $table.NewRow()
             $row['Value'] = 1
             $table.Rows.Add($row)
-            return $table
+            return ,$table
         })
         try {
             Invoke-DbaXOracle -Server s -Database db -Query 'SELECT 1 FROM dual' -Username u -Password p -QueryTimeout 9 -Parameters @{ A = 1 } | Out-Null

--- a/Module/Tests/CmdletInvokeDbaXPostgreSql.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXPostgreSql.Tests.ps1
@@ -37,7 +37,7 @@ describe 'Invoke-DbaXPostgreSql cmdlet' {
             $row = $table.NewRow()
             $row['Value'] = 1
             $table.Rows.Add($row)
-            return $table
+            return ,$table
         })
         try {
             Invoke-DbaXPostgreSql -Server s -Database db -Query 'SELECT 1' -Credential $credential | Out-Null

--- a/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
+++ b/Module/Tests/CmdletInvokeDbaXQuery.Tests.ps1
@@ -193,6 +193,28 @@ describe 'Invoke-DbaXQuery cmdlet' {
         }
     }
 
+    it 'canonicalizes reserved PowerShell column names without dropping the row' {
+        $binding = [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static
+        $prop = [DBAClientX.PowerShell.CmdletIInvokeDbaXQuery].GetProperty('QueryOverride', $binding)
+        $orig = $prop.GetValue($null)
+        $prop.SetValue($null, [scriptblock]{
+            param($cmdlet, $parameters, $dbParameters)
+            $table = [System.Data.DataTable]::new()
+            $null = $table.Columns.Add('Column_PSObject', [int])
+            $null = $table.Columns.Add('PSObject', [int])
+            $null = $table.Rows.Add(1, 2)
+            return [System.Threading.Tasks.Task[System.Data.DataTable]]::FromResult($table)
+        })
+        try {
+            $rows = @(Invoke-DbaXQuery -Server s -Database db -Query 'SELECT 1')
+            $rows.Count | Should -Be 1
+            $rows[0].Column_PSObject | Should -Be 1
+            $rows[0].Column_PSObject1 | Should -Be 2
+        } finally {
+            $prop.SetValue($null, $orig)
+        }
+    }
+
     it 'streams rows asynchronously' {
         if ($PSVersionTable.PSEdition -ne 'Core') {
             Set-ItResult -Skipped -Because 'Streaming cmdlet execution is only available on Core targets.'

--- a/Module/en-US/DbaClientX-help.xml
+++ b/Module/en-US/DbaClientX-help.xml
@@ -3776,7 +3776,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
           <maml:name>ReturnType</maml:name>
           <maml:description>
-            <maml:para>Selects the format of the returned data.</maml:para>
+            <maml:para>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
           <command:parameterValueGroup>
@@ -3905,7 +3905,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
         <maml:name>ReturnType</maml:name>
         <maml:description>
-          <maml:para>Selects the format of the returned data.</maml:para>
+          <maml:para>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
         <command:parameterValueGroup>
@@ -3989,7 +3989,7 @@
             LIMIT 25;&#xD;
             '@</dev:code>
         <dev:remarks>
-          <maml:para>Returns recent active users as DataRow objects.</maml:para>
+          <maml:para>Returns every recent active user as a PowerShell object.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -5211,7 +5211,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
           <maml:name>ReturnType</maml:name>
           <maml:description>
-            <maml:para>Selects the format of the returned data.</maml:para>
+            <maml:para>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
           <command:parameterValueGroup>
@@ -5340,7 +5340,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
         <maml:name>ReturnType</maml:name>
         <maml:description>
-          <maml:para>Selects the format of the returned data.</maml:para>
+          <maml:para>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
         <command:parameterValueGroup>
@@ -5420,7 +5420,7 @@
             FROM dual&#xD;
             '@</dev:code>
         <dev:remarks>
-          <maml:para>Returns Oracle session context as DataRow objects.</maml:para>
+          <maml:para>Returns every Oracle session context row as a PowerShell object.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -6337,7 +6337,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
           <maml:name>ReturnType</maml:name>
           <maml:description>
-            <maml:para>Selects the format of returned data.</maml:para>
+            <maml:para>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
           <command:parameterValueGroup>
@@ -6454,7 +6454,7 @@
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
           <maml:name>ReturnType</maml:name>
           <maml:description>
-            <maml:para>Selects the format of returned data.</maml:para>
+            <maml:para>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
           <command:parameterValueGroup>
@@ -6583,7 +6583,7 @@
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
         <maml:name>ReturnType</maml:name>
         <maml:description>
-          <maml:para>Selects the format of returned data.</maml:para>
+          <maml:para>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
         <command:parameterValueGroup>
@@ -6675,7 +6675,7 @@
                 version() AS server_version;&#xD;
             '@</dev:code>
         <dev:remarks>
-          <maml:para>Executes the query and returns each row as a DataRow.</maml:para>
+          <maml:para>Executes the query and returns every row as a PowerShell object.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -7331,7 +7331,7 @@ A disabled switch remains compatible with ordinary buffered query options.</maml
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
           <maml:name>ReturnType</maml:name>
           <maml:description>
-            <maml:para>Selects the type of returned objects.</maml:para>
+            <maml:para>Selects the type of returned objects. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
           <command:parameterValueGroup>
@@ -7584,7 +7584,7 @@ A disabled switch remains compatible with ordinary buffered query options.</maml
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
           <maml:name>ReturnType</maml:name>
           <maml:description>
-            <maml:para>Selects the type of returned objects.</maml:para>
+            <maml:para>Selects the type of returned objects. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
           <command:parameterValueGroup>
@@ -7750,7 +7750,7 @@ A disabled switch remains compatible with ordinary buffered query options.</maml
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
         <maml:name>ReturnType</maml:name>
         <maml:description>
-          <maml:para>Selects the type of returned objects.</maml:para>
+          <maml:para>Selects the type of returned objects. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
         <command:parameterValueGroup>
@@ -7858,7 +7858,7 @@ A disabled switch remains compatible with ordinary buffered query options.</maml
             &#xD;
              $rows | Format-Table name, database_id, create_date</dev:code>
         <dev:remarks>
-          <maml:para>Executes a multi-line query against a local SQL Server instance and returns each row as a DataRow.</maml:para>
+          <maml:para>Executes a multi-line query against a local SQL Server instance and returns every row as a PowerShell object.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -7984,7 +7984,7 @@ A disabled switch remains compatible with ordinary buffered query options.</maml
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
           <maml:name>ReturnType</maml:name>
           <maml:description>
-            <maml:para>Controls the returned object format.</maml:para>
+            <maml:para>Controls the returned object format. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
           <command:parameterValueGroup>
@@ -8084,7 +8084,7 @@ A disabled switch remains compatible with ordinary buffered query options.</maml
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
         <maml:name>ReturnType</maml:name>
         <maml:description>
-          <maml:para>Controls the returned object format.</maml:para>
+          <maml:para>Controls the returned object format. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
         <command:parameterValueGroup>
@@ -8206,7 +8206,7 @@ A disabled switch remains compatible with ordinary buffered query options.</maml
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
           <maml:name>ReturnType</maml:name>
           <maml:description>
-            <maml:para>Selects the format of returned data.</maml:para>
+            <maml:para>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
           <command:parameterValueGroup>
@@ -8287,7 +8287,7 @@ A disabled switch remains compatible with ordinary buffered query options.</maml
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
         <maml:name>ReturnType</maml:name>
         <maml:description>
-          <maml:para>Selects the format of returned data.</maml:para>
+          <maml:para>Selects the format of returned data. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
         <command:parameterValueGroup>
@@ -8337,7 +8337,7 @@ A disabled switch remains compatible with ordinary buffered query options.</maml
         </maml:introduction>
         <dev:code>Invoke-DbaXSQLite -Database 'app.db' -Query 'SELECT * FROM Users'</dev:code>
         <dev:remarks>
-          <maml:para>Executes the query and outputs each row as a DataRow.</maml:para>
+          <maml:para>Executes the query and outputs every row as a PowerShell object.</maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
@@ -8866,7 +8866,7 @@ A disabled switch remains compatible with ordinary buffered query options.</maml
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
           <maml:name>ReturnType</maml:name>
           <maml:description>
-            <maml:para>Controls the returned object format.</maml:para>
+            <maml:para>Controls the returned object format. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
           <command:parameterValueGroup>
@@ -8978,7 +8978,7 @@ A disabled switch remains compatible with ordinary buffered query options.</maml
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="As">
         <maml:name>ReturnType</maml:name>
         <maml:description>
-          <maml:para>Controls the returned object format.</maml:para>
+          <maml:para>Controls the returned object format. Defaults to PSObject so an ordinary PowerShell query emits every row.</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">ReturnType</command:parameterValue>
         <command:parameterValueGroup>


### PR DESCRIPTION
## Summary

- make the SQL Server, PostgreSQL, Oracle, MySQL, SQLite, streaming, and stored-procedure PowerShell query commands default to `PSObject`
- return one normal PowerShell object per row for ordinary query invocations
- keep explicit `-ReturnType DataRow`, `DataTable`, and reader modes available
- canonicalize PowerShell-reserved `PS*` column aliases as `Column_<name>` and add numeric suffixes when needed, so unusual schemas do not drop query results
- refresh generated command documentation and MAML help to describe the default

## Compatibility

This intentionally changes the default output shape from `DataRow` to `PSObject`. Scripts that require the legacy object type can continue to use `-ReturnType DataRow` (or `-As DataRow`) explicitly.

Ordinary SQL aliases are preserved. Because PowerShell reserves the `PS*` member namespace, a source alias such as `PSObject` is exposed as `Column_PSObject`; if that name already exists, DbaClientX selects the next numeric suffix without hiding either value.

## Validation

- full .NET 8 suite: 1,225 passed
- focused converter contracts: 5/5 on .NET 8 and 5/5 on .NET 10
- full PowerShell 7 suite: 228 passed
- full Windows PowerShell 5.1 suite: 219 passed, 9 expected platform skips
- packaged SQLite query returned both rows as `PSCustomObject` values in PowerShell 7 and Windows PowerShell 5.1
- generated Markdown and MAML help are synchronized with the public default