### PR TITLE
Retry transient SQLite I/O failures during connection startup

### DIFF
--- a/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.AsyncCommandExecution.cs
@@ -381,23 +381,26 @@ public partial class SQLite
             }
         }
 
-        var connection = new SqliteConnection(connectionString);
-        try
+        return await SqliteTransientRetry.RunAsync(async retryToken =>
         {
-            await AwaitWithCallerCancellationAsync(
-                () => connection.OpenAsync(cancellationToken),
-                cancellationToken).ConfigureAwait(false);
-            await ApplyBusyTimeoutAsync(
-                connection,
-                ResolveConnectionBusyTimeout(connectionString, busyTimeoutMs),
-                cancellationToken).ConfigureAwait(false);
-            return (connection, null, true);
-        }
-        catch
-        {
-            await DisposeSQLiteConnectionAsync(connection).ConfigureAwait(false);
-            throw;
-        }
+            var connection = new SqliteConnection(connectionString);
+            try
+            {
+                await AwaitWithCallerCancellationAsync(
+                    () => connection.OpenAsync(retryToken),
+                    retryToken).ConfigureAwait(false);
+                await ApplyBusyTimeoutAsync(
+                    connection,
+                    ResolveConnectionBusyTimeout(connectionString, busyTimeoutMs),
+                    retryToken).ConfigureAwait(false);
+                return (connection, (SqliteTransaction?)null, true);
+            }
+            catch
+            {
+                await DisposeSQLiteConnectionAsync(connection).ConfigureAwait(false);
+                throw;
+            }
+        }, CreateTransientRetryOptions(), cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>Executes a query after the SQLite connection and optional transaction have been resolved.</summary>

--- a/DbaClientX.SQLite/SQLite.CommandExecution.cs
+++ b/DbaClientX.SQLite/SQLite.CommandExecution.cs
@@ -201,18 +201,21 @@ public partial class SQLite
             }
         }
 
-        var connection = new SqliteConnection(connectionString);
-        try
+        return SqliteTransientRetry.Run(() =>
         {
-            connection.Open();
-            ApplyBusyTimeout(connection, ResolveConnectionBusyTimeout(connectionString, busyTimeoutMs));
-            return (connection, null, true);
-        }
-        catch
-        {
-            connection.Dispose();
-            throw;
-        }
+            var connection = new SqliteConnection(connectionString);
+            try
+            {
+                connection.Open();
+                ApplyBusyTimeout(connection, ResolveConnectionBusyTimeout(connectionString, busyTimeoutMs));
+                return (connection, (SqliteTransaction?)null, true);
+            }
+            catch
+            {
+                connection.Dispose();
+                throw;
+            }
+        }, CreateTransientRetryOptions());
     }
 
     private static IDictionary<string, DbType>? ConvertParameterTypes(IDictionary<string, SqliteType>? types) =>

