### PR TITLE
Keep SQLite net472 provider architecture-neutral

### DIFF
--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -30,7 +30,9 @@
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+    <!-- Select native restore assets with a RID while keeping the managed provider usable by x86 and x64 hosts. -->
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

- keeps the .NET Framework SQLite provider assembly architecture-neutral
- retains `win-x64` only for restore-time native asset selection
- allows consumers to load the managed provider from both 32-bit and 64-bit Windows PowerShell hosts

## Why

`DbaClientX.SQLite` 0.14.0 marks its `net472` managed assembly as AMD64. Consumers that correctly bundle both x86 and x64 SQLite native runtimes still fail before native selection when loaded by a 32-bit process.

## Validation

- Release `net472` build succeeds with no warnings or errors
- compiled and packed `lib/net472/DbaClientX.SQLite.dll` reports `I386` plus `ILOnly` (AnyCPU), rather than `AMD64`
- the existing RID and output layout remain unchanged