### PR TITLE
Add .NET Standard targets for SQLite storage

### DIFF
--- a/DbaClientX.Core/Compatibility/DynamicallyAccessedMembers.cs
+++ b/DbaClientX.Core/Compatibility/DynamicallyAccessedMembers.cs
@@ -1,4 +1,4 @@
-#if NET472
+#if NET472 || NETSTANDARD2_1
 namespace System.Diagnostics.CodeAnalysis;
 
 [System.Flags]

--- a/DbaClientX.Core/DataMovement/DbaProviderCapabilities.cs
+++ b/DbaClientX.Core/DataMovement/DbaProviderCapabilities.cs
@@ -67,7 +67,7 @@ public static class DbaProviderCapabilities
     {
         get
         {
-#if NETCOREAPP
+#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
             return true;
 #else
             return false;

--- a/DbaClientX.Core/DbaClientX.Core.csproj
+++ b/DbaClientX.Core/DbaClientX.Core.csproj
@@ -3,9 +3,9 @@
     <Description>DbaClientX Core library</Description>
     <AssemblyName>DbaClientX.Core</AssemblyName>
     <AssemblyTitle>DbaClientX.Core</AssemblyTitle>
-    <VersionPrefix>1.0.1</VersionPrefix>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
+    <VersionPrefix>1.0.2</VersionPrefix>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;netstandard2.1;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/DbaClientX.Core/README.md
+++ b/DbaClientX.Core/README.md
@@ -2,7 +2,7 @@
 
 Core building blocks for DbaClientX: retryable execution pipeline, parameter mapping for POCOs/dictionaries, SQL query builder/compiler, and light utilities.
 
-- Target Frameworks: `net472`, `net8.0`, `net10.0`
+- Target Frameworks: `net472`, `netstandard2.1`, `net8.0`, `net10.0`
 - NuGet: `DBAClientX.Core`
 
 ## Install

--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -3,9 +3,9 @@
     <Description>DbaClientX SQLite provider</Description>
     <AssemblyName>DbaClientX.SQLite</AssemblyName>
     <AssemblyTitle>DbaClientX.SQLite</AssemblyTitle>
-    <VersionPrefix>0.15.0</VersionPrefix>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
+    <VersionPrefix>0.16.0</VersionPrefix>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;netstandard2.1;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Company>Evotec</Company>
     <Authors>Przemyslaw Klys</Authors>

--- a/DbaClientX.SQLite/README.md
+++ b/DbaClientX.SQLite/README.md
@@ -3,7 +3,7 @@
 SQLite provider for DbaClientX (Microsoft.Data.Sqlite). Supports non-query, scalar, queries, streaming, transactions, bulk insert.
 Also includes SQLite maintenance helpers for online database backup, WAL checkpointing, `PRAGMA optimize`, and graceful shutdown preparation.
 
-- Target Frameworks: `net472` (win-x64), `net8.0`, `net10.0`
+- Target Frameworks: `net472` (win-x64), `netstandard2.1`, `net8.0`, `net10.0`
 - NuGet: `DBAClientX.SQLite`
 
 ## Install


### PR DESCRIPTION
## Summary

- add `netstandard2.1` assets to DbaClientX.Core and DbaClientX.SQLite for .NET Core 3.1-era consumers
- reuse the existing trimming-attribute compatibility definitions for the new Core target
- advance the public package lines to Core 1.0.2 and SQLite 0.16.0 and update their package READMEs

This is the owning dependency change needed for PowerShell 7.0-compatible EventViewerX storage. Package publication is intentionally not part of this PR.