--- a/DbaClientX.SQLite/SQLite.Transactions.cs
+++ b/DbaClientX.SQLite/SQLite.Transactions.cs
@@ -22,10 +22,7 @@ public partial class SQLite
             SqliteTransaction? transaction = null;
             try
             {
-                connection = new SqliteConnection(connectionString);
-                connection.Open();
-                ApplyBusyTimeout(connection);
-                transaction = connection.BeginTransaction();
+                (connection, transaction) = CreateStartedTransaction(connectionString, isolationLevel: null);
                 StoreStartedTransaction(
                     ref _transaction,
                     ref _transactionConnection,
@@ -58,10 +55,7 @@ public partial class SQLite
             SqliteTransaction? transaction = null;
             try
             {
-                connection = new SqliteConnection(connectionString);
-                connection.Open();
-                ApplyBusyTimeout(connection);
-                transaction = connection.BeginTransaction(isolationLevel);
+                (connection, transaction) = CreateStartedTransaction(connectionString, isolationLevel);
                 StoreStartedTransaction(
                     ref _transaction,
                     ref _transactionConnection,
@@ -97,16 +91,10 @@ public partial class SQLite
             var connectionString = BuildOperationalConnectionString(database);
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
 
-            connection = new SqliteConnection(connectionString);
-            await AwaitWithCallerCancellationAsync(
-                () => connection.OpenAsync(cancellationToken),
+            (connection, transaction) = await CreateStartedTransactionAsync(
+                connectionString,
+                isolationLevel: null,
                 cancellationToken).ConfigureAwait(false);
-            await ApplyBusyTimeoutAsync(connection, busyTimeoutMs: null, cancellationToken).ConfigureAwait(false);
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
-            transaction = (SqliteTransaction)await connection.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-#else
-            transaction = connection.BeginTransaction();
-#endif
 
             lock (_syncRoot)
             {
@@ -444,8 +432,7 @@ public partial class SQLite
 
     /// <inheritdoc />
     protected override bool IsTransient(Exception ex) =>
-        ex is SqliteException sqliteEx &&
-        sqliteEx.SqliteErrorCode is 5 or 6;
+        SqliteTransientRetry.IsTransient(ex);
 
     /// <inheritdoc />
     protected override void Dispose(bool disposing)
@@ -478,16 +465,10 @@ public partial class SQLite
             var connectionString = BuildOperationalConnectionString(database);
             var normalizedConnectionString = NormalizeConnectionString(connectionString);
 
-            connection = new SqliteConnection(connectionString);
-            await AwaitWithCallerCancellationAsync(
-                () => connection.OpenAsync(cancellationToken),
+            (connection, transaction) = await CreateStartedTransactionAsync(
+                connectionString,
+                isolationLevel,
                 cancellationToken).ConfigureAwait(false);
-            await ApplyBusyTimeoutAsync(connection, busyTimeoutMs: null, cancellationToken).ConfigureAwait(false);
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
-            transaction = (SqliteTransaction)await connection.BeginTransactionAsync(isolationLevel, cancellationToken).ConfigureAwait(false);
-#else
-            transaction = connection.BeginTransaction(isolationLevel);
-#endif
 
             lock (_syncRoot)
             {
@@ -513,6 +494,67 @@ public partial class SQLite
             await DisposeTransactionResourcesAsync(transaction, connection).ConfigureAwait(false);
             throw;
         }
+    }
+
+    private (SqliteConnection Connection, SqliteTransaction Transaction) CreateStartedTransaction(
+        string connectionString,
+        IsolationLevel? isolationLevel)
+    {
+        return SqliteTransientRetry.Run(() =>
+        {
+            SqliteConnection? connection = null;
+            SqliteTransaction? transaction = null;
+            try
+            {
+                connection = new SqliteConnection(connectionString);
+                connection.Open();
+                ApplyBusyTimeout(connection);
+                transaction = isolationLevel.HasValue
+                    ? connection.BeginTransaction(isolationLevel.Value)
+                    : connection.BeginTransaction();
+                return (connection, transaction);
+            }
+            catch
+            {
+                DisposeTransactionResources(transaction, connection);
+                throw;
+            }
+        }, CreateTransientRetryOptions());
+    }
+
+    private Task<(SqliteConnection Connection, SqliteTransaction Transaction)> CreateStartedTransactionAsync(
+        string connectionString,
+        IsolationLevel? isolationLevel,
+        CancellationToken cancellationToken)
+    {
+        return SqliteTransientRetry.RunAsync(async retryToken =>
+        {
+            SqliteConnection? connection = null;
+            SqliteTransaction? transaction = null;
+            try
+            {
+                connection = new SqliteConnection(connectionString);
+                await AwaitWithCallerCancellationAsync(
+                    () => connection.OpenAsync(retryToken),
+                    retryToken).ConfigureAwait(false);
+                await ApplyBusyTimeoutAsync(connection, busyTimeoutMs: null, retryToken).ConfigureAwait(false);
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP3_0_OR_GREATER || NET5_0_OR_GREATER
+                transaction = isolationLevel.HasValue
+                    ? (SqliteTransaction)await connection.BeginTransactionAsync(isolationLevel.Value, retryToken).ConfigureAwait(false)
+                    : (SqliteTransaction)await connection.BeginTransactionAsync(retryToken).ConfigureAwait(false);
+#else
+                transaction = isolationLevel.HasValue
+                    ? connection.BeginTransaction(isolationLevel.Value)
+                    : connection.BeginTransaction();
+#endif
+                return (connection, transaction);
+            }
+            catch
+            {
+                await DisposeTransactionResourcesAsync(transaction, connection).ConfigureAwait(false);
+                throw;
+            }
+        }, CreateTransientRetryOptions(), cancellationToken: cancellationToken);
     }
 
     /// <summary>

--- a/DbaClientX.SQLite/SqliteTransientRetry.cs
+++ b/DbaClientX.SQLite/SqliteTransientRetry.cs
@@ -21,7 +21,7 @@ public static class SqliteTransientRetry {
         TransientRetryOptions? options = null,
         Action<TransientRetryAttempt>? onRetry = null,
         Action<SqliteTransientRetryAttempt>? onSqliteRetry = null) {
-        TransientRetry.Run(action, IsTransientSqlite, options, attempt => {
+        TransientRetry.Run(action, IsTransient, options, attempt => {
             onRetry?.Invoke(attempt);
             onSqliteRetry?.Invoke(ToSqliteAttempt(attempt));
         });
@@ -41,7 +41,7 @@ public static class SqliteTransientRetry {
         TransientRetryOptions? options = null,
         Action<TransientRetryAttempt>? onRetry = null,
         Action<SqliteTransientRetryAttempt>? onSqliteRetry = null) {
-        return TransientRetry.Run(operation, IsTransientSqlite, options, attempt => {
+        return TransientRetry.Run(operation, IsTransient, options, attempt => {
             onRetry?.Invoke(attempt);
             onSqliteRetry?.Invoke(ToSqliteAttempt(attempt));
         });
@@ -61,7 +61,7 @@ public static class SqliteTransientRetry {
         Action<TransientRetryAttempt>? onRetry = null,
         Action<SqliteTransientRetryAttempt>? onSqliteRetry = null,
         CancellationToken cancellationToken = default) {
-        return TransientRetry.RunAsync(operation, IsTransientSqlite, options, attempt => {
+        return TransientRetry.RunAsync(operation, IsTransient, options, attempt => {
             onRetry?.Invoke(attempt);
             onSqliteRetry?.Invoke(ToSqliteAttempt(attempt));
         }, cancellationToken);
@@ -83,18 +83,38 @@ public static class SqliteTransientRetry {
         Action<TransientRetryAttempt>? onRetry = null,
         Action<SqliteTransientRetryAttempt>? onSqliteRetry = null,
         CancellationToken cancellationToken = default) {
-        return TransientRetry.RunAsync(operation, IsTransientSqlite, options, attempt => {
+        return TransientRetry.RunAsync(operation, IsTransient, options, attempt => {
             onRetry?.Invoke(attempt);
             onSqliteRetry?.Invoke(ToSqliteAttempt(attempt));
         }, cancellationToken);
     }
 
-    private static bool IsTransientSqlite(Exception ex) =>
-        ex is SqliteException sqliteEx &&
-        sqliteEx.SqliteErrorCode is 5 or 6;
+    /// <summary>
+    /// Determines whether an exception chain contains a retryable SQLite busy, locked, or I/O failure.
+    /// </summary>
+    /// <param name="exception">The exception to classify.</param>
+    /// <returns><see langword="true"/> when the failure is suitable for bounded retry.</returns>
+    public static bool IsTransient(Exception exception) {
+        if (exception is null) {
+            throw new ArgumentNullException(nameof(exception));
+        }
+
+        return FindSqliteException(exception) is not null;
+    }
 
     private static SqliteTransientRetryAttempt ToSqliteAttempt(TransientRetryAttempt attempt) {
-        var sqliteErrorCode = attempt.Exception is SqliteException sqlite ? sqlite.SqliteErrorCode : 0;
+        int sqliteErrorCode = FindSqliteException(attempt.Exception)?.SqliteErrorCode ?? 0;
         return new SqliteTransientRetryAttempt(attempt.Attempt, attempt.Delay, sqliteErrorCode, attempt.Exception);
+    }
+
+    private static SqliteException? FindSqliteException(Exception exception) {
+        for (Exception? current = exception; current != null; current = current.InnerException) {
+            if (current is SqliteException sqliteException &&
+                sqliteException.SqliteErrorCode is 5 or 6 or 10) {
+                return sqliteException;
+            }
+        }
+
+        return null;
     }
 }

--- a/DbaClientX.Tests/ProviderRetryTests.cs
+++ b/DbaClientX.Tests/ProviderRetryTests.cs
@@ -177,6 +177,27 @@ public class ProviderRetryTests
     }
 
     [Fact]
+    public void Sqlite_RetriesIoErrors()
+    {
+        using var client = new SqliteRetryClient { MaxRetryAttempts = 2, RetryDelay = TimeSpan.Zero };
+        var exception = new SqliteException("disk I/O error", 10);
+        var attempts = 0;
+
+        var result = client.Run(() =>
+        {
+            if (++attempts < 2)
+            {
+                throw exception;
+            }
+
+            return 1;
+        });
+
+        Assert.Equal(1, result);
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
     public void ProviderCancellationClassifiers_RecognizeOnlyProviderCancellationCodes()
     {
         using var sqlServer = new SqlServerRetryClient();

--- a/DbaClientX.Tests/SqliteTransientRetryTests.cs
+++ b/DbaClientX.Tests/SqliteTransientRetryTests.cs
@@ -73,6 +73,32 @@ public class SqliteTransientRetryTests {
     }
 
     [Fact]
+    public void Run_RetriesWrappedIoErrors() {
+        var attempts = 0;
+        var options = new TransientRetryOptions {
+            MaxAttempts = 2,
+            BaseDelay = TimeSpan.Zero
+        };
+
+        string result = SqliteTransientRetry.Run(
+            () => {
+                attempts++;
+                if (attempts == 1) {
+                    throw new DbaQueryExecutionException(
+                        "Temporary SQLite I/O failure.",
+                        "SELECT 1;",
+                        new SqliteException("disk I/O error", 10));
+                }
+
+                return "ok";
+            },
+            options);
+
+        Assert.Equal("ok", result);
+        Assert.Equal(2, attempts);
+    }
+
+    [Fact]
     public void Run_EmitsSqliteRetryTelemetryWithErrorCode() {
         var attempts = 0;
         var telemetry = new List<SqliteTransientRetryAttempt>();


### PR DESCRIPTION
## Summary

- recognize SQLite busy, locked, and transient disk I/O failures through wrapped exception chains
- apply bounded retry while opening connections, setting busy timeout, and starting transactions
- include SQLite error details in retry telemetry

## Validation

- the complete .NET 10 test suite passes: 1,227 tests
- synchronous and asynchronous retry classification and provider paths are covered