### PR TITLE
Use canonical commands in database benchmarks

### DIFF
--- a/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
+++ b/Module/Examples/Benchmark.OfficeFileRoundTrip.ps1
@@ -217,27 +217,27 @@ $settings = {
     $officeIMOExcelAssemblyIdentity = & $getAssemblyIdentity -SimpleName 'OfficeIMO.Excel'
     $officeIMOCsvAssemblyIdentity = & $getAssemblyIdentity -SimpleName 'OfficeIMO.CSV'
     $epplusAssemblyIdentity = & $getAssemblyIdentity -SimpleName 'EPPlus'
-    benchmark 'office-file-roundtrip' -out $outputRootBase {
-        policy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
-        profile Current -Cleanup KeepOnFailure
-        metadata ProcessorAffinity $appliedProcessorAffinity
-        metadata ProcessPriority $appliedProcessPriority
-        metadata BenchmarkScript $benchmarkScript
-        metadata BenchmarkSupport $benchmarkSupport
-        metadata SqlServer $sqlServerIdentity
-        metadata DbaClientXModule $dbaClientXModuleIdentity
-        metadata DbaClientXAssembly $dbaClientXAssemblyIdentity
-        metadata PSWriteOfficeModule $psWriteOfficeModuleIdentity
-        metadata PSWriteOfficeAssembly $psWriteOfficeAssemblyIdentity
-        metadata OfficeIMOExcelAssembly $officeIMOExcelAssemblyIdentity
-        metadata OfficeIMOCsvAssembly $officeIMOCsvAssemblyIdentity
-        metadata ParallelCsvRead $parallelCsvRead
-        metadata CsvReaderMaxDegreeOfParallelism $csvReaderMaxDegreeOfParallelism
-        metadata CsvReaderParallelBatchSize $csvReaderParallelBatchSize
-        metadata ImportExcelModule $importExcelModuleIdentity
-        metadata EPPlusAssembly $epplusAssemblyIdentity
+    New-BenchmarkSuite 'office-file-roundtrip' -OutputRoot $outputRootBase {
+        Set-BenchmarkPolicy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
+        Set-BenchmarkProfile Current -Cleanup KeepOnFailure
+        Add-BenchmarkMetadata ProcessorAffinity $appliedProcessorAffinity
+        Add-BenchmarkMetadata ProcessPriority $appliedProcessPriority
+        Add-BenchmarkMetadata BenchmarkScript $benchmarkScript
+        Add-BenchmarkMetadata BenchmarkSupport $benchmarkSupport
+        Add-BenchmarkMetadata SqlServer $sqlServerIdentity
+        Add-BenchmarkMetadata DbaClientXModule $dbaClientXModuleIdentity
+        Add-BenchmarkMetadata DbaClientXAssembly $dbaClientXAssemblyIdentity
+        Add-BenchmarkMetadata PSWriteOfficeModule $psWriteOfficeModuleIdentity
+        Add-BenchmarkMetadata PSWriteOfficeAssembly $psWriteOfficeAssemblyIdentity
+        Add-BenchmarkMetadata OfficeIMOExcelAssembly $officeIMOExcelAssemblyIdentity
+        Add-BenchmarkMetadata OfficeIMOCsvAssembly $officeIMOCsvAssemblyIdentity
+        Add-BenchmarkMetadata ParallelCsvRead $parallelCsvRead
+        Add-BenchmarkMetadata CsvReaderMaxDegreeOfParallelism $csvReaderMaxDegreeOfParallelism
+        Add-BenchmarkMetadata CsvReaderParallelBatchSize $csvReaderParallelBatchSize
+        Add-BenchmarkMetadata ImportExcelModule $importExcelModuleIdentity
+        Add-BenchmarkMetadata EPPlusAssembly $epplusAssemblyIdentity
 
-        caseSource {
+        Add-BenchmarkCaseSource {
             foreach ($rowCount in $rowCounts) {
                 foreach ($fileKind in $fileKinds) {
                     foreach ($columnShape in $columnShapes) {
@@ -258,7 +258,7 @@ $settings = {
             }
         }
 
-        setup {
+        Set-BenchmarkSetup {
             param($case, $run)
 
             $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -327,7 +327,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             }
         }
 
-        skip {
+        Add-BenchmarkSkipRule {
             param($case)
 
             if ($case.Engine -eq 'dbatools') {
@@ -349,8 +349,8 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             return $false
         }
 
-        engine DbaClientX {
-            operation RoundTrip {
+        Add-BenchmarkEngine DbaClientX {
+            Add-BenchmarkOperation RoundTrip {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -508,8 +508,8 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             }
         }
 
-        engine NativePowerShell {
-            operation RoundTrip {
+        Add-BenchmarkEngine NativePowerShell {
+            Add-BenchmarkOperation RoundTrip {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -527,8 +527,8 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             }
         }
 
-        engine ImportExcel {
-            operation RoundTrip {
+        Add-BenchmarkEngine ImportExcel {
+            Add-BenchmarkOperation RoundTrip {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -546,8 +546,8 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             }
         }
 
-        engine dbatools {
-            operation RoundTrip {
+        Add-BenchmarkEngine dbatools {
+            Add-BenchmarkOperation RoundTrip {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -607,7 +607,7 @@ IF OBJECT_ID(N'dbo.$($run.SourceTable)', N'U') IS NOT NULL DROP TABLE dbo.$($run
             }
         }
 
-        validate {
+        Add-BenchmarkValidation {
             param($case, $run)
 
             $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -677,43 +677,43 @@ FULL OUTER JOIN dbo.$($run.SourceTable) AS source
             }
         }
 
-        metric RowsProcessed {
+        Add-BenchmarkMetric RowsProcessed {
             param($case, $run)
 
             $run.RowsProcessed
         }
 
-        metric ExportMs {
+        Add-BenchmarkMetric ExportMs {
             param($case, $run)
 
             $run.ExportMs
         }
 
-        metric LoadMs {
+        Add-BenchmarkMetric LoadMs {
             param($case, $run)
 
             $run.LoadMs
         }
 
-        metric IdSum {
+        Add-BenchmarkMetric IdSum {
             param($case, $run)
 
             $run.IdSum
         }
 
-        metric ScoreSum {
+        Add-BenchmarkMetric ScoreSum {
             param($case, $run)
 
             $run.ScoreSum
         }
 
-        metric ExactMismatchCount {
+        Add-BenchmarkMetric ExactMismatchCount {
             param($case, $run)
 
             $run.ExactMismatchCount
         }
 
-        metric RowsPerSecond {
+        Add-BenchmarkMetric RowsPerSecond {
             param($case, $run)
 
             if ($run.DurationMs -le 0) {
@@ -724,12 +724,12 @@ FULL OUTER JOIN dbo.$($run.SourceTable) AS source
         }
 
         if ($selectedEngines.Count -gt 1) {
-            comparison Engine -Baseline $engineComparisonBaseline -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
+            Add-BenchmarkComparison Engine -Baseline $engineComparisonBaseline -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
             if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
-                readme $readmePath -Block 'office-file-roundtrip-benchmark' -Renderer ComparisonTable
+                Add-BenchmarkReadmeBlock $readmePath -Block 'office-file-roundtrip-benchmark' -Renderer ComparisonTable
             }
         }
-        artifacts Json, Csv, Markdown
+        Set-BenchmarkArtifacts Json, Csv, Markdown
     }
 }.GetNewClosure()
 

--- a/Module/Examples/Benchmark.SqlServerCsvExport.ps1
+++ b/Module/Examples/Benchmark.SqlServerCsvExport.ps1
@@ -305,14 +305,14 @@ FROM numbers;
     $getSeedQuery = ${function:Get-DbaClientXCsvExportSeedQuery}
     $getFileMetrics = ${function:Get-DbaClientXCsvExportFileMetrics}
 
-    benchmark 'sqlserver-csv-export' -out $outputRootBase {
-        policy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
-        profile Current -Cleanup KeepOnFailure
-        metadata ProcessorAffinity $appliedProcessorAffinity
-        metadata ProcessPriority $appliedProcessPriority
-        metadata Culture InvariantCulture
+    New-BenchmarkSuite 'sqlserver-csv-export' -OutputRoot $outputRootBase {
+        Set-BenchmarkPolicy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
+        Set-BenchmarkProfile Current -Cleanup KeepOnFailure
+        Add-BenchmarkMetadata ProcessorAffinity $appliedProcessorAffinity
+        Add-BenchmarkMetadata ProcessPriority $appliedProcessPriority
+        Add-BenchmarkMetadata Culture InvariantCulture
 
-        caseSource {
+        Add-BenchmarkCaseSource {
             foreach ($rowCount in $rowCounts) {
                 [pscustomobject]@{
                     Scenario = "$rowCount rows / CSV export"
@@ -321,7 +321,7 @@ FROM numbers;
             }
         }
 
-        setup {
+        Set-BenchmarkSetup {
             param($case, $run)
 
             $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -387,7 +387,7 @@ ORDER BY Id;
             }
         }
 
-        skip {
+        Add-BenchmarkSkipRule {
             param($case)
 
             if ($case.Engine -in @('DbaClientXDataTable', 'DbaClientXPowerShellStream', 'DbaClientXReader', 'DbaClientXPartitionedReader')) {
@@ -413,8 +413,8 @@ ORDER BY Id;
             return $false
         }
 
-        engine DbaClientXDataTable {
-            operation Export {
+        Add-BenchmarkEngine DbaClientXDataTable {
+            Add-BenchmarkOperation Export {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -430,8 +430,8 @@ ORDER BY Id;
             }
         }
 
-        engine DbaClientXPowerShellStream {
-            operation Export {
+        Add-BenchmarkEngine DbaClientXPowerShellStream {
+            Add-BenchmarkOperation Export {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -447,8 +447,8 @@ ORDER BY Id;
             }
         }
 
-        engine DbaClientXReader {
-            operation Export {
+        Add-BenchmarkEngine DbaClientXReader {
+            Add-BenchmarkOperation Export {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -471,8 +471,8 @@ ORDER BY Id;
             }
         }
 
-        engine DbaClientXPartitionedReader {
-            operation Export {
+        Add-BenchmarkEngine DbaClientXPartitionedReader {
+            Add-BenchmarkOperation Export {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -524,8 +524,8 @@ ORDER BY Id;
             }
         }
 
-        engine dbatools {
-            operation Export {
+        Add-BenchmarkEngine dbatools {
+            Add-BenchmarkOperation Export {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -549,8 +549,8 @@ ORDER BY Id;
             }
         }
 
-        engine bcp {
-            operation Export {
+        Add-BenchmarkEngine bcp {
+            Add-BenchmarkOperation Export {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -574,8 +574,8 @@ ORDER BY Id;
             }
         }
 
-        engine FastBCP {
-            operation Export {
+        Add-BenchmarkEngine FastBCP {
+            Add-BenchmarkOperation Export {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -617,7 +617,7 @@ ORDER BY Id;
             }
         }
 
-        validate {
+        Add-BenchmarkValidation {
             param($case, $run)
 
             $outputFiles = if ($case.Engine -eq 'FastBCP') {
@@ -675,25 +675,25 @@ ORDER BY Id;
             }
         }
 
-        metric RowsExported {
+        Add-BenchmarkMetric RowsExported {
             param($case, $run)
 
             $run.RowsExported
         }
 
-        metric FileBytes {
+        Add-BenchmarkMetric FileBytes {
             param($case, $run)
 
             $run.FileBytes
         }
 
-        metric OutputFileCount {
+        Add-BenchmarkMetric OutputFileCount {
             param($case, $run)
 
             if ($null -ne $run.OutputFileCount) { $run.OutputFileCount } else { 1 }
         }
 
-        metric RowsPerSecond {
+        Add-BenchmarkMetric RowsPerSecond {
             param($case, $run)
 
             if ($run.DurationMs -le 0) {
@@ -703,11 +703,11 @@ ORDER BY Id;
             [double] $case.RowCount / ($run.DurationMs / 1000)
         }
 
-        comparison Engine -Baseline DbaClientXReader -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
+        Add-BenchmarkComparison Engine -Baseline DbaClientXReader -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
         if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
-            readme $readmePath -Block 'sqlserver-csv-export-benchmark' -Renderer ComparisonTable
+            Add-BenchmarkReadmeBlock $readmePath -Block 'sqlserver-csv-export-benchmark' -Renderer ComparisonTable
         }
-        artifacts Json, Csv, Markdown
+        Set-BenchmarkArtifacts Json, Csv, Markdown
     }
 }.GetNewClosure()
 

--- a/Module/Examples/Benchmark.SqlServerDataMovement.ps1
+++ b/Module/Examples/Benchmark.SqlServerDataMovement.ps1
@@ -373,13 +373,13 @@ CREATE TABLE dbo.$TableName
     $assertIntegrity = ${function:Assert-DbaClientXBenchmarkIntegrity}
 
     if ($selectedOperations -contains 'Write') {
-        benchmark 'sqlserver-data-movement-write' -out (Join-Path $outputRootBase 'Write') {
-            policy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
-            profile Current -Cleanup KeepOnFailure
-            metadata ProcessorAffinity $appliedProcessorAffinity
-            metadata ProcessPriority $appliedProcessPriority
+        New-BenchmarkSuite 'sqlserver-data-movement-write' -OutputRoot (Join-Path $outputRootBase 'Write') {
+            Set-BenchmarkPolicy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
+            Set-BenchmarkProfile Current -Cleanup KeepOnFailure
+            Add-BenchmarkMetadata ProcessorAffinity $appliedProcessorAffinity
+            Add-BenchmarkMetadata ProcessPriority $appliedProcessPriority
 
-            caseSource {
+            Add-BenchmarkCaseSource {
                 foreach ($rowCount in $rowCounts) {
                     foreach ($batchSize in $batchSizes) {
                         foreach ($inputKind in $inputKinds) {
@@ -394,7 +394,7 @@ CREATE TABLE dbo.$TableName
                 }
             }
 
-            setup {
+            Set-BenchmarkSetup {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -429,7 +429,7 @@ CREATE TABLE dbo.$TableName
                 }
             }
 
-            skip {
+            Add-BenchmarkSkipRule {
                 param($case)
 
                 if ($case.Engine -eq 'dbatools' -and -not (Get-Command Write-DbaDbTableData -ErrorAction SilentlyContinue)) {
@@ -447,8 +447,8 @@ CREATE TABLE dbo.$TableName
                 return $false
             }
 
-            engine DbaClientX {
-                operation Write {
+            Add-BenchmarkEngine DbaClientX {
+                Add-BenchmarkOperation Write {
                     param($case, $run)
 
                     $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -482,8 +482,8 @@ CREATE TABLE dbo.$TableName
                 }
             }
 
-            engine dbatools {
-                operation Write {
+            Add-BenchmarkEngine dbatools {
+                Add-BenchmarkOperation Write {
                     param($case, $run)
 
                     $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -510,8 +510,8 @@ CREATE TABLE dbo.$TableName
                 }
             }
 
-            engine SqlServer {
-                operation Write {
+            Add-BenchmarkEngine SqlServer {
+                Add-BenchmarkOperation Write {
                     param($case, $run)
 
                     $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -538,7 +538,7 @@ CREATE TABLE dbo.$TableName
                 }
             }
 
-            validate {
+            Add-BenchmarkValidation {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -568,25 +568,25 @@ CREATE TABLE dbo.$TableName
                 }
             }
 
-            metric RowsProcessed {
+            Add-BenchmarkMetric RowsProcessed {
                 param($case, $run)
 
                 $run.RowsProcessed
             }
 
-            metric IdSum {
+            Add-BenchmarkMetric IdSum {
                 param($case, $run)
 
                 $run.IdSum
             }
 
-            metric ScoreSum {
+            Add-BenchmarkMetric ScoreSum {
                 param($case, $run)
 
                 $run.ScoreSum
             }
 
-            metric RowsPerSecond {
+            Add-BenchmarkMetric RowsPerSecond {
                 param($case, $run)
 
                 if ($run.DurationMs -le 0) {
@@ -596,22 +596,22 @@ CREATE TABLE dbo.$TableName
                 [double] $case.RowCount / ($run.DurationMs / 1000)
             }
 
-            comparison Engine -Baseline DbaClientX -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
+            Add-BenchmarkComparison Engine -Baseline DbaClientX -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
             if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
-                readme $readmePath -Block 'sqlserver-data-movement-write-benchmark' -Renderer ComparisonTable
+                Add-BenchmarkReadmeBlock $readmePath -Block 'sqlserver-data-movement-write-benchmark' -Renderer ComparisonTable
             }
-            artifacts Json, Csv, Markdown
+            Set-BenchmarkArtifacts Json, Csv, Markdown
         }
     }
 
     if ($selectedOperations -contains 'Read') {
-        benchmark 'sqlserver-data-movement-read' -out (Join-Path $outputRootBase 'Read') {
-            policy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
-            profile Current -Cleanup KeepOnFailure
-            metadata ProcessorAffinity $appliedProcessorAffinity
-            metadata ProcessPriority $appliedProcessPriority
+        New-BenchmarkSuite 'sqlserver-data-movement-read' -OutputRoot (Join-Path $outputRootBase 'Read') {
+            Set-BenchmarkPolicy -Warmup $benchmarkWarmupCount -Iterations $benchmarkIterationCount -Order Rotated -MemoryCleanup BeforeIteration -OutlierMode None
+            Set-BenchmarkProfile Current -Cleanup KeepOnFailure
+            Add-BenchmarkMetadata ProcessorAffinity $appliedProcessorAffinity
+            Add-BenchmarkMetadata ProcessPriority $appliedProcessPriority
 
-            caseSource {
+            Add-BenchmarkCaseSource {
                 foreach ($rowCount in $rowCounts) {
                     foreach ($readShape in $readShapes) {
                         [pscustomobject]@{
@@ -623,7 +623,7 @@ CREATE TABLE dbo.$TableName
                 }
             }
 
-            setup {
+            Set-BenchmarkSetup {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -670,7 +670,7 @@ CREATE TABLE dbo.$TableName
                 }
             }
 
-            skip {
+            Add-BenchmarkSkipRule {
                 param($case)
 
                 if ($case.Engine -eq 'SqlServer') {
@@ -684,8 +684,8 @@ CREATE TABLE dbo.$TableName
                 return $false
             }
 
-            engine DbaClientX {
-                operation Read {
+            Add-BenchmarkEngine DbaClientX {
+                Add-BenchmarkOperation Read {
                     param($case, $run)
 
                     $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -712,8 +712,8 @@ CREATE TABLE dbo.$TableName
                 }
             }
 
-            engine dbatools {
-                operation Read {
+            Add-BenchmarkEngine dbatools {
+                Add-BenchmarkOperation Read {
                     param($case, $run)
 
                     $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -741,13 +741,13 @@ CREATE TABLE dbo.$TableName
                 }
             }
 
-            engine SqlServer {
-                operation Read {
+            Add-BenchmarkEngine SqlServer {
+                Add-BenchmarkOperation Read {
                     throw 'The SqlServer module read lane is not implemented for this benchmark suite.'
                 }
             }
 
-            validate {
+            Add-BenchmarkValidation {
                 param($case, $run)
 
                 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
@@ -764,25 +764,25 @@ CREATE TABLE dbo.$TableName
                 }
             }
 
-            metric RowsProcessed {
+            Add-BenchmarkMetric RowsProcessed {
                 param($case, $run)
 
                 $run.RowsProcessed
             }
 
-            metric IdSum {
+            Add-BenchmarkMetric IdSum {
                 param($case, $run)
 
                 $run.IdSum
             }
 
-            metric ScoreSum {
+            Add-BenchmarkMetric ScoreSum {
                 param($case, $run)
 
                 $run.ScoreSum
             }
 
-            metric RowsPerSecond {
+            Add-BenchmarkMetric RowsPerSecond {
                 param($case, $run)
 
                 if ($run.DurationMs -le 0) {
@@ -792,11 +792,11 @@ CREATE TABLE dbo.$TableName
                 [double] $case.RowCount / ($run.DurationMs / 1000)
             }
 
-            comparison Engine -Baseline DbaClientX -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
+            Add-BenchmarkComparison Engine -Baseline DbaClientX -Metric MedianMs -TieTolerance 0.05 -RequireBaselineFastest
             if ($updateReadme -and (Test-Path -LiteralPath $readmePath)) {
-                readme $readmePath -Block 'sqlserver-data-movement-read-benchmark' -Renderer ComparisonTable
+                Add-BenchmarkReadmeBlock $readmePath -Block 'sqlserver-data-movement-read-benchmark' -Renderer ComparisonTable
             }
-            artifacts Json, Csv, Markdown
+            Set-BenchmarkArtifacts Json, Csv, Markdown
         }
     }
 }.GetNewClosure()


### PR DESCRIPTION
## Summary

- replace compact benchmark DSL words with the full PSPublishModule command names
- use explicit benchmark input switches and full parameter names
- preserve the existing benchmark cases, engines, operations, and validation behavior

Related shared cleanup: EvotecIT/PSPublishModule#745.