### PR TITLE
Coordinate DbaClientX module and NuGet versions

### DIFF
--- a/Build/Build-Project.ps1
+++ b/Build/Build-Project.ps1
@@ -10,26 +10,17 @@ param(
 
 Import-Module PSPublishModule -MinimumVersion 3.0.55 -Force -ErrorAction Stop
 
-$publishingNuget = $PublishNuget -eq $true
-$publishingGitHub = $PublishGitHub -eq $true
-$publishingAny = $publishingNuget -or $publishingGitHub
-$publishingSingleDestination = $publishingNuget -xor $publishingGitHub
-$updateVersionsExplicitlyDisabled = $null -ne $UpdateVersions -and $UpdateVersions -eq $false
-
-if ($publishingSingleDestination -and -not $updateVersionsExplicitlyDisabled) {
-    throw "Publishing only one destination while version updates are enabled can split NuGet and GitHub across different versions. Run one command with both -PublishNuget `$true and -PublishGitHub `$true, or explicitly use -UpdateVersions `$false only when replaying an already-versioned build."
+if ($UpdateVersions -eq $true -or $PublishNuget -eq $true -or $PublishGitHub -eq $true) {
+    throw "DbaClientX versions and publishes its NuGet packages and PowerShell module as one coordinated release. Use Module\Build\Build-Module.ps1 with RunMode Build or Publish."
 }
 
 $invokeParams = @{
-    ConfigPath = $ConfigPath
+    ConfigPath     = $ConfigPath
+    UpdateVersions = $false
+    PublishNuget   = $false
+    PublishGitHub  = $false
 }
-if ($publishingAny -and $null -eq $UpdateVersions) {
-    $invokeParams.UpdateVersions = $true
-}
-if ($null -ne $UpdateVersions) { $invokeParams.UpdateVersions = $UpdateVersions }
 if ($null -ne $Build) { $invokeParams.Build = $Build }
-if ($null -ne $PublishNuget) { $invokeParams.PublishNuget = $PublishNuget }
-if ($null -ne $PublishGitHub) { $invokeParams.PublishGitHub = $PublishGitHub }
 if ($null -ne $Plan) { $invokeParams.Plan = $Plan }
 if ($PlanPath) { $invokeParams.PlanPath = $PlanPath }
 

--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -4,15 +4,16 @@
   "ExpectedVersion": null,
   "ExpectedVersionMap": {
     "DbaClientX.Core": "1.0.X",
-    "DbaClientX.AzureTables": "0.X.0",
-    "DbaClientX.SqlServer": "0.X.0",
-    "DbaClientX.PostgreSql": "0.X.0",
-    "DbaClientX.MySql": "0.X.0",
-    "DbaClientX.SQLite": "0.X.0",
-    "DbaClientX.Oracle": "0.X.0"
+    "DbaClientX.AzureTables": "1.0.X",
+    "DbaClientX.SqlServer": "1.0.X",
+    "DbaClientX.PostgreSql": "1.0.X",
+    "DbaClientX.MySql": "1.0.X",
+    "DbaClientX.SQLite": "1.0.X",
+    "DbaClientX.Oracle": "1.0.X"
   },
   "ExpectedVersionMapAsInclude": true,
   "ExpectedVersionMapUseWildcards": false,
+  "AlignPackageVersions": true,
   "ExcludeProjects": [
     "DbaClientX.PowerShell",
     "DbaClientX.Tests",

--- a/DbaClientX.AzureTables/DbaClientX.AzureTables.csproj
+++ b/DbaClientX.AzureTables/DbaClientX.AzureTables.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX Azure Tables provider</Description>
     <AssemblyName>DbaClientX.AzureTables</AssemblyName>
     <AssemblyTitle>DbaClientX.AzureTables</AssemblyTitle>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>1.0.8</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/DbaClientX.Core/DbaClientX.Core.csproj
+++ b/DbaClientX.Core/DbaClientX.Core.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX Core library</Description>
     <AssemblyName>DbaClientX.Core</AssemblyName>
     <AssemblyTitle>DbaClientX.Core</AssemblyTitle>
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.0.8</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.MySql/DbaClientX.MySql.csproj
+++ b/DbaClientX.MySql/DbaClientX.MySql.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX MySql provider</Description>
     <AssemblyName>DbaClientX.MySql</AssemblyName>
     <AssemblyTitle>DbaClientX.MySql</AssemblyTitle>
-    <VersionPrefix>0.16.0</VersionPrefix>
+    <VersionPrefix>1.0.8</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.Oracle/DbaClientX.Oracle.csproj
+++ b/DbaClientX.Oracle/DbaClientX.Oracle.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX Oracle provider</Description>
     <AssemblyName>DbaClientX.Oracle</AssemblyName>
     <AssemblyTitle>DbaClientX.Oracle</AssemblyTitle>
-    <VersionPrefix>0.16.0</VersionPrefix>
+    <VersionPrefix>1.0.8</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
+++ b/DbaClientX.PostgreSql/DbaClientX.PostgreSql.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX PostgreSql provider</Description>
     <AssemblyName>DbaClientX.PostgreSql</AssemblyName>
     <AssemblyTitle>DbaClientX.PostgreSql</AssemblyTitle>
-    <VersionPrefix>0.15.0</VersionPrefix>
+    <VersionPrefix>1.0.8</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.SQLite/DbaClientX.SQLite.csproj
+++ b/DbaClientX.SQLite/DbaClientX.SQLite.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX SQLite provider</Description>
     <AssemblyName>DbaClientX.SQLite</AssemblyName>
     <AssemblyTitle>DbaClientX.SQLite</AssemblyTitle>
-    <VersionPrefix>0.16.0</VersionPrefix>
+    <VersionPrefix>1.0.8</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/DbaClientX.SqlServer/DbaClientX.SqlServer.csproj
+++ b/DbaClientX.SqlServer/DbaClientX.SqlServer.csproj
@@ -3,7 +3,7 @@
     <Description>DbaClientX SQL Server provider</Description>
     <AssemblyName>DbaClientX.SqlServer</AssemblyName>
     <AssemblyTitle>DbaClientX.SqlServer</AssemblyTitle>
-    <VersionPrefix>0.16.0</VersionPrefix>
+    <VersionPrefix>1.0.8</VersionPrefix>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">net472;net8.0;net10.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">net8.0;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -131,10 +131,8 @@ Build-Module -ModuleName 'DbaClientX' -NoInteractive {
 
     New-ConfigurationBuild @newConfigurationBuildSplat
 
-    # NuGet packages keep independent 0.x versions; build them as module dependencies,
-    # not as members of the PowerShell module's coordinated 1.0.x release line.
-    New-ConfigurationProjectBuild -Name 'DbaClientX' -ConfigPath '..\Build\project.build.json' -Enabled:$false -BuildBeforeModule -ProvideLocalNuGetFeed -PublishNuget
-    New-ConfigurationRelease -StageRoot 'Artefacts\UploadReady' -VersionSource Module -BuildOrder 'Module' -PublishOrder 'PowerShellGallery', 'GitHub'
+    New-ConfigurationProjectBuild -Name 'DbaClientX' -ConfigPath '..\Build\project.build.json' -Enabled:$true -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget
+    New-ConfigurationRelease -StageRoot 'Artefacts\UploadReady' -VersionSource ProjectBuild -PrimaryProject 'DbaClientX.Core' -SynchronizeModuleVersion -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
 
     New-ConfigurationArtefact -Type Unpacked -Enable -Path 'Artefacts\Unpacked' #-RequiredModulesPath "$PSScriptRoot\..\Artefacts\Modules"
     New-ConfigurationArtefact -Type Packed -Enable -Path 'Artefacts\Packed' -IncludeTagName

--- a/Module/DbaClientX.psd1
+++ b/Module/DbaClientX.psd1
@@ -8,7 +8,7 @@
     Description          = 'Simple project to query Sql Server and other databases using PowerShell'
     FunctionsToExport    = @()
     GUID                 = 'c22cc272-c829-49e2-aaa1-58d3c36edb94'
-    ModuleVersion        = '1.0.7'
+    ModuleVersion        = '1.0.8'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{

--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -2,7 +2,7 @@
 Module Name: DbaClientX
 Module Guid: c22cc272-c829-49e2-aaa1-58d3c36edb94
 Download Help Link: https://github.com/EvotecIT/DbaClientX
-Help Version: 1.0.7
+Help Version: 1.0.8
 Locale: en-US
 ---
 # DbaClientX Module

--- a/README.md
+++ b/README.md
@@ -580,26 +580,35 @@ Module package builds:
 
 Package publishing is intentionally manual in this repository because releases are signed locally with the USB key certificate.
 
-Generate a build plan:
+The DbaClientX PowerShell module and its seven NuGet packages use one coordinated version. FabricClientX remains a separate release train.
+
+Generate a package plan without changing versions:
 
 ```powershell
 pwsh.exe -NoLogo -NoProfile -File .\Build\Build-Project.ps1 -Plan $true
 pwsh.exe -NoLogo -NoProfile -File .\Build\Build-Project.ps1 -ConfigPath .\Build\fabricclientx.build.json -Plan $true
 ```
 
-Build signed packages locally:
+Build signed release candidates without publishing:
 
 ```powershell
-pwsh.exe -NoLogo -NoProfile -File .\Build\Build-Project.ps1 -Build $true -PublishNuget $false -PublishGitHub $false
+pwsh.exe -NoLogo -NoProfile -File .\Module\Build\Build-Module.ps1 -RunMode Build
+pwsh.exe -NoLogo -NoProfile -File .\Module-FabricClientX\Build\Build-Module.ps1 -RunMode Build
 ```
 
-Publish NuGet and GitHub together in one versioned run:
+Publish the coordinated DbaClientX module and NuGet release:
 
 ```powershell
-pwsh.exe -NoLogo -NoProfile -File .\Build\Build-Project.ps1 -PublishNuget $true -PublishGitHub $true
+pwsh.exe -NoLogo -NoProfile -File .\Module\Build\Build-Module.ps1 -RunMode Publish
 ```
 
-Build configuration lives in [`Build/project.build.json`](Build/project.build.json), and artifacts are generated under `Artefacts/ProjectBuild`.
+Publish FabricClientX separately:
+
+```powershell
+pwsh.exe -NoLogo -NoProfile -File .\Module-FabricClientX\Build\Build-Module.ps1 -RunMode Publish
+```
+
+Package build configuration lives in [`Build/project.build.json`](Build/project.build.json) and [`Build/fabricclientx.build.json`](Build/fabricclientx.build.json). Package artifacts are generated under `Artefacts/DbaClientX/ProjectBuild` and `Artefacts/FabricClientX/ProjectBuild`; coordinated release assets are staged under each module's `Artefacts/UploadReady` directory.
 
 ## Notes
 
@@ -607,4 +616,4 @@ Build configuration lives in [`Build/project.build.json`](Build/project.build.js
 - SourceLink is enabled for provider projects for easier debugging into packages.
 - SQL Server uses `Microsoft.Data.SqlClient`.
 - PowerShell 7 package builds use a module-scoped AssemblyLoadContext so DbaClientX can coexist more safely with other modules that load overlapping assemblies.
-- The release wrapper treats version updates as part of publishing. If you intentionally need a replay-only publish for already-versioned artifacts, pass `-UpdateVersions $false` explicitly.
+- `Build/Build-Project.ps1` is for package-only plans and local builds. Version updates and publication must run through the matching module build so package and module versions cannot diverge.


### PR DESCRIPTION
## Summary

- align all seven DbaClientX NuGet packages on the shared `1.0.X` release train
- use the project build as the release version source and synchronize the PowerShell module to the same resolved version
- keep package-only plans and local builds non-versioning, with publication owned by the coordinated module pipeline
- document DbaClientX and FabricClientX as separate release trains with their correct build and publish entry points

## Release behavior

The next coordinated DbaClientX release resolves to `1.0.8`, based on the current public module version `1.0.7`, and applies that version to the module and every DbaClientX NuGet package. FabricClientX remains separately versioned.

## Validation

A full Build gate completed with publication disabled. It produced and payload-verified seven NuGet packages plus symbol packages at `1.0.8`, synchronized and packed the PowerShell module at `1.0.8`, and staged the unified release assets. Package-only plan/guard contracts and PowerShell 5.1/7 parsing also passed. No packages were published.